### PR TITLE
fix: accumulative rotation timeline

### DIFF
--- a/src/widgets/Spine/Spine.vue
+++ b/src/widgets/Spine/Spine.vue
@@ -85,7 +85,7 @@ async function load() {
   }));
   isLoading.value = false;
   spineRef.spine!.play(`${curSkin.value}-${curModel.value}`);
-  animationState.setAnimation(0, names[0], isLoop.value);
+  spineRef.spine!.setAnimation(names[0], isLoop.value);
   curAni.value = names[0];
   animationState.timeScale = speed.value;
 }
@@ -110,15 +110,14 @@ function onSelectAni(e: string) {
   const cur = spineRef.spine?.getCurrent();
   if (cur) {
     console.log("ani change", cur);
-    cur.state.setAnimation(0, e, isLoop.value);
+    spineRef.spine!.setAnimation(e, isLoop.value);
     cur.state.timeScale = speed.value;
   }
 }
 function onChangeLoop(e: boolean) {
-  const state = spineRef.spine?.getCurrent()?.state;
-  if (!state) return;
+  if (!spineRef.spine?.getCurrent()) return;
 
-  state.setAnimation(0, state.tracks[0].animation.name, e);
+  spineRef.spine.setAnimation(curAni.value, e);
 }
 function onChangeColor(e: string) {
   if (!spineRef.spine) return;

--- a/src/widgets/Spine/spine.ts
+++ b/src/widgets/Spine/spine.ts
@@ -4,6 +4,11 @@ import { downloadBlob } from "@/utils/utils";
 function noop() {
   // noop
 }
+
+// 重复播放一次性动画（如 Die）时，在每遍之间插入的小幅交叉淡化（秒）。
+// 经测试 ~0.2s 是较优值：太大反而会和下一遍自身的快速动作重叠、更难看。
+const REPEAT_MIX = 0.2;
+
 interface Skeleton {
   skeleton: spine.Skeleton;
   bounds: {
@@ -12,6 +17,8 @@ interface Skeleton {
   };
   state: spine.AnimationState;
   premultipliedAlpha: boolean;
+  // 当前“循环”动画使用的重新入队监听器，切换动画时需要先移除
+  repeatListener?: spine.AnimationStateListener;
 }
 interface Position {
   x: number;
@@ -238,6 +245,46 @@ export class Spine {
     return this.skeletons[this.activeSkeleton];
   }
 
+  // 设置当前骨架播放的动画。loop 为 true 时不使用 spine 原生 loop：
+  // 原生 loop 会全程复用同一个 TrackEntry，配合 MixBlend.first 让骨骼旋转
+  // 每圈缠绕 360°，一次性动画（如 Die）会被 IK 约束放大成越来越严重的抽搐。
+  // 这里改为每遍重新入队（每次都是全新 TrackEntry，旋转累加器被重置），
+  // 并对“同名动画”设置小幅 mix 抹平首尾帧的姿态跳变。
+  setAnimation(animationName: string, loop: boolean): void {
+    if (!this.activeSkeleton) return;
+
+    const skeleton = this.skeletons[this.activeSkeleton];
+    if (!skeleton) return;
+
+    const { state } = skeleton;
+    // 切换动画前先拆掉上一个循环监听器，避免它继续把旧动画排进队列
+    if (skeleton.repeatListener) {
+      state.removeListener(skeleton.repeatListener);
+      skeleton.repeatListener = undefined;
+    }
+
+    if (!loop) {
+      state.setAnimation(0, animationName, false);
+      return;
+    }
+
+    state.data.setMix(animationName, animationName, REPEAT_MIX);
+    state.setAnimation(0, animationName, false);
+    const listener: spine.AnimationStateListener = {
+      start: noop,
+      interrupt: noop,
+      end: noop,
+      dispose: noop,
+      // 每播完一遍就再排一遍，delay=0 让交叉淡化叠在上一遍缓慢的尾巴上
+      complete: () => {
+        state.addAnimation(0, animationName, false, 0);
+      },
+      event: noop,
+    };
+    state.addListener(listener);
+    skeleton.repeatListener = listener;
+  }
+
   move(x: number, y: number): void {
     console.log(x, y);
     if (!this.activeSkeleton) return;
@@ -290,7 +337,13 @@ export class Spine {
       chunks.push(e.data);
     };
     let started = false;
-    const state = this.skeletons[this.activeSkeleton].state;
+    const skeleton = this.skeletons[this.activeSkeleton];
+    // 录制单遍动画，先移除循环监听器，避免录制中被重新入队
+    if (skeleton.repeatListener) {
+      skeleton.state.removeListener(skeleton.repeatListener);
+      skeleton.repeatListener = undefined;
+    }
+    const state = skeleton.state;
 
     state.addListener({
       start: (_) => {


### PR DESCRIPTION
claude: 

改好了一版,vue-tsc 类型检查和 eslint 都过了。下面是这次改动的说明。

改了什么
核心思路就是前面验证过的方案:「循环」不再用 spine 原生 loop=true,而是每播完一遍重新入队一遍 + 同名小幅 mix。

[spine.ts](vscode-webview://1u4fq42blfgq13tjo300cnfbps75i8bi40k7k8lmdrtkggpldh09/src/widgets/Spine/spine.ts) — 新增 Spine.setAnimation(animationName, loop):

loop=false:就是普通 setAnimation(0, name, false),播一遍停住。
loop=true:setMix(name, name, 0.2) + setAnimation(0, name, false),然后挂一个 complete 监听器,每遍播完用 addAnimation(0, name, false, 0) 续上下一遍。每遍都是全新 TrackEntry,旋转累加器被重置 → 不再缠绕 → IK 不再被放大抽搐。
切换动画/切开关时会先 removeListener 旧的循环监听器,避免它继续把旧动画排进队列。
record() 里也加了一处:录制前移除循环监听器,防止录制单遍时被重新入队。
[Spine.vue](vscode-webview://1u4fq42blfgq13tjo300cnfbps75i8bi40k7k8lmdrtkggpldh09/src/widgets/Spine/Spine.vue) — 三个入口(初始 load、下拉选动画 onSelectAni、循环开关 onChangeLoop)统一改走 spineRef.spine.setAnimation(...),不再各自直接调 state.setAnimation(0, name, loop)。

我已经验证的部分(用项目自带的 3.8 运行时 + 这个 enemy_1266 素材离线仿真)
同样的 addAnimation 重触发逻辑跑 20 秒:13 个完整循环、0 抖帧、手部单帧最大跳变 -15.2°、arm.rot 封顶 358°(不缠绕)。
对比原生 loop=true:20 秒 203 抖帧、arm.rot 缠到 4491°。
需要你看的
代码层面我没法直接在浏览器里跑这个 widget 看实际渲染(本地没有 npm 启动后的页面操作能力)。麻烦你 pnpm dev(或项目对应命令)起来,选 enemy_1266 → 选 Die → 打开「循环播放」,确认:

重复播放手部不再越转越疯;
每遍接缝处是否平滑(我预期 -15° 以内,基本看不出跳);
顺便看下 Idle/Move 这类正常可循环动画有没有被影响(理论上没有,它们首尾帧一致)。
如果实际效果你不满意(比如接缝还是有点跳、或者你想要更"硬"的瞬切感),告诉我,我再调 REPEAT_MIX 或换策略。要是这套在真机上还是不行,我就按之前说的,直接把 spine-webgl.js 里 RotateTimeline 那段 wrap-累加按 4.x 的 getRelativeValue(不 wrap、alpha=1 时直接 setup+value)逻辑 patch 掉,从运行时根上断掉缠绕。