### PR TITLE
修复voicetable icon出现重复圆圈问题

### DIFF
--- a/src/widgets/VoiceTable/VoiceTitle.vue
+++ b/src/widgets/VoiceTable/VoiceTitle.vue
@@ -22,11 +22,12 @@ const tip = computed(() => (props.title ? displayTips[props.title] : ""));
     <NTooltip v-if="tip" trigger="hover">
       <template #trigger>
         <span
-          class="voice-title-tip mdi mdi-help-circle-outline color-[var(--darkblue)]"
+          class="voice-title-tip"
           role="img"
           tabindex="0"
           aria-label="显示时间说明"
-        />
+          >?</span
+        >
       </template>
       {{ tip }}
     </NTooltip>
@@ -61,8 +62,8 @@ const tip = computed(() => (props.title ? displayTips[props.title] : ""));
     line-height: 1;
 
     &:focus-visible {
-      outline: 2px solid var(--tip-color);
-      outline-offset: 0.125rem;
+      background: color-mix(in srgb, var(--tip-color) 12%, transparent);
+      outline: 0;
     }
   }
 }


### PR DESCRIPTION
将  mdi-help-circle-outline （带圆圈的问号）换成普通 ？ 字符避免圆圈重复出现