### PR TITLE
feat(VoiceTable): 为限时语音标题添加提示

### DIFF
--- a/src/widgets/VoiceTable/VoiceTable.vue
+++ b/src/widgets/VoiceTable/VoiceTable.vue
@@ -6,6 +6,7 @@ import { NConfigProvider, NSelect } from "naive-ui";
 import FormItem from "@/components/FormItem.vue";
 
 import VoicePlayer from "./VoicePlayer.vue";
+import VoiceTitle from "./VoiceTitle.vue";
 import { ILLUST_SHOW_TYPES, SkinVoiceType } from "./consts";
 
 import type { Props } from "./types";
@@ -100,7 +101,7 @@ provide("audioElem", new Audio());
             <div
               class="table-cell truncate border border-divider border-solid p-1 text-center align-middle font-bold !bg-table"
             >
-              {{ ele.title }}
+              <VoiceTitle :title="ele.title" />
             </div>
             <div
               class="w-full table-cell border border-divider rounded border-solid p-2 align-middle"

--- a/src/widgets/VoiceTable/VoiceTableMobile.vue
+++ b/src/widgets/VoiceTable/VoiceTableMobile.vue
@@ -6,6 +6,7 @@ import { NConfigProvider, NSelect } from "naive-ui";
 import FormItem from "@/components/FormItem.vue";
 
 import VoicePlayer from "./VoicePlayer.vue";
+import VoiceTitle from "./VoiceTitle.vue";
 import { ILLUST_SHOW_TYPES, SkinVoiceType } from "./consts";
 
 import type { Props } from "./types";
@@ -103,7 +104,7 @@ provide("audioElem", new Audio());
               <div
                 class="flex-auto self-center justify-self-center text-center"
               >
-                {{ ele.title }}
+                <VoiceTitle :title="ele.title" />
               </div>
               <div>
                 <VoicePlayer

--- a/src/widgets/VoiceTable/VoiceTitle.vue
+++ b/src/widgets/VoiceTable/VoiceTitle.vue
@@ -22,12 +22,11 @@ const tip = computed(() => (props.title ? displayTips[props.title] : ""));
     <NTooltip v-if="tip" trigger="hover">
       <template #trigger>
         <span
-          class="voice-title-tip"
+          class="voice-title-tip mdi mdi-help-circle-outline color-[var(--darkblue)]"
           role="img"
           tabindex="0"
           aria-label="显示时间说明"
-          >?</span
-        >
+        />
       </template>
       {{ tip }}
     </NTooltip>

--- a/src/widgets/VoiceTable/VoiceTitle.vue
+++ b/src/widgets/VoiceTable/VoiceTitle.vue
@@ -36,29 +36,35 @@ const tip = computed(() => (props.title ? displayTips[props.title] : ""));
 
 <style scoped>
 .voice-title {
+  --tip-color: #36c;
+  --tip-size: 0.875rem;
+
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.25em;
-}
+  gap: 0.25rem;
 
-.voice-title-tip {
-  display: inline-flex;
-  width: 1em;
-  height: 1em;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid #36c;
-  border-radius: 50%;
-  color: #36c;
-  cursor: help;
-  font-size: 0.85em;
-  font-weight: 700;
-  line-height: 1;
-}
+  &-tip {
+    display: inline-flex;
+    width: 1rem;
+    height: 1rem;
 
-.voice-title-tip:focus-visible {
-  outline: 2px solid #36c;
-  outline-offset: 2px;
+    align-items: center;
+    justify-content: center;
+
+    border: 1px solid var(--tip-color);
+    border-radius: 50%;
+
+    color: var(--tip-color);
+    cursor: help;
+
+    font-size: var(--tip-size);
+    font-weight: 700;
+    line-height: 1;
+
+    &:focus-visible {
+      outline: 2px solid var(--tip-color);
+      outline-offset: 0.125rem;
+    }
+  }
 }
 </style>

--- a/src/widgets/VoiceTable/VoiceTitle.vue
+++ b/src/widgets/VoiceTable/VoiceTitle.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { NTooltip } from "naive-ui";
+
+const props = defineProps<{
+  title?: string;
+}>();
+
+const displayTips: Record<string, string> = {
+  新年祝福: "游戏内仅在每年1月1日-1月4日显示",
+  生日: "游戏内仅在每年博士生日显示",
+  周年庆典: "游戏内仅在每年5月1日-5月4日显示",
+};
+
+const tip = computed(() => (props.title ? displayTips[props.title] : ""));
+</script>
+
+<template>
+  <span class="voice-title">
+    <span>{{ title }}</span>
+    <NTooltip v-if="tip" trigger="hover">
+      <template #trigger>
+        <span
+          class="voice-title-tip"
+          role="img"
+          tabindex="0"
+          aria-label="显示时间说明"
+          >?</span
+        >
+      </template>
+      {{ tip }}
+    </NTooltip>
+  </span>
+</template>
+
+<style scoped>
+.voice-title {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25em;
+}
+
+.voice-title-tip {
+  display: inline-flex;
+  width: 1em;
+  height: 1em;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid #36c;
+  border-radius: 50%;
+  color: #36c;
+  cursor: help;
+  font-size: 0.85em;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.voice-title-tip:focus-visible {
+  outline: 2px solid #36c;
+  outline-offset: 2px;
+}
+</style>


### PR DESCRIPTION
## 变更内容

为语音记录中的限时显示语音添加说明提示。

## 主要改动

- 在 `新年祝福`、`生日`、`周年庆典` 三个语音标题旁添加蓝色问号提示。
- hover 问号时显示对应游戏内可见时间：
  - `新年祝福`：游戏内仅在每年1月1日-1月4日显示
  - `生日`：游戏内仅在每年博士生日显示
  - `周年庆典`：游戏内仅在每年5月1日-5月4日显示
