### PR TITLE
feat(ISEvent): Jie Garden Update

### DIFF
--- a/src/entries/ISEvent.ts
+++ b/src/entries/ISEvent.ts
@@ -29,6 +29,7 @@ for (const eventEle of Array.from(eventEles)) {
         etype: data.etype,
         edesc: scene.querySelectorAll(".edesc")[0]?.innerHTML,
         name: data.name,
+        ename: data.ename,
         nav: data.nav,
         index: data.index,
         image: data.image,
@@ -47,9 +48,11 @@ for (const eventEle of Array.from(eventEles)) {
             dest: chooseData.dest,
             customBadgeText:
               choose.querySelectorAll(".customBadgeText")[0]?.innerHTML,
+            subChoose: chooseData.subchoose,
             index,
           };
         }),
+        prtsinfo: data.prtsinfo,
       };
     },
   );
@@ -58,7 +61,7 @@ for (const eventEle of Array.from(eventEles)) {
     sceneCategoryTabList.push(scenes[0].etype);
     sceneCategoryData.push([]);
   }
-  sceneCategoryData.at(-1)?.push(scenes[0].name || "？？？");
+  sceneCategoryData.at(-1)?.push(scenes[0].ename || scenes[0].name || "？？？");
   // creat event
   createApp(ISEventFramework, {
     sceneData: scenes,

--- a/src/entries/ISEvent.ts
+++ b/src/entries/ISEvent.ts
@@ -45,7 +45,7 @@ for (const eventEle of Array.from(eventEles)) {
             iconId: chooseData.iconid,
             desc1: choose.querySelectorAll(".desc1")[0]?.innerHTML,
             desc2: choose.querySelectorAll(".desc2")[0]?.innerHTML,
-            dest: chooseData.dest,
+            dest: Number.parseInt(chooseData.dest || "0"),
             customBadgeText:
               choose.querySelectorAll(".customBadgeText")[0]?.innerHTML,
             subChoose: chooseData.subchoose,

--- a/src/widgets/ISEvents/ISEventCategory.vue
+++ b/src/widgets/ISEvents/ISEventCategory.vue
@@ -20,8 +20,10 @@ defineProps<{
   <NConfigProvider
     preflight-style-disabled
     :theme-overrides="{
+      common: {
+        borderRadius: '0',
+      },
       Card: {
-        borderRadius: '5px',
         actionColor: '#343434',
         borderColor: '#ADADAD',
       },
@@ -30,7 +32,8 @@ defineProps<{
         tabTextColorActiveLine: '#4294CF',
         barColor: '#4294CF',
         tabFontWeightActive: 'bold',
-        tabGapSmallLine: '20px',
+        tabGapSmallLine: '1em',
+        tabPaddingSmallLine: '0.3em 0.5em',
       },
       Breadcrumb: { itemTextColor: '#A8AFB5' },
       Button: {
@@ -42,6 +45,10 @@ defineProps<{
     <NSpace class="max-w-full w-140">
       <NLayout>
         <NLayoutContent>
+          <div class="bg-[#2f2f2f] px-2 py-1 c-white">
+            <i class="mdi mdi-information-variant-circle"></i>
+            可以使用鼠标滚轮或手指拖动来滚动分类栏。
+          </div>
           <NCard class="relative" size="small">
             <NTabs type="line" size="small" animated>
               <NTabPane
@@ -69,3 +76,32 @@ defineProps<{
     </NSpace>
   </NConfigProvider>
 </template>
+
+<style>
+.n-breadcrumb .n-breadcrumb-item .n-breadcrumb-item__separator {
+  margin: 0 !important;
+}
+
+.n-breadcrumb ul {
+  margin: 0 !important;
+  padding: 0.2em !important;
+}
+
+.n-breadcrumb li {
+  margin: 0 !important;
+}
+
+.n-collapse
+  .n-collapse-item.n-collapse-item--left-arrow-placement
+  .n-collapse-item__header
+  .n-collapse-item-arrow {
+  margin: 0 !important;
+}
+
+.n-collapse
+  .n-collapse-item
+  .n-collapse-item__content-wrapper
+  .n-collapse-item__content-inner {
+  padding-top: 0.5em !important;
+}
+</style>

--- a/src/widgets/ISEvents/ISEventCategory.vue
+++ b/src/widgets/ISEvents/ISEventCategory.vue
@@ -78,37 +78,8 @@ defineProps<{
   </NConfigProvider>
 </template>
 
-<style>
-.ISEventFrame .n-breadcrumb .n-breadcrumb-item .n-breadcrumb-item__separator {
-  margin: 0 !important;
-}
-
-.ISEventFrame .n-breadcrumb ul {
-  margin: 0 !important;
-  padding: 0.2em !important;
-}
-
-.ISEventFrame .n-breadcrumb li {
-  margin: 0 !important;
-}
-
-.ISEventFrame
-  .n-collapse
-  .n-collapse-item.n-collapse-item--left-arrow-placement
-  .n-collapse-item__header
-  .n-collapse-item-arrow {
-  margin: 0 !important;
-}
-
-.ISEventFrame
-  .n-collapse
-  .n-collapse-item
-  .n-collapse-item__content-wrapper
-  .n-collapse-item__content-inner {
-  padding-top: 0.5em !important;
-}
-
-.ISEventCategory a {
+<style scoped>
+a {
   text-decoration: none;
   color: unset;
 }

--- a/src/widgets/ISEvents/ISEventCategory.vue
+++ b/src/widgets/ISEvents/ISEventCategory.vue
@@ -41,6 +41,7 @@ defineProps<{
         textColorTextPressed: '#07426D',
       },
     }"
+    class="ISEventCategory"
   >
     <NSpace class="max-w-full w-140">
       <NLayout>
@@ -78,30 +79,37 @@ defineProps<{
 </template>
 
 <style>
-.n-breadcrumb .n-breadcrumb-item .n-breadcrumb-item__separator {
+.ISEventFrame .n-breadcrumb .n-breadcrumb-item .n-breadcrumb-item__separator {
   margin: 0 !important;
 }
 
-.n-breadcrumb ul {
+.ISEventFrame .n-breadcrumb ul {
   margin: 0 !important;
   padding: 0.2em !important;
 }
 
-.n-breadcrumb li {
+.ISEventFrame .n-breadcrumb li {
   margin: 0 !important;
 }
 
-.n-collapse
+.ISEventFrame
+  .n-collapse
   .n-collapse-item.n-collapse-item--left-arrow-placement
   .n-collapse-item__header
   .n-collapse-item-arrow {
   margin: 0 !important;
 }
 
-.n-collapse
+.ISEventFrame
+  .n-collapse
   .n-collapse-item
   .n-collapse-item__content-wrapper
   .n-collapse-item__content-inner {
   padding-top: 0.5em !important;
+}
+
+.ISEventCategory a {
+  text-decoration: none;
+  color: unset;
 }
 </style>

--- a/src/widgets/ISEvents/ISEventFramework.vue
+++ b/src/widgets/ISEvents/ISEventFramework.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 import { HomeSharp } from "@vicons/material";
 import {
@@ -12,6 +12,7 @@ import {
   NLayout,
   NLayoutContent,
   NSpace,
+  type DropdownOption,
 } from "naive-ui";
 
 import { getImagePath } from "@/utils/utils";
@@ -28,6 +29,7 @@ interface Option {
   dest: number;
   index: number;
   customBadgeText?: string;
+  subChoose?: string;
 }
 
 const props = withDefaults(
@@ -36,11 +38,13 @@ const props = withDefaults(
       etype?: string;
       edesc?: string;
       name?: string;
+      ename?: string;
       nav?: string;
       index?: number;
       image?: string;
       text?: string;
       options: Array<Option>;
+      prtsinfo?: string;
     }[];
     isTheme: string;
   }>(),
@@ -51,6 +55,12 @@ const props = withDefaults(
 
 const sceneNav = ref<Array<number>>([0]);
 const currentSceneId = ref(0);
+function isPrtsInfo(sceneId: number) {
+  return props.sceneData[sceneId].prtsinfo !== "";
+}
+const isCurScenePrtsInfo = computed(() => {
+  return isPrtsInfo(currentSceneId.value);
+});
 function jump(id: number) {
   if (id) {
     const index = sceneNav.value.indexOf(id);
@@ -59,6 +69,15 @@ function jump(id: number) {
       sceneNav.value.splice(index + 1);
 
     currentSceneId.value = id;
+
+    const name =
+      props.sceneData[currentSceneId.value].ename ||
+      props.sceneData[currentSceneId.value].name ||
+      "";
+    const element = document.querySelector(`#${name}`);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth" });
+    }
   }
 }
 function navJump(index: number) {
@@ -68,19 +87,59 @@ function navJump(index: number) {
   sceneNav.value.splice(index + 1);
 }
 function optionsToNavDrop(options: Array<Option>) {
-  return options
-    .filter((option) => option.type !== "desc")
-    .map((option) => {
-      return {
-        label: option.title,
-        key: option.index,
-      };
-    });
+  const navDrop: sceneNavDropdownOption[] = [];
+  for (const o of options.filter((option) => option.type !== "desc")) {
+    const scd = getSubChooseData(o.subChoose || "");
+    if (scd.length === 0) {
+      navDrop.push({
+        label: o.title,
+        key: `m-${o.index}`,
+        props: {
+          isSubChoose: false,
+          destScene: o.dest,
+        },
+        children: undefined,
+      });
+    } else {
+      const children: any[] = [];
+      for (const d of scd) {
+        children.push({
+          label: `${d[0]}`,
+          key: `s-${o.index}-${d[1]}`,
+          props: {
+            isSubChoose: true,
+            destScene: d[1],
+          },
+        });
+      }
+      navDrop.push({
+        label: o.title,
+        key: `m-${o.index}-main`,
+        children,
+      });
+    }
+  }
+  return navDrop;
 }
-function dropJump(key: number, navIndex: number) {
-  const option = props.sceneData[sceneNav.value[navIndex]].options[key];
+
+type sceneNavDropdownOption = DropdownOption & {
+  props?: Record<string, any>;
+};
+function dropJump(
+  _key: string,
+  navIndex: number,
+  ndropoption: sceneNavDropdownOption,
+) {
   navJump(navIndex);
-  jump(option.dest);
+  jump(ndropoption.props?.destScene);
+}
+function getSubChooseData(scStr: string) {
+  if (scStr === "") {
+    return [];
+  }
+  return scStr.split(";;").map((i) => {
+    return i.split(";");
+  });
 }
 </script>
 
@@ -95,42 +154,52 @@ function dropJump(key: number, navIndex: number) {
     </span>
   </h2>
   <h3>
-    <span :id="sceneData[0].name" />
+    <span :id="sceneData[0].ename || sceneData[0].name" />
     <span
-      :id="encodeURI(sceneData[0].name!).replace(/%/g, '.')"
+      :id="
+        encodeURI((sceneData[0].ename || sceneData[0].name)!).replace(/%/g, '.')
+      "
       class="mw-headline"
     >
-      {{ sceneData[0].name }}
+      {{ sceneData[0].ename || sceneData[0].name }}
     </span>
   </h3>
   <div v-if="sceneData[0].edesc" v-html="sceneData[0].edesc"></div>
   <NConfigProvider
     preflight-style-disabled
     :theme-overrides="{
+      common: {
+        borderRadius: '0',
+      },
       Card: {
         color: '#212121',
         textColor: '#fff',
         titleTextColor: '#fff',
-        borderRadius: '3px',
         actionColor: '#343434',
-        paddingSmall: '0.8em',
-        lineHeight: '1.5',
-        titleFontSizeSmall: '1rem',
-        fontSizeSmall: '0.8rem',
+        paddingSmall: '0.6em',
+        lineHeight: '1.4',
       },
       Breadcrumb: { itemTextColor: '#A8AFB5' },
       Button: { textColor: '#fff' },
+      Collapse: {
+        arrowColor: '#fff',
+        titleTextColor: '#fff',
+        titleFontSize: '0.75rem',
+      },
     }"
   >
     <NSpace class="max-w-full w-140">
       <NLayout>
         <NLayoutContent>
-          <NBreadcrumb separator=">">
+          <NBreadcrumb class="from-[#2f2f2f20] to-[#2f2f2f00] bg-gradient-to-b">
             <NBreadcrumbItem
               v-for="(SceneId, index) in sceneNav"
               :key="index"
               @click="navJump(index)"
             >
+              <template #separator>
+                <div class="scale-x-50">&gt;</div>
+              </template>
               <NDropdown
                 v-if="
                   sceneData[SceneId].options.length > 0 &&
@@ -139,20 +208,46 @@ function dropJump(key: number, navIndex: number) {
                 placement="bottom-start"
                 :show-arrow="true"
                 :options="optionsToNavDrop(sceneData[SceneId].options)"
-                @select="(i) => dropJump(i, index)"
+                @select="(k, op) => dropJump(k, index, op)"
               >
                 <div class="trigger">
                   <NIcon v-if="SceneId === 0">
                     <HomeSharp />
                   </NIcon>
-                  <span v-else>{{ sceneData[SceneId].nav }}</span>
+                  <span
+                    v-else
+                    :class="[
+                      {
+                        'px-1 bg-[#00638f] b-0.5 b-[#0098dc] b-solid c-white':
+                          isPrtsInfo(SceneId),
+                      },
+                    ]"
+                  >
+                    <sup v-if="isPrtsInfo(SceneId)">
+                      <i class="mdi mdi-rhombus-outline font-size-2"></i>
+                    </sup>
+                    {{ sceneData[SceneId].nav }}
+                  </span>
                 </div>
               </NDropdown>
               <div v-else>
                 <NIcon v-if="SceneId === 0">
                   <HomeSharp />
                 </NIcon>
-                <span v-else>{{ sceneData[SceneId].nav }}</span>
+                <span
+                  v-else
+                  :class="[
+                    {
+                      'px-1 bg-[#00638f] b-0.5 b-[#0098dc] b-solid c-white':
+                        isPrtsInfo(SceneId),
+                    },
+                  ]"
+                >
+                  <sup v-if="isPrtsInfo(SceneId)">
+                    <i class="mdi mdi-rhombus-outline font-size-2"></i>
+                  </sup>
+                  {{ sceneData[SceneId].nav }}
+                </span>
               </div>
             </NBreadcrumbItem>
           </NBreadcrumb>
@@ -169,8 +264,25 @@ function dropJump(key: number, navIndex: number) {
                 />
               </a>
             </template>
-            <div v-html="sceneData[currentSceneId].text" />
-            <template v-if="sceneData[currentSceneId].options" #action>
+            <div
+              v-if="isCurScenePrtsInfo"
+              class="b-1 b-[#0098dca0] b-b-transparent b-solid bg-[#0098dc50] px-2 font-size-2.5"
+            >
+              <i class="mdi mdi-rhombus-outline"></i>
+              PRTS info.
+            </div>
+            <div
+              :class="[
+                {
+                  'pa-1 b-1 b-[#0098dca0] b-solid': isCurScenePrtsInfo,
+                },
+              ]"
+              v-html="sceneData[currentSceneId].text"
+            ></div>
+            <template
+              v-if="sceneData[currentSceneId].options.length > 0"
+              #action
+            >
               <NSpace vertical>
                 <ISEventOption
                   v-for="(item, index) in sceneData[currentSceneId].options"
@@ -183,6 +295,8 @@ function dropJump(key: number, navIndex: number) {
                   :desc2="item.desc2"
                   :is-theme="isTheme"
                   :custom-badge-text="item.customBadgeText"
+                  :subchoose="getSubChooseData(item.subChoose ?? '')"
+                  :method-jump="jump"
                   @click="jump(item.dest)"
                 />
               </NSpace>

--- a/src/widgets/ISEvents/ISEventFramework.vue
+++ b/src/widgets/ISEvents/ISEventFramework.vue
@@ -101,21 +101,19 @@ function optionsToNavDrop(options: Array<Option>) {
         children: undefined,
       });
     } else {
-      const children: any[] = [];
-      for (const d of scd) {
-        children.push({
-          label: `${d[0]}`,
-          key: `s-${o.index}-${d[1]}`,
-          navData: {
-            isSubChoose: true,
-            destScene: d[1],
-          },
-        });
-      }
       navDrop.push({
         label: o.title,
         key: `m-${o.index}-main`,
-        children,
+        children: scd.map((d) => {
+          return {
+            label: `${d[0]}`,
+            key: `s-${o.index}-${d[1]}`,
+            navData: {
+              isSubChoose: true,
+              destScene: d[1],
+            },
+          };
+        }),
       });
     }
   }
@@ -184,11 +182,6 @@ function getSubChooseData(scStr: string) {
       },
       Breadcrumb: { itemTextColor: '#A8AFB5' },
       Button: { textColor: '#fff' },
-      Collapse: {
-        arrowColor: '#fff',
-        titleTextColor: '#fff',
-        titleFontSize: '0.75rem',
-      },
     }"
     class="ISEventFrame"
   >
@@ -309,3 +302,18 @@ function getSubChooseData(scStr: string) {
     </NSpace>
   </NConfigProvider>
 </template>
+
+<style scoped>
+:deep(.n-breadcrumb .n-breadcrumb-item .n-breadcrumb-item__separator) {
+  margin: 0 !important;
+}
+
+:deep(.n-breadcrumb ul) {
+  margin: 0 !important;
+  padding: 0.2em !important;
+}
+
+:deep(.n-breadcrumb li) {
+  margin: 0 !important;
+}
+</style>

--- a/src/widgets/ISEvents/ISEventFramework.vue
+++ b/src/widgets/ISEvents/ISEventFramework.vue
@@ -187,6 +187,7 @@ function getSubChooseData(scStr: string) {
         titleFontSize: '0.75rem',
       },
     }"
+    class="ISEventFrame"
   >
     <NSpace class="max-w-full w-140">
       <NLayout>
@@ -216,12 +217,10 @@ function getSubChooseData(scStr: string) {
                   </NIcon>
                   <span
                     v-else
-                    :class="[
-                      {
-                        'px-1 bg-[#00638f] b-0.5 b-[#0098dc] b-solid c-white':
-                          isPrtsInfo(SceneId),
-                      },
-                    ]"
+                    :class="{
+                      'px-1 bg-[#00638f] b-0.5 b-[#0098dc] b-solid c-white':
+                        isPrtsInfo(SceneId),
+                    }"
                   >
                     <sup v-if="isPrtsInfo(SceneId)">
                       <i class="mdi mdi-rhombus-outline font-size-2"></i>

--- a/src/widgets/ISEvents/ISEventFramework.vue
+++ b/src/widgets/ISEvents/ISEventFramework.vue
@@ -87,14 +87,14 @@ function navJump(index: number) {
   sceneNav.value.splice(index + 1);
 }
 function optionsToNavDrop(options: Array<Option>) {
-  const navDrop: sceneNavDropdownOption[] = [];
+  const navDrop: SceneNavDropdownOption[] = [];
   for (const o of options.filter((option) => option.type !== "desc")) {
     const scd = getSubChooseData(o.subChoose || "");
     if (scd.length === 0) {
       navDrop.push({
         label: o.title,
         key: `m-${o.index}`,
-        props: {
+        navData: {
           isSubChoose: false,
           destScene: o.dest,
         },
@@ -106,7 +106,7 @@ function optionsToNavDrop(options: Array<Option>) {
         children.push({
           label: `${d[0]}`,
           key: `s-${o.index}-${d[1]}`,
-          props: {
+          navData: {
             isSubChoose: true,
             destScene: d[1],
           },
@@ -122,16 +122,19 @@ function optionsToNavDrop(options: Array<Option>) {
   return navDrop;
 }
 
-type sceneNavDropdownOption = DropdownOption & {
-  props?: Record<string, any>;
+type SceneNavDropdownOption = DropdownOption & {
+  navData?: {
+    isSubChoose: boolean;
+    destScene: number;
+  };
 };
 function dropJump(
   _key: string,
   navIndex: number,
-  ndropoption: sceneNavDropdownOption,
+  ndropoption: SceneNavDropdownOption,
 ) {
   navJump(navIndex);
-  jump(ndropoption.props?.destScene);
+  jump(ndropoption.navData?.destScene || 0);
 }
 function getSubChooseData(scStr: string) {
   if (scStr === "") {

--- a/src/widgets/ISEvents/ISEventOption.vue
+++ b/src/widgets/ISEvents/ISEventOption.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
-import { NAvatar, NBadge, NCard } from "naive-ui";
+import { ref } from "vue";
+
+import {
+  NAvatar,
+  NBadge,
+  NButton,
+  NCard,
+  NCollapseTransition,
+  NSpace,
+} from "naive-ui";
 
 import { TORAPPU_ENDPOINT } from "@/utils/consts";
 import { getImagePath } from "@/utils/utils";
@@ -12,17 +21,21 @@ defineProps<{
   desc2?: string;
   isTheme?: string;
   customBadgeText?: string;
+  subchoose: string[][];
+  methodJump: (index: number) => void;
 }>();
+const showSubChoose = ref(false);
 </script>
 
 <template>
   <NCard
     v-if="title || desc1 || desc2"
-    :style="
+    :style="[
       type === 'desc'
         ? { cursor: 'default' }
-        : { cursor: 'pointer', borderColor: '#929292' }
-    "
+        : { cursor: 'pointer', borderColor: '#929292' },
+      subchoose.length > 0 ? { cursor: 'default' } : {},
+    ]"
     :title="type === 'guide' ? '' : title"
     size="small"
     :header-style="{ height: '3em' }"
@@ -90,8 +103,56 @@ defineProps<{
         `${desc1}${type === 'guide' ? '<span class=\'mdi mdi-arrow-right float-right\'></span>' : ''}`
       "
     />
-    <template v-if="desc2" #footer>
-      <div class="text-xs" v-html="desc2" />
+    <template v-if="desc2 || subchoose.length > 0" #action>
+      <div
+        v-if="desc2"
+        :class="['text-xs', { 'pb-2': subchoose.length > 0 }]"
+        v-html="desc2"
+      />
+      <div v-if="subchoose.length > 0">
+        <NButton
+          size="small"
+          color="#ccc"
+          class="w-full"
+          ghost
+          icon-placement="right"
+          @click="showSubChoose = !showSubChoose"
+        >
+          {{ showSubChoose ? "收起" : "展开" }}子项
+          <template #icon>
+            <i
+              :class="[
+                'mdi mdi-menu-down transition transition-duration-0.3s',
+                { 'scale-y-[-1]': showSubChoose },
+              ]"
+            ></i>
+          </template>
+        </NButton>
+        <NCollapseTransition :show="showSubChoose">
+          <NSpace vertical class="mt-2">
+            <NCard
+              v-for="(data, index) in subchoose"
+              :key="index"
+              :style="{ cursor: 'pointer', borderColor: '#929292' }"
+              size="small"
+              :header-style="{ height: '3em' }"
+              @click.stop
+              @click="
+                () => {
+                  showSubChoose = false;
+                  methodJump(parseInt(data[1]));
+                }
+              "
+            >
+              <div
+                v-html="
+                  `${data[0]}<span class=\'mdi mdi-arrow-right float-right\'></span>`
+                "
+              />
+            </NCard>
+          </NSpace>
+        </NCollapseTransition>
+      </div>
     </template>
   </NCard>
 </template>

--- a/src/widgets/SOExpCalc/SOExpCalc.vue
+++ b/src/widgets/SOExpCalc/SOExpCalc.vue
@@ -219,14 +219,15 @@ const tableData = computed(() =>
         特勤经验计算
       </template>
       <template #header-extra>
-        <NTooltip placement="left" trigger="hover">
+        <NTooltip placement="bottom-end" trigger="hover">
           <template #trigger>
             <NButton size="tiny" color="#f5d003" @click="showSOETModal = true">
               <i class="mdi mdi-stairs-box"></i>&nbsp;查看完整升级表
             </NButton>
           </template>
           <i class="mdi mdi-alert"></i
-          >&nbsp;<b>注意：</b>特勤干员经验阶梯与普通干员不同。<br />请勿将特勤干员的经验阶梯与普通干员的经验阶梯混淆。
+          >&nbsp;<b>注意：</b>特勤干员经验阶梯与普通干员不同。
+          <br />请勿将特勤干员的经验阶梯与普通干员的经验阶梯混淆。
         </NTooltip>
       </template>
       <NFlex vertical align="center">
@@ -299,8 +300,10 @@ const tableData = computed(() =>
           />
         </NFlex>
         <br />
-        ※可以使用键盘的上下键来调整等级和经验值。<br />
-
+        <span>
+          <i class="mdi mdi-information-variant-circle"></i>
+          可以使用键盘的上下键来调整等级和经验值。
+        </span>
         <NCard class="text-center">
           <div
             :class="[
@@ -366,13 +369,15 @@ const tableData = computed(() =>
             </div>
             <div v-else-if="selectLevel.start.level === selectLevel.maxLevel">
               <span class="font-size-1.5em font-bold"> 等级已满 </span><br />
-              <span
+              <div
                 v-if="selectedElite !== 2"
-                class="level-max-warn bg-[#ff7070] px-3em color-white font-bold"
+                class="level-max-warn bg-[#ff7070] px-3em color-white font-bold outline-1 outline-white outline"
               >
                 <i class="mdi mdi-alert"></i>
-                继续获得的经验将被丢弃！请尽快完成干员晋升。
-              </span>
+                继续获得的经验将被丢弃！
+                <br v-if="isMobile" />
+                请尽快完成干员晋升。
+              </div>
               <span
                 v-else
                 class="bg-[linear-gradient(to_right,#0000,#f5d003,#0000)] px-5em color-black font-bold"
@@ -400,6 +405,11 @@ const tableData = computed(() =>
         特勤经验全表
       </template>
       <NFlex vertical align="center">
+        <div v-if="isMobile" class="text-center">
+          <i class="mdi mdi-alert"></i
+          >&nbsp;<b>注意：</b>特勤干员经验阶梯与普通干员不同。
+          <br />请勿将特勤干员的经验阶梯与普通干员的经验阶梯混淆。
+        </div>
         <NRadioGroup
           v-model:value="selectedElite"
           name="elite"
@@ -468,7 +478,26 @@ const tableData = computed(() =>
   }
 }
 
+@keyframes lv-warn-outline {
+  0% {
+    outline-offset: 0;
+    outline-color: #fffc;
+  }
+
+  20% {
+    outline-offset: 10px;
+    outline-color: #fff0;
+  }
+
+  100% {
+    outline-offset: 10px;
+    outline-color: #fff0;
+  }
+}
+
 .level-max-warn {
-  animation: lv-warn 2s ease-in-out 0s infinite;
+  animation:
+    lv-warn 2s ease-in-out 0s infinite,
+    lv-warn-outline 2s linear infinite;
 }
 </style>


### PR DESCRIPTION
Scene：
- 增加全新参数：prtsinfo
  该参数会把这一屏的内容标注为“PRTS提供的内容”。
  这在有些不得不需要单开一屏写分叉的情况下，可以与游戏内原有的内容区分。
  ※对应模板参数：prtsinfo
- 增加全新参数：ename
  该参数会重新定义事件的h3标题
  这个参数是一个先见参数，因为我们发现界园里出现了同样的事件在不同区域里有不同的变化。
  ※对应模板参数：ename

Choose：
- 增加全新参数：subChoose
  该参数用于为这个选项写分歧，目前推荐用于像水月扔骰子/界园扔钱这种一次性又短小的“运气”分歧
  ※格式为：选项名称;前往场景编号;;...
  ※对应模板参数：subChoose

其它：
- 优化了显示样式
- 优化了按钮交互后的事件位置，现在点击后会自动滚动到对应事件的顶部，这在一些长屏事件中会有比较好的交互效果
- 由于subChoose的加入，顺带优化了nav的数据包装，现在它对subChoose有了更好的支持
- (SOExpCalc) 修复了晋升提示在手机端的显示问题，并优化了全表按钮的popup位置

以上效果可参阅各组件的/dev页面

---

一些可能的问题：
- 由于NaiveUI的部分细节样式是硬编码的，因此不得不使用未scoped的style来调整