### PR TITLE
feat(CharList): set unavailable tags as dimmed

### DIFF
--- a/src/components/Checkbox.vue
+++ b/src/components/Checkbox.vue
@@ -6,9 +6,11 @@ const props = withDefaults(
     modelValue?: boolean;
     noWidth?: boolean;
     value?: string;
+    dimmed?: boolean;
   }>(),
   {
     noWidth: false,
+    dimmed: false,
   },
 );
 const emit = defineEmits<{
@@ -38,6 +40,7 @@ const isSelected = computed({
     :class="{
       selected: isSelected,
       'no-width': noWidth,
+      dimmed,
     }"
     class="checkbox-container"
     @click="
@@ -74,5 +77,8 @@ const isSelected = computed({
 }
 .no-width {
   width: initial;
+}
+.dimmed {
+  opacity: 0.45;
 }
 </style>

--- a/src/components/FilterRow.vue
+++ b/src/components/FilterRow.vue
@@ -12,9 +12,11 @@ const props = withDefaults(
     noWidth?: boolean;
     someSelected?: boolean;
     modelValue?: Record<string, boolean>;
+    dimmedLabels?: Record<string, boolean>;
   }>(),
   {
     modelValue: () => ({}),
+    dimmedLabels: () => ({}),
   },
 );
 const emit = defineEmits<{
@@ -87,6 +89,7 @@ const removeAll = () => {
         :key="label"
         :value="label"
         :no-width="noWidth"
+        :dimmed="dimmedLabels?.[label]"
       >
         {{ label }}
       </Checkbox>


### PR DESCRIPTION
在 CharList Widget 中，将“选中后无结果”的筛选标签设置为 dimmed（不透明度 0.45），实现选择职业后自动在视觉上淡化无关分支，提升筛选体验的直观性。