### PR TITLE
feat(MedalList): torappu implement

### DIFF
--- a/src/widgets/MedalList/Medal.vue
+++ b/src/widgets/MedalList/Medal.vue
@@ -3,8 +3,6 @@ import { defineComponent, ref, type PropType } from "vue";
 
 import { NCard, NConfigProvider, NImage, NTag, NTooltip } from "naive-ui";
 
-import { getImagePath } from "../../utils/utils";
-
 import type { Medal } from "./types";
 
 export default defineComponent({
@@ -41,7 +39,6 @@ export default defineComponent({
     };
 
     return {
-      getImagePath,
       isDecrypt: ref(false),
       showTrimed: ref(false),
       rarityGradient,
@@ -89,11 +86,7 @@ export default defineComponent({
         >
           <NImage
             :width="rarityImgStyleSet[medalData.rarity][1]"
-            :src="`/images/${getImagePath(
-              `蚀刻章_${medalData.alias}${
-                showTrimed && medalData.isTrim ? '_镀层' : ''
-              }.png`,
-            )}`"
+            :src="`https://torappu.prts.wiki/assets/medal_icon/${showTrimed && medalData.isTrim ? medalData.trimId : medalData.id}.png`"
             show-toolbar-tooltip
             :previewed-img-props="{
               style: {

--- a/src/widgets/MedalList/MedalGroup.vue
+++ b/src/widgets/MedalList/MedalGroup.vue
@@ -12,8 +12,6 @@ import {
   NTooltip,
 } from "naive-ui";
 
-import { getImagePath } from "../../utils/utils";
-
 import MedalComponent from "./Medal.vue";
 import type { Medal, MedalGroup } from "./types";
 function goToLink(link: string) {
@@ -54,7 +52,6 @@ export default defineComponent({
 
     return {
       eventLinkList,
-      getImagePath,
       goToLink,
       showTrimed: ref(false),
     };
@@ -176,11 +173,7 @@ export default defineComponent({
         </div>
         <div class="flex max-w-full">
           <NImage
-            :src="`/images/${getImagePath(
-              `蚀刻章套组_${groupData.alias}${
-                showTrimed && groupData.isTrim ? '_镀层' : ''
-              }.png`,
-            )}`"
+            :src="`https://torappu.prts.wiki/assets/medal_diy/${(showTrimed && groupData.isTrim ? 'trim/' : '') + groupData.id}.png`"
             :img-props="{
               style: {
                 width: '100%',

--- a/src/widgets/MedalList/MedalList.vue
+++ b/src/widgets/MedalList/MedalList.vue
@@ -188,11 +188,16 @@ export default defineComponent({
       <NCard>
         <template #header>
           <img
-            :src="`/images/${getImagePath('图标_光荣之路.png')}`"
+            :src="`/images/${getImagePath('图标_光荣之路.svg')}`"
+            :class="`${theme ? 'brightness-100' : 'brightness-0'} transition-all`"
             width="25"
           />&nbsp;&nbsp;光荣之路
         </template>
         <template #header-extra>
+          <div class="mx-1 cursor-pointer" @click="toggleDark()">
+            <span v-if="theme" class="text-2xl mdi mdi-brightness-6" />
+            <span v-else class="text-2xl mdi mdi-brightness-4" />
+          </div>
           <div class="mx-1 cursor-pointer">
             <NPopover trigger="click" raw>
               <template #trigger>

--- a/src/widgets/MedalList/MedalShowcase.vue
+++ b/src/widgets/MedalList/MedalShowcase.vue
@@ -128,7 +128,8 @@ export default defineComponent({
       <NCard>
         <template #header>
           <img
-            :src="`/images/${getImagePath('图标_光荣之路.png')}`"
+            :src="`/images/${getImagePath('图标_光荣之路.svg')}`"
+            :class="`${theme ? 'brightness-100' : 'brightness-0'} transition-all`"
             width="25"
             class="mr-3"
           />

--- a/src/widgets/MedalList/types.ts
+++ b/src/widgets/MedalList/types.ts
@@ -1,18 +1,20 @@
 export interface Medal {
   name: string;
-  alias: string;
+  id: string;
   rarity: number;
   desc: string;
   method: string;
   decrypt?: string;
   isHidden: boolean;
   isTrim: boolean;
+  trimId?: string;
   trimMethod?: string;
   reward?: string;
 }
 
 export interface MedalGroup {
   name: string;
+  id: string;
   desc: string;
   color: string;
   bindEvent: Array<string>;

--- a/src/widgets/MemoryList/Memory.vue
+++ b/src/widgets/MemoryList/Memory.vue
@@ -46,8 +46,11 @@ export default defineComponent({
       return `/images/${getImagePath(`图标_升级_精英化${elite || "0"}.png`)}`;
     };
     const getSrcMedal = (mmr: Memory) => {
+      /*
       const search = mmr.medal.alias.replace(" ", "_");
       return `/images/${getImagePath(`蚀刻章_${search}.png`)}`;
+      */
+      return `https://torappu.prts.wiki/assets/medal_icon/${mmr.medal.id}`;
     };
     const srcfavor = `/images/${getImagePath("图标_信赖.png")}`;
     const srcplay = `/images/${getImagePath("情报处理室_播放按钮.png")}`;

--- a/src/widgets/MemoryList/types.ts
+++ b/src/widgets/MemoryList/types.ts
@@ -22,7 +22,7 @@ export interface CharMemory {
 
 export interface Medal {
   medal: string;
-  alias: string;
+  id: string;
   desc: string;
   method: string;
 }

--- a/src/widgets/MemoryList/util.ts
+++ b/src/widgets/MemoryList/util.ts
@@ -89,7 +89,7 @@ function toMemories(
           medalData.find(
             (e) =>
               e.method === `解锁干员${char}的干员密录《${item.storySetName}》`,
-          ) ?? medalData.find((e) => e.alias === item.medal)!,
+          ) ?? medalData.find((e) => e.id === item.medal)!,
         info: [{ intro: item.storyIntro, link: item.storyTxt }],
       });
     }


### PR DESCRIPTION
- torappu适配
  - 该适配修改了metadata结构：
    - 废除 `alias`，改为 `id`
    - 对于蚀刻章，新增可选参数 `trimId`
  - 同时修改了干员密录列表蚀刻章的读取
- 将标题抬头图标更改为SVG
- 为光荣之路列表增加夜间模式

如要进行复查测试，请将数据源临时改为 `光荣之路/devdata`