### PR TITLE
fix(story-player): 角色立绘 key 后缀容忍空白，对齐原生解析

### DIFF
--- a/src/widgets/StoryPlayer/engine/preload.ts
+++ b/src/widgets/StoryPlayer/engine/preload.ts
@@ -211,7 +211,7 @@ function resolveCharacterSelection(
   }
 
   const match = normalized.match(
-    /^([^@#$]+)(?:#(\d+)(?:\$(\d+))?|@([\w-]+)|\$(\d+))?$/,
+    /^([^@#$]+)(?:#\s*(\d+)\s*(?:\$\s*(\d+)\s*)?|@([\w-]+)|\$\s*(\d+)\s*)?$/,
   );
   if (!match) return null;
 

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -807,7 +807,9 @@ export class StoryRuntime {
       const expression = normalized.slice(prefix.length);
       if (!expression) continue;
 
-      const found = link.array.find((item) => item.name === expression);
+      const found = link.array.find(
+        (item) => item.name.toLowerCase() === expression,
+      );
       if (!found) continue;
 
       return { base, expression: found.name };

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -814,7 +814,7 @@ export class StoryRuntime {
     }
 
     const match = normalized.match(
-      /^([^@#$]+)(?:#(\d+)(?:\$(\d+))?|@([\w-]+)|\$(\d+))?$/,
+      /^([^@#$]+)(?:#\s*(\d+)\s*(?:\$\s*(\d+)\s*)?|@([\w-]+)|\$\s*(\d+)\s*)?$/,
     );
     if (!match) return null;
 

--- a/tests/preload.spec.ts
+++ b/tests/preload.spec.ts
@@ -198,6 +198,41 @@ describe("preloadContextAssets", () => {
     expect(loadMock).not.toHaveBeenCalled();
   });
 
+  it("resolves character refs with whitespace inside the suffix like native", () => {
+    const context = createContext([
+      '[charslot(slot="m",name="avg_4236_tmslot_1#3 $1")]',
+    ]);
+    context.linkMap.avg_4236_tmslot_1 = {
+      array: [
+        { alias: "", face: "tmslot/1", group: 0, name: "1$1" },
+        { alias: "", face: "tmslot/2", group: 0, name: "2$1" },
+        { alias: "", face: "tmslot/3", group: 0, name: "3$1" },
+      ],
+      groups: [
+        {
+          base: "tmslot/base",
+          faceRect: { h: 80, w: 100, x: 120, y: 40 },
+          mode: "face_overlay",
+        },
+      ],
+      pos: { x: 0, y: 0 },
+      size: { x: 0, y: 0 },
+    };
+
+    const manifest = collectContextAssetManifest(context);
+
+    expect(
+      manifest.faceAssets.map((asset) => ({
+        expression: asset.expression,
+        used: asset.used,
+      })),
+    ).toEqual([
+      { expression: "1$1", used: false },
+      { expression: "2$1", used: false },
+      { expression: "3$1", used: true },
+    ]);
+  });
+
   it("preloads character command portraits using case-insensitive refs", async () => {
     const progress = vi.fn();
     const context = createContext([

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1334,8 +1334,11 @@ describe("StoryRuntime", () => {
   it("resolves character refs with whitespace inside the suffix like native", async () => {
     const renderer = new FakeRenderer();
     const context = createContext([
+      // One case per whitespace position the native Int32.TryParse tolerates:
+      // between the index digits and `$`, after `#`, and after `$`.
       '[charslot(slot="m",name="avg_4236_tmslot_1#3 $1")]',
-      '[charslot(slot="l",name="avg_npc_1#1 ")]',
+      '[charslot(slot="l",name="avg_npc_1# 1")]',
+      '[charslot(slot="r",name="avg_4236_tmslot_1$ 1")]',
       '[name="A"]ok',
     ]);
     context.linkMap.avg_4236_tmslot_1 = {
@@ -1361,6 +1364,11 @@ describe("StoryRuntime", () => {
       characterKey: "avg_npc_1",
       expression: "1$1",
       slot: "l",
+    });
+    expect(renderer.characterCalls[2]).toMatchObject({
+      characterKey: "avg_4236_tmslot_1",
+      expression: "1$1",
+      slot: "r",
     });
     expect(runtime.getState()).toBe("waiting_input");
   });

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1331,6 +1331,40 @@ describe("StoryRuntime", () => {
     expect(runtime.getState()).toBe("waiting_input");
   });
 
+  it("resolves character refs with whitespace inside the suffix like native", async () => {
+    const renderer = new FakeRenderer();
+    const context = createContext([
+      '[charslot(slot="m",name="avg_4236_tmslot_1#3 $1")]',
+      '[charslot(slot="l",name="avg_npc_1#1 ")]',
+      '[name="A"]ok',
+    ]);
+    context.linkMap.avg_4236_tmslot_1 = {
+      array: [
+        { alias: "", group: 0, name: "1$1" },
+        { alias: "", group: 0, name: "2$1" },
+        { alias: "", group: 0, name: "3$1" },
+      ],
+      groups: [],
+      pos: { x: 0, y: 0 },
+      size: { x: 0, y: 0 },
+    };
+    const runtime = new StoryRuntime(context, renderer, new FakeAudio());
+
+    await runtime.start();
+
+    expect(renderer.characterCalls[0]).toMatchObject({
+      characterKey: "avg_4236_tmslot_1",
+      expression: "3$1",
+      slot: "m",
+    });
+    expect(renderer.characterCalls[1]).toMatchObject({
+      characterKey: "avg_npc_1",
+      expression: "1$1",
+      slot: "l",
+    });
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
   it("maps charslot slot aliases and duration blocking like legacy runtime", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(


### PR DESCRIPTION
原生 AVGCharacterSlot._LoadImage 逐段 LastIndexOf($/@/#) 剥后缀， Int32.TryParse 容忍首尾空白，故 name="avg_4236_tmslot_1#3 $1" 这类 后缀区带空格的笔误会被无害吸收；Web 端单条正则要求 $ 紧跟数字，
导致整体失配 → 角色不显示且资源不预载。

后缀区(#/$ 与数字之间)加入 \s* 容忍，base 段保持严格(与原生
"base 带空格即加载失败"一致)；runtime 与 preload 两处同步修改，
并补回归测试。