### PR TITLE
fix(story-player): 移除旧版播放器的全局初始化调用

### DIFF
--- a/src/mw.d.ts
+++ b/src/mw.d.ts
@@ -7,8 +7,5 @@ declare interface Window {
     ) => Promise<void>;
     showReportDialog?: (...args: any[]) => void;
   };
-  // 旧版剧情播放器 gadget（#sys_fullscreen）暴露的全局对象
-  data?: { init?: () => void };
-  system?: { disabled?: { init?: () => void } };
   mw: any;
 }

--- a/src/widgets/StoryPlayer/index.vue
+++ b/src/widgets/StoryPlayer/index.vue
@@ -419,8 +419,6 @@ function onLoadLegacyPlayer(): void {
 
   legacyPlayerActive.value = true;
   legacyRoot.style.removeProperty("display");
-  window.data.init();
-  window.system.disabled.init();
 }
 
 async function onStartPlay(): Promise<void> {


### PR DESCRIPTION
翻了一下发现这个 window.data.init() 和window.system.disabled.init()一上来直接调用也不会有问题。widget:ScenarioSimulator里之前注释了这两行 现在去掉了。
不再在显示旧版播放器后调用 window.data.init() 和window.system.disabled.init()，并同步删除 mw.d.ts 中对应的旧版 gadget 全局对象类型声明。