### PR TITLE
fix(ArkSign): 修复半身像路径大小写问题，获取cookie指令去掉多余空格

### DIFF
--- a/src/widgets/ArkSign/Skland.vue
+++ b/src/widgets/ArkSign/Skland.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { NInput, NButton, useMessage } from "naive-ui";
+import { NButton, NInput, useMessage } from "naive-ui";
 const message = useMessage();
 const commandValue =
-  "localStorage.getItem('SK_OAUTH_CRED_KEY')+','+localStorage .getItem('SK_TOKEN_CACHE_KEY')";
+  "localStorage.getItem('SK_OAUTH_CRED_KEY')+','+localStorage.getItem('SK_TOKEN_CACHE_KEY')";
 
 async function textCopy() {
   // 如果当前浏览器版本不兼容navigator.clipboard

--- a/src/widgets/ArkSign/getUrl.ts
+++ b/src/widgets/ArkSign/getUrl.ts
@@ -17,7 +17,7 @@ export function docAvatar(id: string) {
 }
 
 export function portrait(skinId: string) {
-  skinId = skinId.toLowerCase();
+  // skinId = skinId.toLowerCase();
   if (skinId.includes("@")) {
     skinId = skinId.replaceAll("@", "_");
     skinId = encodeURIComponent(skinId);


### PR DESCRIPTION
1.原来需要对带@符号的skinId做LowerCase，现在似乎不需要了
2.获取cookie的指令莫名多了个空格（虽然也能用但还是修了