### PR TITLE
feat: 兼容沙洲遗闻的数据

### DIFF
--- a/src/widgets/XbMapViewer/XbMapViewer.vue
+++ b/src/widgets/XbMapViewer/XbMapViewer.vue
@@ -66,19 +66,19 @@ export default defineComponent({
     }
     const self = ref<HTMLElement>();
     const fontsize = ref("");
+    const width = computed(() => {
+      return props.map!.mapData.width ?? props.map!.mapData.map[0].length;
+    });
     onMounted(() => {
       if (!self.value || !props.map) return;
 
       fontsize.value = `${
-        (self.value.getBoundingClientRect().width /
-          props.map.mapData.width /
-          9) *
-        5
+        (self.value.getBoundingClientRect().width / width.value / 9) * 5
       }px`;
     });
     return {
       mapData: props.map!.mapData,
-      width: props.map!.mapData.width,
+      width,
       predefines: props.map!.predefines,
       black,
       self,


### PR DESCRIPTION
新的生息演算地图数据把 mapData.width 删了，所以 Widget 没法算出正确的宽度，把用到的地方换成 mapData.map[0].length 应该就好了(ZheiZhei说的)