### PR TITLE
fix(item-list): 添加基础道具分类筛选项

### DIFF
--- a/src/widgets/ItemList/consts.ts
+++ b/src/widgets/ItemList/consts.ts
@@ -9,6 +9,7 @@ export const defaultFilterConfig: FilterConfig = {
     category: {
       title: "分类",
       options: [
+        "基础道具",
         "材料",
         "消耗道具",
         "作战记录",


### PR DESCRIPTION
## 变更内容
- 在道具一览的分类筛选项中添加 `基础道具`。
- 将 `基础道具` 放在分类筛选列表最前面。

## 背景
`道具一览` 中已有一批道具的 Cargo `category1` 调整为 `基础道具`，用于对齐游戏数据字段中 `classifyType=NORMAL` 而非 `CONSUME` 的条目。前端筛选器需要加入该分类，才能在 UI 中筛选这些道具。