### PR TITLE
feat(XbMapViewer): load style and config from wiki page

### DIFF
--- a/src/widgets/XbMapViewer/Block.vue
+++ b/src/widgets/XbMapViewer/Block.vue
@@ -19,18 +19,17 @@ const props = withDefaults(
 );
 
 const self = ref();
-const checkIdInMap = (id: string) => {
-  return id in props.blockmap;
-};
-const style = computed(() => {
-  const result = {} as Record<string, string>;
 
-  if (checkIdInMap(props.tile!) && props.blockmap[props.tile!].img)
-    result.backgroundImage = `url(${getImagePath(props.blockmap[props.tile!].img as string)})`;
+const style = computed(() => {
+  const result: Record<string, string> = {};
+
+  if (props.blockmap[props.tile!]?.img) {
+    result.backgroundImage = `url(${getImagePath(props.blockmap[props.tile!].img!)})`;
+  }
 
   for (const token of props.tokens || []) {
-    if (token && checkIdInMap(token) && props.blockmap[token].img)
-      result.backgroundImage = `url(${getImagePath(props.blockmap[token].img as string)})`;
+    if (props.blockmap[token]?.img)
+      result.backgroundImage = `url(${getImagePath(props.blockmap[token].img)})`;
   }
 
   if (
@@ -47,11 +46,11 @@ const style = computed(() => {
 
 onMounted(() => {
   let content = "";
-  if (props.tile && checkIdInMap(props.tile) && props.blockmap[props.tile].desc)
+  if (props.tile && props.blockmap[props.tile]?.desc)
     content += props.blockmap[props.tile].desc;
 
   for (const token of props.tokens || []) {
-    if (token && checkIdInMap(token) && props.blockmap[token].desc)
+    if (token && props.blockmap[token]?.desc)
       content += content
         ? `<br/> ${props.blockmap[token].desc}`
         : ` ${props.blockmap[token].desc}`;
@@ -85,13 +84,13 @@ onMounted(() => {
   >
     <template v-if="tokens">
       <template v-for="(token, i) in tokens" :key="i">
-        <span v-if="checkIdInMap(token!) && blockmap[token!].icon">
+        <span v-if="blockmap[token!]?.icon">
           <i :class="blockmap[token!].icon" />
         </span>
       </template>
     </template>
     <template v-else>
-      <span v-if="checkIdInMap(tile!) && blockmap[tile!].icon">
+      <span v-if="blockmap[tile!]?.icon">
         <i :class="blockmap[tile!].icon" />
       </span>
     </template>

--- a/src/widgets/XbMapViewer/Block.vue
+++ b/src/widgets/XbMapViewer/Block.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, ref } from "vue";
 
 import { getImagePath } from "@/utils/utils";
 
-import { blockmap } from "./consts";
+import { type BlockDefine } from "./consts";
 
 const props = withDefaults(
   defineProps<{
@@ -11,6 +11,7 @@ const props = withDefaults(
     tileHeightType: string;
     tokens?: string[];
     black?: string;
+    blockmap: Record<string, BlockDefine>;
   }>(),
   {
     black: "",
@@ -19,17 +20,17 @@ const props = withDefaults(
 
 const self = ref();
 const checkIdInMap = (id: string) => {
-  return id in blockmap;
+  return id in props.blockmap;
 };
 const style = computed(() => {
   const result = {} as Record<string, string>;
 
-  if (checkIdInMap(props.tile!) && blockmap[props.tile!].img)
-    result.backgroundImage = `url(${getImagePath(blockmap[props.tile!].img as string)})`;
+  if (checkIdInMap(props.tile!) && props.blockmap[props.tile!].img)
+    result.backgroundImage = `url(${getImagePath(props.blockmap[props.tile!].img as string)})`;
 
   for (const token of props.tokens || []) {
-    if (token && checkIdInMap(token) && blockmap[token].img)
-      result.backgroundImage = `url(${getImagePath(blockmap[token].img as string)})`;
+    if (token && checkIdInMap(token) && props.blockmap[token].img)
+      result.backgroundImage = `url(${getImagePath(props.blockmap[token].img as string)})`;
   }
 
   if (
@@ -46,14 +47,14 @@ const style = computed(() => {
 
 onMounted(() => {
   let content = "";
-  if (props.tile && checkIdInMap(props.tile) && blockmap[props.tile].desc)
-    content += blockmap[props.tile].desc;
+  if (props.tile && checkIdInMap(props.tile) && props.blockmap[props.tile].desc)
+    content += props.blockmap[props.tile].desc;
 
   for (const token of props.tokens || []) {
-    if (token && checkIdInMap(token) && blockmap[token].desc)
+    if (token && checkIdInMap(token) && props.blockmap[token].desc)
       content += content
-        ? `<br/> ${blockmap[token].desc}`
-        : ` ${blockmap[token].desc}`;
+        ? `<br/> ${props.blockmap[token].desc}`
+        : ` ${props.blockmap[token].desc}`;
   }
 
   if (content.length > 0) {

--- a/src/widgets/XbMapViewer/Block.vue
+++ b/src/widgets/XbMapViewer/Block.vue
@@ -3,7 +3,7 @@ import { computed, onMounted, ref } from "vue";
 
 import { getImagePath } from "@/utils/utils";
 
-import { TipMap, bgMap, classMap } from "./consts";
+import { blockmap } from "./consts";
 
 const props = withDefaults(
   defineProps<{
@@ -18,14 +18,18 @@ const props = withDefaults(
 );
 
 const self = ref();
+const checkIdInMap = (id: string) => {
+  return id in blockmap;
+};
 const style = computed(() => {
   const result = {} as Record<string, string>;
-  if (bgMap[props.tile!])
-    result.backgroundImage = `url(${getImagePath(bgMap[props.tile!])})`;
+
+  if (checkIdInMap(props.tile!) && blockmap[props.tile!].img)
+    result.backgroundImage = `url(${getImagePath(blockmap[props.tile!].img as string)})`;
 
   for (const token of props.tokens || []) {
-    if (token && bgMap[token])
-      result.backgroundImage = `url(${getImagePath(bgMap[token])})`;
+    if (token && checkIdInMap(token) && blockmap[token].img)
+      result.backgroundImage = `url(${getImagePath(blockmap[token].img as string)})`;
   }
 
   if (
@@ -42,11 +46,14 @@ const style = computed(() => {
 
 onMounted(() => {
   let content = "";
-  if (props.tile && TipMap[props.tile]) content += TipMap[props.tile];
+  if (props.tile && checkIdInMap(props.tile) && blockmap[props.tile].desc)
+    content += blockmap[props.tile].desc;
 
   for (const token of props.tokens || []) {
-    if (token && TipMap[token])
-      content += content ? `<br/> ${TipMap[token]}` : ` ${TipMap[token]}`;
+    if (token && checkIdInMap(token) && blockmap[token].desc)
+      content += content
+        ? `<br/> ${blockmap[token].desc}`
+        : ` ${blockmap[token].desc}`;
   }
 
   if (content.length > 0) {
@@ -77,14 +84,14 @@ onMounted(() => {
   >
     <template v-if="tokens">
       <template v-for="(token, i) in tokens" :key="i">
-        <span v-if="classMap[token!]">
-          <i :class="classMap[token!]" />
+        <span v-if="checkIdInMap(token!) && blockmap[token!].icon">
+          <i :class="blockmap[token!].icon" />
         </span>
       </template>
     </template>
     <template v-else>
-      <span v-if="classMap[tile!]">
-        <i :class="classMap[tile!]" />
+      <span v-if="checkIdInMap(tile!) && blockmap[tile!].icon">
+        <i :class="blockmap[tile!].icon" />
       </span>
     </template>
   </div>
@@ -134,182 +141,5 @@ onMounted(() => {
 
 .empty {
   background-color: transparent;
-}
-
-.start,
-.flystart {
-  background-color: indianred;
-  border: 2px solid darkred;
-}
-
-.start span,
-.flystart span,
-.ballis span,
-.ore span,
-.airsup span,
-.xbalis span,
-.xbbillb span {
-  color: darkred;
-}
-
-.end {
-  background-color: skyblue;
-  border: 2px solid dodgerblue;
-}
-
-.end span {
-  color: dodgerblue;
-}
-
-.floor {
-  background-color: darkgray;
-  border: 1px dashed yellow;
-  box-shadow: inset 0 0 0 2px black;
-}
-
-.floor span {
-  color: white;
-}
-
-.road {
-  background-color: darkgray;
-  border: 2px dotted dimgray;
-}
-
-.wall {
-  background-color: lightgray;
-  border: 2px dotted dimgray;
-  box-shadow: 5px 5px 8px black;
-  z-index: 2;
-}
-
-.fence_bound {
-  background-color: darkgray;
-  border: 2px solid lightgray;
-}
-
-.hole {
-  background-color: black;
-}
-
-.grass {
-  background-color: yellowgreen;
-  border: 2px dotted dimgray;
-}
-
-.deepsea,
-.xbdpsea {
-  /* 清澈水域，为啥有两个得问YJ */
-  background-color: steelblue;
-  border: 2px dotted darkgray;
-}
-
-.infection,
-.corrosion_2,
-.healing,
-.telin,
-.telout,
-.volcano,
-.volspread {
-  background-color: darkgray;
-  border: 2px dotted dimgray;
-  background-position: center;
-  background-size: contain;
-  background-repeat: no-repeat;
-}
-
-.corrosion_2 span {
-  color: darkgoldenrod;
-}
-
-.telin,
-.telout {
-  border: 2px dashed dimgray;
-}
-
-.telin {
-  transform: rotate(180deg); /* fa 和 windicss 都不起作用 */
-}
-
-.token {
-  background-position: center;
-  background-size: contain;
-  background-repeat: no-repeat;
-}
-
-.hiddenstone {
-  /* 遗迹残骸 */
-  background-color: dimgray;
-  border: 2px solid darkgray;
-}
-
-.streasure span {
-  /* 宝刺金属箱 */
-  color: black;
-}
-
-.roadblock {
-  /* 道路障碍物 */
-  background-color: slategray;
-  border: 2px dotted darkgray;
-}
-
-.hstone span {
-  /* 城防路障 */
-  color: #745d32;
-}
-
-.xbmgbird span {
-  /* 喙中奇物 */
-  color: #653409;
-}
-
-.airsup {
-  /* 空袭侵入点 */
-  background-color: indianred;
-  border: 2px solid darkred;
-}
-
-.wdescp span, /* 逃脱点 */
-.xbbase span, /* 基地 */
-.xbfdtion span, /* 风沙营垒 */
-.xbmcv span /* 矿业房车 */ {
-  color: green;
-}
-
-.tower span {
-  /* 留声机 */
-  color: darkslategray;
-}
-
-.redtower span /* 移动战塔 */
-.xbstation span /* 号令点 */ {
-  color: crimson;
-}
-
-/* 池沼地块 */
-.puddle {
-  background-color: #599bd1;
-  border: 2px dotted darkgray;
-}
-.puddle span {
-  color: #82bded;
-}
-
-/* 隐焰地块 */
-.steam {
-  background-color: #935858;
-  border: 2px dotted darkgray;
-}
-.steam span {
-  color: #973a3a;
-}
-
-.xbrandprop span {
-  color: rgb(255, 229, 194);
-}
-
-.xbcp span {
-  color: rgb(255, 255, 99);
 }
 </style>

--- a/src/widgets/XbMapViewer/Map.vue
+++ b/src/widgets/XbMapViewer/Map.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+
+import Block from "./Block.vue";
+import { type XbConstData } from "./consts";
+
+export interface Props {
+  map: {
+    options: Record<string, any>;
+    mapData: Record<string, any>;
+    predefines: Record<string, any>;
+  };
+  embed?: boolean;
+  xbMapConst: XbConstData;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  embed: false,
+});
+
+const tokens = computed(() => {
+  const result: Record<string, any> = {};
+  const tokenInsts = props.map?.predefines.tokenInsts || [];
+  for (const token of tokenInsts) {
+    const pos = token.position;
+    const coord = `${pos.row}-${pos.col}`;
+    result[coord] = result[coord] ?? [];
+    result[coord].push(token.inst.characterKey.replaceAll(/trap_\d+_/g, ""));
+  }
+  return result;
+});
+
+const black = computed(() => {
+  const result: Record<string, string> = {};
+  const configBlackBoard = props.map?.options.configBlackBoard || [];
+  for (const block of configBlackBoard) {
+    const val = block.valueStr;
+    if (val === null) continue;
+
+    const pos = val.replaceAll(/\(|\)/g, "").split(",");
+    if (pos.length === 4) {
+      // let list = []
+      for (let y = Number.parseInt(pos[0]); y <= Number.parseInt(pos[2]); y++) {
+        for (
+          let x = Number.parseInt(pos[1]);
+          x <= Number.parseInt(pos[3]);
+          x++
+        ) {
+          result[`${y}-${x}`] = "rect";
+        }
+      }
+    }
+  }
+
+  return result;
+});
+
+function getTile(index: number) {
+  let a = props.map?.mapData.tiles[index].tileKey.replace("tile_", "");
+  if (a === "floor" || a === "road") {
+    const buildableType = props.map?.mapData.tiles[index].buildableType;
+    const isRoad =
+      buildableType === 1 ||
+      buildableType === "MELEE" ||
+      buildableType === "ALL";
+    a = isRoad ? "road" : "floor";
+  }
+  return a;
+}
+
+function getToken(row: number, col: number) {
+  return tokens.value[`${row}-${col}`];
+}
+
+const rootRef = ref<HTMLElement>();
+const fontsize = ref("");
+const bordersize = ref("");
+const width = computed(() => {
+  const mapData = props.map.mapData;
+  return mapData.width ?? mapData.map[0].length;
+});
+
+onMounted(() => {
+  if (!rootRef.value || !props.map) return;
+
+  fontsize.value = `${
+    (rootRef.value.getBoundingClientRect().width /
+      width.value /
+      (props.embed ? 5 : 9)) *
+    5
+  }px`;
+
+  bordersize.value = `${width.value <= 25 ? "2px" : "1px"}`;
+});
+</script>
+
+<template>
+  <div :id="embed ? 'mapmodal' : 'map'" ref="rootRef" class="xbmap w-full">
+    <div v-for="(row, i) in map.mapData.map" :key="i" class="row">
+      <Block
+        v-for="(board, n) in row"
+        :key="i * row.length + n"
+        :tile="getTile(board)"
+        :tile-height-type="map.mapData.tiles[board].heightType.toString()"
+        :tokens="getToken(map.mapData.map.length - 1 - i, n)"
+        :black="black && black[`${map.mapData.map.length - 1 - i}-${n}`]"
+        :blockmap="xbMapConst.blockmap"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+#map .row {
+  display: grid;
+  grid-template-columns: repeat(v-bind(width), 1fr);
+}
+
+#map :deep(.block span) {
+  font-size: v-bind(fontsize);
+}
+
+#map :deep(.block) {
+  border-width: v-bind(bordersize);
+}
+
+#mapmodal .row {
+  display: grid;
+  grid-template-columns: repeat(v-bind(width), 1fr);
+}
+
+#mapmodal :deep(.block span) {
+  font-size: v-bind(fontsize);
+}
+
+#mapmodal :deep(.block) {
+  border-width: v-bind(bordersize);
+}
+</style>

--- a/src/widgets/XbMapViewer/Map.vue
+++ b/src/widgets/XbMapViewer/Map.vue
@@ -90,7 +90,7 @@ onMounted(() => {
     5
   }px`;
 
-  bordersize.value = `${width.value <= 25 ? "2px" : "1px"}`;
+  bordersize.value = width.value <= 25 ? "2px" : "1px";
 });
 </script>
 

--- a/src/widgets/XbMapViewer/XbMapViewer.vue
+++ b/src/widgets/XbMapViewer/XbMapViewer.vue
@@ -7,6 +7,7 @@ import { getNaiveUILocale } from "@/utils/i18n";
 import { useTheme } from "@/utils/theme";
 
 import Block from "./Block.vue";
+import { getConstData, type XbConstData } from "./consts";
 
 export interface Props {
   map: {
@@ -17,6 +18,12 @@ export interface Props {
   embed?: boolean;
 }
 
+const XbMapConst = ref<XbConstData>({
+  blockmap: {},
+});
+onMounted(async () => {
+  XbMapConst.value = await getConstData();
+});
 const { theme } = useTheme();
 const i18nConfig = getNaiveUILocale();
 
@@ -117,6 +124,7 @@ onMounted(() => {
           :tile-height-type="map.mapData.tiles[board].heightType.toString()"
           :tokens="getToken(map.mapData.map.length - 1 - i, n)"
           :black="black && black[`${map.mapData.map.length - 1 - i}-${n}`]"
+          :blockmap="XbMapConst.blockmap"
         />
       </div>
     </div>

--- a/src/widgets/XbMapViewer/XbMapViewer.vue
+++ b/src/widgets/XbMapViewer/XbMapViewer.vue
@@ -108,7 +108,7 @@ onMounted(() => {
     :locale="i18nConfig.locale"
     :date-locale="i18nConfig.dateLocale"
   >
-    <div :id="embed ? 'mapmodal' : 'map'" ref="rootRef" class="w-full">
+    <div :id="embed ? 'mapmodal' : 'map'" ref="rootRef" class="xbmap w-full">
       <div v-for="(row, i) in map.mapData.map" :key="i" class="row">
         <Block
           v-for="(board, n) in row"

--- a/src/widgets/XbMapViewer/XbMapViewer.vue
+++ b/src/widgets/XbMapViewer/XbMapViewer.vue
@@ -1,111 +1,28 @@
 <script setup lang="ts">
-import { computed, onMounted, ref } from "vue";
+import { computed, onBeforeMount, ref } from "vue";
 
-import { NModal, NButton, NConfigProvider } from "naive-ui";
+import { NModal, NButton, NConfigProvider, NSkeleton } from "naive-ui";
 
 import { getNaiveUILocale } from "@/utils/i18n";
 import { useTheme } from "@/utils/theme";
 
-import Block from "./Block.vue";
+import Map, { type Props } from "./Map.vue";
 import { getConstData, type XbConstData } from "./consts";
 
-export interface Props {
-  map: {
-    options: Record<string, any>;
-    mapData: Record<string, any>;
-    predefines: Record<string, any>;
-  };
-  embed?: boolean;
-}
-
-const XbMapConst = ref<XbConstData>({
-  blockmap: {},
-});
-onMounted(async () => {
-  XbMapConst.value = await getConstData();
+const xbMapConst = ref<XbConstData>();
+onBeforeMount(async () => {
+  xbMapConst.value = await getConstData();
 });
 const { theme } = useTheme();
 const i18nConfig = getNaiveUILocale();
 
-const props = withDefaults(defineProps<Props>(), {
-  embed: false,
-});
+const props = defineProps<Pick<Props, "map">>();
 
-const tokens = computed(() => {
-  const result: Record<string, any> = {};
-  const tokenInsts = props.map?.predefines.tokenInsts || [];
-  for (const token of tokenInsts) {
-    const pos = token.position;
-    const coord = `${pos.row}-${pos.col}`;
-    result[coord] = result[coord] ?? [];
-    result[coord].push(token.inst.characterKey.replaceAll(/trap_\d+_/g, ""));
-  }
-  return result;
-});
-
-const black = computed(() => {
-  const result: Record<string, string> = {};
-  const configBlackBoard = props.map?.options.configBlackBoard || [];
-  for (const block of configBlackBoard) {
-    const val = block.valueStr;
-    if (val === null) continue;
-
-    const pos = val.replaceAll(/\(|\)/g, "").split(",");
-    if (pos.length === 4) {
-      // let list = []
-      for (let y = Number.parseInt(pos[0]); y <= Number.parseInt(pos[2]); y++) {
-        for (
-          let x = Number.parseInt(pos[1]);
-          x <= Number.parseInt(pos[3]);
-          x++
-        ) {
-          result[`${y}-${x}`] = "rect";
-        }
-      }
-    }
-  }
-
-  return result;
-});
-
-function getTile(index: number) {
-  let a = props.map?.mapData.tiles[index].tileKey.replace("tile_", "");
-  if (a === "floor" || a === "road") {
-    const buildableType = props.map?.mapData.tiles[index].buildableType;
-    const isRoad =
-      buildableType === 1 ||
-      buildableType === "MELEE" ||
-      buildableType === "ALL";
-    a = isRoad ? "road" : "floor";
-  }
-  return a;
-}
-
-function getToken(row: number, col: number) {
-  return tokens.value[`${row}-${col}`];
-}
-
-const rootRef = ref<HTMLElement>();
-const fontsize = ref("");
-const bordersize = ref("");
 const width = computed(() => {
   const mapData = props.map.mapData;
   return mapData.width ?? mapData.map[0].length;
 });
 const showModal = ref(false);
-
-onMounted(() => {
-  if (!rootRef.value || !props.map) return;
-
-  fontsize.value = `${
-    (rootRef.value.getBoundingClientRect().width /
-      width.value /
-      (props.embed ? 5 : 9)) *
-    5
-  }px`;
-
-  bordersize.value = `${width.value <= 25 ? "2px" : "1px"}`;
-});
 </script>
 
 <template>
@@ -115,69 +32,33 @@ onMounted(() => {
     :locale="i18nConfig.locale"
     :date-locale="i18nConfig.dateLocale"
   >
-    <div :id="embed ? 'mapmodal' : 'map'" ref="rootRef" class="xbmap w-full">
-      <div v-for="(row, i) in map.mapData.map" :key="i" class="row">
-        <Block
-          v-for="(board, n) in row"
-          :key="i * row.length + n"
-          :tile="getTile(board)"
-          :tile-height-type="map.mapData.tiles[board].heightType.toString()"
-          :tokens="getToken(map.mapData.map.length - 1 - i, n)"
-          :black="black && black[`${map.mapData.map.length - 1 - i}-${n}`]"
-          :blockmap="XbMapConst.blockmap"
-        />
+    <template v-if="xbMapConst">
+      <Map :map="map" :xb-map-const="xbMapConst"></Map>
+      <div v-if="width >= 25">
+        <NButton
+          quaternary
+          class="float-right mt-1 h-2em justify-end lt-sm:hidden"
+          @click="showModal = true"
+        >
+          <i class="mdi mdi-magnify-plus-outline"></i> 放大查看
+        </NButton>
+        <NModal
+          v-model:show="showModal"
+          class="custom-card h-full max-w-[1200px] w-full"
+          preset="card"
+          size="small"
+          :bordered="false"
+          :block-scroll="false"
+        >
+          <template #header>
+            <i class="mdi mdi-map"></i>
+          </template>
+          <Map :map="map" embed :xb-map-const="xbMapConst"></Map>
+        </NModal>
       </div>
-    </div>
-    <div v-if="!embed && width >= 25">
-      <NButton
-        quaternary
-        class="float-right mt-1 h-2em justify-end lt-sm:hidden"
-        @click="showModal = true"
-      >
-        <i class="mdi mdi-magnify-plus-outline"></i> 放大查看
-      </NButton>
-      <NModal
-        v-model:show="showModal"
-        class="custom-card"
-        preset="card"
-        style="width: 100%; max-width: 1200px; height: 100%"
-        size="small"
-        :bordered="false"
-        :block-scroll="false"
-      >
-        <template #header>
-          <i class="mdi mdi-map"></i>
-        </template>
-        <XbMapViewer :map="map" embed />
-      </NModal>
-    </div>
+    </template>
+    <NSkeleton v-else class="h-xs"></NSkeleton>
   </NConfigProvider>
 </template>
 
-<style scoped>
-#map .row {
-  display: grid;
-  grid-template-columns: repeat(v-bind(width), 1fr);
-}
-
-#map :deep(.block span) {
-  font-size: v-bind(fontsize);
-}
-
-#map :deep(.block) {
-  border-width: v-bind(bordersize);
-}
-
-#mapmodal .row {
-  display: grid;
-  grid-template-columns: repeat(v-bind(width), 1fr);
-}
-
-#mapmodal :deep(.block span) {
-  font-size: v-bind(fontsize);
-}
-
-#mapmodal :deep(.block) {
-  border-width: v-bind(bordersize);
-}
-</style>
+<style scoped></style>

--- a/src/widgets/XbMapViewer/consts.ts
+++ b/src/widgets/XbMapViewer/consts.ts
@@ -1,132 +1,23 @@
-export const classMap: Record<string, string> = {
-  start: "mdi mdi-alert", // 侵入点
-  end: "mdi mdi-alert", // 保护目标
-  flystart: "mdi mdi-quadcopter", // 空袭侵入点
-  telin: "mdi mdi-login-variant", // 通道入口
-  telout: "mdi mdi-logout", // 通道出口
-  puddle: "mdi mdi-waves", // 池沼地块
-  steam: "mdi mdi-fire", // 隐焰地块
-  // tokens
-  gtreasure: "mdi mdi-crown", // 埋没金属箱
-  //ballis: "fas fa-exclamation", // 弩炮
-  streasure: "mdi mdi-crown-outline", // 宝刺金属箱
-  airsup: "mdi mdi-close-octagon-outline", //可移动战术机库
-  wdescp: "mdi mdi-run", //逃脱点
-  redtower: "mdi mdi-transmission-tower", // 移动战塔
-  xbbase: "mdi mdi-chess-rook", // 基地
-  xbfdtion: "mdi mdi-chess-rook", // 风沙营垒
-  xbmcv: "mdi mdi-car", // 风沙营垒
-  poachr: "mdi mdi-crosshairs-gps", // 老练猎手
-  ore: "mdi mdi-radioactive", //源石祭坛
-  tower: "mdi mdi-tower-fire", // L-44留声机
-  xbalis: "mdi mdi-bow-arrow", //简易弩台
-  xbhydr: "mdi mdi-star-three-points", //机关石门
-  xbbillb: "mdi mdi-sign-real-estate", // 告示牌
-  roadblock: "mdi mdi-cube", //道路障碍物
-  hiddenstone: "mdi mdi-shield-key", //遗迹残骸
-  xbstation: "mdi mdi-flag-triangle", //号令点
-  xbmgbird: "mdi mdi-bird", //喙中奇物
-  hstone: "mdi mdi-cube-outline", //城防路障
-  xbrandprop: "mdi mdi-help-box-outline", //赛虫-随机道具盒
-};
+interface blockDefine {
+  icon: string | null;
+  img: string | null;
+  desc: string;
+}
 
-export const TipMap: Record<string, string> = {
-  start: "<b>侵入点</b><br>敌方会从此进入战场",
-  end: "<b>保护目标</b><br>蓝色目标点，敌方进入后会减少此目标点的耐久",
-  flystart: "<b>空袭侵入点</b><br>敌方飞行单位会从此处进入战场",
-  hole: "<b>地穴</b><br>危险的凹陷地形或地面破洞，经过的敌人会摔落至底部直接死亡",
-  grass: "<b>草丛</b><br>置于其中的干员不会成为敌军远程攻击的目标",
-  deepsea: "<b>清澈水域</b><br>可使用<蟹蟹抽水泵>采集<清水>",
-  xbdpsea: "<b>清澈水域</b><br>可使用<蟹蟹抽水泵>采集<清水>",
-  infection:
-    "<b>活性源石</b><br>部署于其上的我军和经过的敌军持续受到伤害，但攻击力和攻速大幅度提升",
-  corrosion_2: "<b>腐蚀地面</b><br>置于其上的我方单位防御力减半",
-  healing: "<b>医疗符文</b><br>部署在其上的干员会持续恢复生命",
-  telin: "<b>通道入口</b><br>敌方会从此进入通道，从通道出口出现",
-  telout: "<b>通道出口</b><br>进入通道的敌方单位会从此处再度出现",
-  volcano: "<b>热泵通道</b><br>每隔一段时间便会对其上的我军和敌军造成大量伤害",
-  volspread:
-    "<b>岩浆喷射处</b><br>每隔一定时间会喷出岩浆，对周围8格内的我方单位造成大量伤害且融化障碍物",
-  steam:
-    "<b>隐焰</b><br><盛季>和<荒季>时每隔一段时间对其上的任何单位造成无视防御和法术抗性的伤害",
-  puddle:
-    "<b>池沼</b><br>未干涸时具有与<清澈水域>相同的效果，<荒季>时会干涸露出地面",
-  // tokens
-  xbwood: "<b>杂木林</b><br>可开采<木材>",
-  xboverwatch: "<b>监控塔</b><br>可以侦查范围内的视野",
-  vegetation: "<b>灌木丛</b><br>击破后可以获得一些素材",
-  hiddenstone: "<b>遗迹残骸</b><br>击破后可解锁隐藏区域",
-  gtreasure: "<b>埋没金属箱</b><br>击破后可获得一些宝物",
-  ballis: "<b>弩炮</b><br>会定期射出弩箭对我方单位造成物理伤害",
-  streasure:
-    "<b>宝刺金属箱</b><br>击破后可以获得一些珍贵宝物，受到攻击时会反弹真实伤害",
-  xbstone: "<b>巨大岩石</b><br>可开采<石材>",
-  roadblock: "<b>道路障碍物</b><br>不容易受到我方单位的攻击",
-  xbiron: "<b>奇异矿脉</b><br>可开采<铁矿石>",
-  airsup:
-    "<b>可移动战术机库</b><br>根据需要可随时发射无人机支援敌方佣兵小队作战",
-  wdescp: "<b>逃脱点</b><br>部署干员后激活野外支援可进行逃脱",
-  redtower:
-    "<b>移动战塔</b><br>敌方老巢，击败该地区的全部老巢使该地区不会刷新精英敌袭",
-  xbbase: "<b>基地</b>必须保护的核心，被击败后视为演算失败",
-  xbfdtion: "<b>风沙营垒</b>必须保护的核心，被击败后视为演算失败",
-  xbmcv: "<b>旷野房车</b>在特殊行动中必须保护的核心，被击败后视为本次行动失败",
-  xbfarm: "<b>便携式种植槽</b><br>每天产出一定数量的<稻谷>，可部署在低地",
-  xbfarmm: "<b>种植箱集群</b><br>部署后，每个演算日产出一定数量的<稻谷>",
-  poachr:
-    "<b>老练猎手</b><br>只攻击野生动物，找不到攻击目标时可以闪现移动至周围随机可部署低地，拥有25%的物理和法术闪避",
-  ore: "<b>源石祭坛</b><br>周期性向四周释放脉冲波，对我军与敌军造成伤害",
-  tidectrl: "<b>涨潮控制</b>",
-  stone: "<b>碎石</b><br>改变敌人行进路线",
-  tower:
-    '<b>L-44"留声机"</b><br>我方与敌方可夺取控制权，激活后对敌方造成法术伤害，并可治疗友方单位',
-  rmtarms: "<b>R-11a突击动力装甲</b><br>吸收周围实验产物回复技力，技力满时激活",
-  xblight: "<b>监视哨站</b><br>可以侦查范围内的视野",
-  xbalis:
-    "<b>简易弩台</b><br>自身前方直线存在我方单位时发射弩箭造成物理伤害，可被击破",
-  xbdiam: "<b>澄亮矿脉</b><br>可被采集",
-  xbhydr: "<b>机关石门</b><br>被攻破后开启后续区域",
-  xbstation: "<b>号令点</b><br>被攻破后解锁荒废城镇远征",
-  xbmgbird: "<b>喙中奇物</b><br>可被治疗，完全恢复后可获得额外资源",
-  xbbillb: "<b>告示牌</b><br>会记录一些信息",
-  hstone: "<b>城防路障</b><br>可以阻挡多名敌人",
-  xbabal:
-    "<b>追猎发射台</b><br>每受到一定次数攻击，向范围内的一只【野生动物】发射捕猎网，其生命值低于一定比例时被捕获，否则受到一段时间的束缚",
-  xbrandprop:
-    "<b>随机道具盒</b><br>源石虫触碰后获得随机一个本场比赛中可提供的比赛用道具，之后消失一段时间",
-  xbcp: "<b>检查点</b><br>源石虫赛跑时的目标点位，其中靠近出发点的检查点为终点线",
-  xbspd: "<b>加速块</b><br>源石虫经过后会加速",
-  pushtw: "<b>喷拒器</b><br>将前方一名敌人推开",
-  battery: "<b>便携式补给站</b><br>每4秒对友方单位回复3点技力",
-  bondtw: "<b>缚网发射台</b><br>对前方一名敌方释放束缚网，束缚一段时间",
-  eradio:
-    "<b>废热喷口</b><br>对前方范围内所有敌人造成法术伤害并降低移动速度，可通过受击加速启动",
-};
+interface xbConstData {
+  blockmap: Record<string, blockDefine>;
+}
 
-export const bgMap: Record<string, string> = {
-  infection: "特殊地形_活性源石.png",
-  corrosion_2: "特殊地形_腐蚀地面.png",
-  healing: "特殊地形_医疗符文.png",
-  volcano: "特殊地形_热泵通道.png",
-  volspread: "特殊地形_岩浆喷射处.png",
-  // tokens
-  ballis: "技能_发射弩箭.png",
-  xbwood: "生息演算_资源_木材.png",
-  xboverwatch: "头像_装置_监控塔.png",
-  vegetation: "生息演算_资源_其他掉落物品.png",
-  xbstone: "生息演算_资源_石材.png",
-  xbiron: "生息演算_资源_铁矿石.png",
-  xbfarm: "头像_装置_便携式种植槽.png",
-  xbfarmm: "头像_装置_种植箱集群.png",
-  stone: "头像_装置_碎石.png",
-  rmtarms: "头像_装置_R-11突击动力装甲.png",
-  xblight: "头像_装置_监视哨站.png",
-  xbdiam: "生息演算_资源_澄亮石.png",
-  xbabal: "头像_装置_追猎发射台.png",
-  xbspd: "特殊地形_加速块.png",
-  xbcp: "特殊地形_检查点.png",
-  pushtw: "头像_装置_喷拒器.png",
-  battery: "头像_装置_便携式补给站.png",
-  bondtw: "头像_装置_缚网发射台.png",
-  eradio: "头像_装置_废热喷口.png",
-};
+async function getConstData(): Promise<xbConstData> {
+  const resp = await fetch(
+    `/index.php?${new URLSearchParams({
+      title: "模板:XbMapViewer/const",
+      action: "raw",
+    })}`,
+  );
+  return await resp.json();
+}
+
+const receivedConst = await getConstData();
+
+export const blockmap: Record<string, blockDefine> = receivedConst.blockmap;

--- a/src/widgets/XbMapViewer/consts.ts
+++ b/src/widgets/XbMapViewer/consts.ts
@@ -1,14 +1,14 @@
-interface blockDefine {
+export interface BlockDefine {
   icon: string | null;
   img: string | null;
   desc: string;
 }
 
-interface xbConstData {
-  blockmap: Record<string, blockDefine>;
+export interface XbConstData {
+  blockmap: Record<string, BlockDefine>;
 }
 
-async function getConstData(): Promise<xbConstData> {
+export async function getConstData(): Promise<XbConstData> {
   const resp = await fetch(
     `/index.php?${new URLSearchParams({
       title: "模板:XbMapViewer/const",
@@ -17,7 +17,3 @@ async function getConstData(): Promise<xbConstData> {
   );
   return await resp.json();
 }
-
-const receivedConst = await getConstData();
-
-export const blockmap: Record<string, blockDefine> = receivedConst.blockmap;

--- a/src/widgets/XbMapViewer/consts.ts
+++ b/src/widgets/XbMapViewer/consts.ts
@@ -1,6 +1,6 @@
 export interface BlockDefine {
-  icon: string | null;
-  img: string | null;
+  icon?: string;
+  img?: string;
   desc: string;
 }
 


### PR DESCRIPTION
由于XbMap的地块需要不定时维护，为此将其中的数据分开到wiki端，包含如下内容：
- `const`：定义地块类型，包括`icon`（图标显示）、`img`（图片显示）、`desc`（popup说明）三部分。<br>这部分数据移动到[模板:XbMapViewer/const](https://prts.wiki/id/77063)页面，使用JSON格式存储。
- `style`：对地块进行着色。<br>这部分数据移动到[Widget:XbMapViewer/style](https://prts.wiki/id/77068)页面，通过JS注入CSS生效。<br>※注：并非所有的样式都进行了迁移，因为有一些是“基底”样式。