### PR TITLE
feat: 为 ISEvent 增加事件层数筛选

### DIFF
--- a/src/entries/ISEvent.ts
+++ b/src/entries/ISEvent.ts
@@ -18,6 +18,7 @@ const isTheme = eventDataRoot?.dataset?.theme;
 // nav app
 const navArea = document.querySelector("#IS-event-nav");
 const sceneCategoryData: string[][] = [];
+const sceneCategoryFloorData: string[][][] = [];
 const sceneCategoryTabList: string[] = [];
 
 // events app
@@ -30,6 +31,10 @@ for (const eventEle of Array.from(eventEles)) {
         edesc: scene.querySelectorAll(".edesc")[0]?.innerHTML,
         name: data.name,
         ename: data.ename,
+        floors: (data.floor || "")
+          .split(",")
+          .map((floor) => floor.trim())
+          .filter(Boolean),
         nav: data.nav,
         index: data.index,
         image: data.image,
@@ -60,16 +65,21 @@ for (const eventEle of Array.from(eventEles)) {
   if (scenes[0].etype) {
     sceneCategoryTabList.push(scenes[0].etype);
     sceneCategoryData.push([]);
+    sceneCategoryFloorData.push([]);
   }
+  const eventType = sceneCategoryTabList.at(-1) || "";
   sceneCategoryData.at(-1)?.push(scenes[0].ename || scenes[0].name || "？？？");
+  sceneCategoryFloorData.at(-1)?.push(scenes[0].floors);
   // creat event
   createApp(ISEventFramework, {
     sceneData: scenes,
+    eventType,
     isTheme,
   }).mount(eventEle);
 }
 
 createApp(ISEventCategory, {
   eventNameList: sceneCategoryData,
+  eventFloorList: sceneCategoryFloorData,
   tabList: sceneCategoryTabList,
 }).mount(navArea!);

--- a/src/widgets/ISEvents/ISEventCategory.vue
+++ b/src/widgets/ISEvents/ISEventCategory.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, ref, watchEffect } from "vue";
 
 import {
   NButton,
@@ -14,6 +14,8 @@ import {
 } from "naive-ui";
 
 import { useTheme } from "@/utils/theme";
+
+import { activeFloor, visibleEventTypes } from "./floorFilter";
 
 const props = defineProps<{
   tabList: string[];
@@ -37,7 +39,6 @@ const { theme, themeOverrides, isDark } = useTheme({
 });
 
 const showFullCate = ref(false);
-const activeFloor = ref("");
 const romanFloorLabels = ["", "I", "II", "III", "IV", "V", "VI", "VII"];
 const eventFloorListDepth = 2;
 const hasFloorData = computed(() =>
@@ -67,6 +68,16 @@ const visibleEventNameList = computed(() => {
     ),
   );
 });
+const visibleEventTypeSet = computed(() => {
+  if (!activeFloor.value) return new Set(props.tabList);
+  return new Set(
+    props.tabList.filter((_tabName, groupIndex) =>
+      props.eventFloorList[groupIndex]?.some((floors) =>
+        floors.includes(activeFloor.value),
+      ),
+    ),
+  );
+});
 
 const tabChangeAndColseFullCate = () => {
   showFullCate.value = false;
@@ -81,59 +92,9 @@ const changeFloor = (floor: string) => {
   activeFloor.value = floor;
 };
 
-function applyFloorFilter() {
-  const floor = activeFloor.value;
-  const allEventTitles = new Set(props.eventNameList.flat());
-  const allEventTypes = new Set(props.tabList);
-  const visibleTitles = new Set<string>();
-  const visibleTypes = new Set<string>();
-
-  for (const frame of Array.from(
-    document.querySelectorAll<HTMLElement>(".ISEventFrame"),
-  )) {
-    const floors = (frame.dataset.floors || "").split("|").filter(Boolean);
-    const visible = !floor || floors.includes(floor);
-    frame.style.display = visible ? "" : "none";
-    if (visible) {
-      if (frame.dataset.eventTitle) visibleTitles.add(frame.dataset.eventTitle);
-      if (frame.dataset.eventType) visibleTypes.add(frame.dataset.eventType);
-    }
-  }
-
-  for (const description of Array.from(
-    document.querySelectorAll<HTMLElement>(".ISEventDescription"),
-  )) {
-    const floors = (description.dataset.floors || "")
-      .split("|")
-      .filter(Boolean);
-    description.style.display = !floor || floors.includes(floor) ? "" : "none";
-  }
-
-  for (const heading of Array.from(
-    document.querySelectorAll<HTMLElement>(
-      ".mw-parser-output h2, .mw-parser-output h3",
-    ),
-  )) {
-    const title = (heading.textContent || "").trim();
-    if (title === "事件导航" || title === "层数筛选") {
-      heading.style.display = "";
-    } else if (allEventTitles.has(title)) {
-      heading.style.display = !floor || visibleTitles.has(title) ? "" : "none";
-    } else if (allEventTypes.has(title)) {
-      heading.style.display = !floor || visibleTypes.has(title) ? "" : "none";
-    }
-  }
-}
-
-watch(
-  activeFloor,
-  () => {
-    nextTick(() => {
-      window.requestAnimationFrame(applyFloorFilter);
-    });
-  },
-  { immediate: true },
-);
+watchEffect(() => {
+  visibleEventTypes.value = visibleEventTypeSet.value;
+});
 </script>
 
 <template>

--- a/src/widgets/ISEvents/ISEventCategory.vue
+++ b/src/widgets/ISEvents/ISEventCategory.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 
 import {
   NButton,
@@ -18,6 +18,7 @@ import { useTheme } from "@/utils/theme";
 const props = defineProps<{
   tabList: string[];
   eventNameList: string[][];
+  eventFloorList: string[][][];
 }>();
 const curTab = ref(props.tabList[0]);
 const { theme, themeOverrides, isDark } = useTheme({
@@ -36,6 +37,36 @@ const { theme, themeOverrides, isDark } = useTheme({
 });
 
 const showFullCate = ref(false);
+const activeFloor = ref("");
+const romanFloorLabels = ["", "I", "II", "III", "IV", "V", "VI", "VII"];
+const eventFloorListDepth = 2;
+const hasFloorData = computed(() =>
+  props.eventFloorList.some((group) =>
+    group.some((floors) => floors.length > 0),
+  ),
+);
+const floorButtons = computed(() => {
+  const floorValues = Array.from(
+    new Set(props.eventFloorList.flat(eventFloorListDepth).filter(Boolean)),
+  ).sort((a, b) => Number(a) - Number(b));
+  return [
+    { label: "全部", value: "" },
+    ...floorValues.map((floor) => ({
+      label: romanFloorLabels[Number(floor)] || floor,
+      value: floor,
+    })),
+  ];
+});
+const visibleEventNameList = computed(() => {
+  if (!activeFloor.value) return props.eventNameList;
+  return props.eventNameList.map((group, groupIndex) =>
+    group.filter((_eventName, eventIndex) =>
+      props.eventFloorList[groupIndex]?.[eventIndex]?.includes(
+        activeFloor.value,
+      ),
+    ),
+  );
+});
 
 const tabChangeAndColseFullCate = () => {
   showFullCate.value = false;
@@ -45,6 +76,55 @@ const changeTab = (name: string) => {
   curTab.value = name;
   showFullCate.value = false;
 };
+
+const changeFloor = (floor: string) => {
+  activeFloor.value = floor;
+};
+
+function applyFloorFilter() {
+  const floor = activeFloor.value;
+  const allEventTitles = new Set(props.eventNameList.flat());
+  const allEventTypes = new Set(props.tabList);
+  const visibleTitles = new Set<string>();
+  const visibleTypes = new Set<string>();
+
+  for (const frame of Array.from(
+    document.querySelectorAll<HTMLElement>(".ISEventFrame"),
+  )) {
+    const floors = (frame.dataset.floors || "").split("|").filter(Boolean);
+    const visible = !floor || floors.includes(floor);
+    frame.style.display = visible ? "" : "none";
+    if (visible) {
+      if (frame.dataset.eventTitle) visibleTitles.add(frame.dataset.eventTitle);
+      if (frame.dataset.eventType) visibleTypes.add(frame.dataset.eventType);
+    }
+  }
+
+  for (const heading of Array.from(
+    document.querySelectorAll<HTMLElement>(
+      ".mw-parser-output h2, .mw-parser-output h3",
+    ),
+  )) {
+    const title = (heading.textContent || "").trim();
+    if (title === "事件导航" || title === "层数筛选") {
+      heading.style.display = "";
+    } else if (allEventTitles.has(title)) {
+      heading.style.display = !floor || visibleTitles.has(title) ? "" : "none";
+    } else if (allEventTypes.has(title)) {
+      heading.style.display = !floor || visibleTypes.has(title) ? "" : "none";
+    }
+  }
+}
+
+watch(
+  activeFloor,
+  () => {
+    nextTick(() => {
+      window.requestAnimationFrame(applyFloorFilter);
+    });
+  },
+  { immediate: true },
+);
 </script>
 
 <template>
@@ -129,7 +209,7 @@ const changeTab = (name: string) => {
                 >
                   <NSpace class="max-w-full w-140">
                     <NButton
-                      v-for="eventName in eventNameList![index]"
+                      v-for="eventName in visibleEventNameList[index]"
                       :key="eventName"
                       size="small"
                       quaternary
@@ -145,6 +225,27 @@ const changeTab = (name: string) => {
           </NCard>
         </NLayoutContent>
       </NLayout>
+    </NSpace>
+  </NConfigProvider>
+  <h2 v-if="hasFloorData">层数筛选</h2>
+  <NConfigProvider
+    v-if="hasFloorData"
+    preflight-style-disabled
+    :theme="theme"
+    :theme-overrides="themeOverrides"
+    :class="['ISEventCategory', isDark && 'prts-widget-dark']"
+  >
+    <NSpace class="max-w-full w-140">
+      <NButton
+        v-for="button in floorButtons"
+        :key="button.value || 'all'"
+        size="small"
+        :quaternary="button.value !== activeFloor"
+        :type="button.value === activeFloor ? 'info' : 'default'"
+        @click="changeFloor(button.value)"
+      >
+        {{ button.label }}
+      </NButton>
     </NSpace>
   </NConfigProvider>
 </template>

--- a/src/widgets/ISEvents/ISEventCategory.vue
+++ b/src/widgets/ISEvents/ISEventCategory.vue
@@ -100,6 +100,15 @@ function applyFloorFilter() {
     }
   }
 
+  for (const description of Array.from(
+    document.querySelectorAll<HTMLElement>(".ISEventDescription"),
+  )) {
+    const floors = (description.dataset.floors || "")
+      .split("|")
+      .filter(Boolean);
+    description.style.display = !floor || floors.includes(floor) ? "" : "none";
+  }
+
   for (const heading of Array.from(
     document.querySelectorAll<HTMLElement>(
       ".mw-parser-output h2, .mw-parser-output h3",

--- a/src/widgets/ISEvents/ISEventFramework.vue
+++ b/src/widgets/ISEvents/ISEventFramework.vue
@@ -192,7 +192,14 @@ function getSubChooseData(scStr: string) {
       {{ sceneData[0].ename || sceneData[0].name }}
     </span>
   </h3>
-  <div v-if="sceneData[0].edesc" v-html="sceneData[0].edesc"></div>
+  <div
+    v-if="sceneData[0].edesc"
+    class="ISEventDescription"
+    :data-event-title="sceneData[0].ename || sceneData[0].name"
+    :data-event-type="eventType"
+    :data-floors="sceneData[0].floors?.join('|')"
+    v-html="sceneData[0].edesc"
+  ></div>
   <NConfigProvider
     preflight-style-disabled
     :theme="theme"

--- a/src/widgets/ISEvents/ISEventFramework.vue
+++ b/src/widgets/ISEvents/ISEventFramework.vue
@@ -19,6 +19,7 @@ import { useTheme } from "@/utils/theme";
 import { getImagePath } from "@/utils/utils";
 
 import ISEventOption from "./ISEventOption.vue";
+import { activeFloor, visibleEventTypes } from "./floorFilter";
 
 interface Option {
   title: string;
@@ -77,6 +78,17 @@ function isPrtsInfo(sceneId: number) {
 const isCurScenePrtsInfo = computed(() => {
   return isPrtsInfo(currentSceneId.value);
 });
+const eventTitle = computed(
+  () => props.sceneData[0].ename || props.sceneData[0].name || "",
+);
+const eventFloors = computed(() => props.sceneData[0].floors || []);
+const isEventVisible = computed(
+  () => !activeFloor.value || eventFloors.value.includes(activeFloor.value),
+);
+const isEventTypeVisible = computed(
+  () =>
+    !activeFloor.value || visibleEventTypes.value.has(props.eventType || ""),
+);
 function jump(id: number) {
   if (id) {
     const index = sceneNav.value.indexOf(id);
@@ -86,8 +98,7 @@ function jump(id: number) {
 
     currentSceneId.value = id;
 
-    const name = props.sceneData[0].ename || props.sceneData[0].name || "";
-    const element = document.querySelector(`#${name}`);
+    const element = document.querySelector(`#${eventTitle.value}`);
     if (element) {
       element.scrollIntoView({ behavior: "smooth" });
     }
@@ -172,7 +183,7 @@ function getSubChooseData(scStr: string) {
 </script>
 
 <template>
-  <h2 v-if="sceneData[0].etype">
+  <h2 v-if="sceneData[0].etype" v-show="isEventTypeVisible">
     <span :id="sceneData[0].etype" />
     <span
       :id="encodeURI(sceneData[0].etype).replace(/%/g, '.')"
@@ -181,33 +192,24 @@ function getSubChooseData(scStr: string) {
       {{ sceneData[0].etype }}
     </span>
   </h2>
-  <h3>
-    <span :id="sceneData[0].ename || sceneData[0].name" />
-    <span
-      :id="
-        encodeURI((sceneData[0].ename || sceneData[0].name)!).replace(/%/g, '.')
-      "
-      class="mw-headline"
-    >
-      {{ sceneData[0].ename || sceneData[0].name }}
+  <h3 v-show="isEventVisible">
+    <span :id="eventTitle" />
+    <span :id="encodeURI(eventTitle).replace(/%/g, '.')" class="mw-headline">
+      {{ eventTitle }}
     </span>
   </h3>
   <div
     v-if="sceneData[0].edesc"
+    v-show="isEventVisible"
     class="ISEventDescription"
-    :data-event-title="sceneData[0].ename || sceneData[0].name"
-    :data-event-type="eventType"
-    :data-floors="sceneData[0].floors?.join('|')"
     v-html="sceneData[0].edesc"
   ></div>
   <NConfigProvider
+    v-show="isEventVisible"
     preflight-style-disabled
     :theme="theme"
     :theme-overrides="themeOverrides"
     :class="['ISEventFrame', isDark && 'prts-widget-dark']"
-    :data-event-title="sceneData[0].ename || sceneData[0].name"
-    :data-event-type="eventType"
-    :data-floors="sceneData[0].floors?.join('|')"
   >
     <NSpace class="max-w-full w-140">
       <NLayout>

--- a/src/widgets/ISEvents/ISEventFramework.vue
+++ b/src/widgets/ISEvents/ISEventFramework.vue
@@ -40,6 +40,7 @@ const props = withDefaults(
       edesc?: string;
       name?: string;
       ename?: string;
+      floors?: string[];
       nav?: string;
       index?: number;
       image?: string;
@@ -47,6 +48,7 @@ const props = withDefaults(
       options: Array<Option>;
       prtsinfo?: string;
     }[];
+    eventType?: string;
     isTheme: string;
   }>(),
   {
@@ -196,6 +198,9 @@ function getSubChooseData(scStr: string) {
     :theme="theme"
     :theme-overrides="themeOverrides"
     :class="['ISEventFrame', isDark && 'prts-widget-dark']"
+    :data-event-title="sceneData[0].ename || sceneData[0].name"
+    :data-event-type="eventType"
+    :data-floors="sceneData[0].floors?.join('|')"
   >
     <NSpace class="max-w-full w-140">
       <NLayout>

--- a/src/widgets/ISEvents/floorFilter.ts
+++ b/src/widgets/ISEvents/floorFilter.ts
@@ -1,0 +1,4 @@
+import { ref } from "vue";
+
+export const activeFloor = ref("");
+export const visibleEventTypes = ref<Set<string>>(new Set());


### PR DESCRIPTION
为 `ISEvent` 增加“层数筛选”功能，用于按事件出现层数筛选事件

具体改动：

- 从 `ISEvent/scene` 输出的 `data-floor` 读取事件层数字段
- 在 `事件导航` 后新增同级标题 `层数筛选`
- 筛选时同步隐藏不属于当前层数的事件按钮、事件标题和事件内容框
