### PR TITLE
fix(story-player): linkMap 按小写 key 存放，修复带大写角色不显示

### DIFF
--- a/src/widgets/StoryPlayer/context.ts
+++ b/src/widgets/StoryPlayer/context.ts
@@ -37,7 +37,9 @@ function asObject(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
-function normalizeCharacterMap(raw: unknown): Record<string, StoryLinkNode> {
+export function normalizeCharacterMap(
+  raw: unknown,
+): Record<string, StoryLinkNode> {
   const root = asObject(raw);
   if (!root) return {};
 
@@ -113,7 +115,19 @@ function normalizeCharacterMap(raw: unknown): Record<string, StoryLinkNode> {
       }
     }
 
-    output[base] = {
+    // Story refs are matched case-insensitively (both resolveCharacterName and
+    // resolveCharacterSelection lowercase the ref before looking it up), but
+    // character.json keeps each key's original casing and 27 of them carry
+    // uppercase -- char_259_Jessica_1, avg_1029_Yato2_1, npc_2004_Alty,
+    // avg_6D5_1, char_362_Saga and friends. Without folding the key those
+    // characters never resolve: the portrait stays hidden and the asset is
+    // never preloaded. Native sidesteps this by not lowercasing at all
+    // (AVGCharacterSlot._LoadImage passes the ref straight to GetCharacterPath).
+    //
+    // Only the map key is folded. `name`, `image` and `face` stay verbatim --
+    // they are real asset paths and the renderer matches `entry.name` against
+    // the original-cased expression.
+    output[base.toLowerCase()] = {
       array,
       groups,
       pos: {

--- a/src/widgets/StoryPlayer/context.ts
+++ b/src/widgets/StoryPlayer/context.ts
@@ -121,8 +121,13 @@ export function normalizeCharacterMap(
     // uppercase -- char_259_Jessica_1, avg_1029_Yato2_1, npc_2004_Alty,
     // avg_6D5_1, char_362_Saga and friends. Without folding the key those
     // characters never resolve: the portrait stays hidden and the asset is
-    // never preloaded. Native sidesteps this by not lowercasing at all
-    // (AVGCharacterSlot._LoadImage passes the ref straight to GetCharacterPath).
+    // never preloaded.
+    //
+    // Native is case-insensitive here, so folding the key is what actually
+    // matches it. _LoadImage and ResourceRouter.GetCharacterPath do preserve
+    // case, but Torappu.Resource.AB.ABResourceManager._PreprocessAssetPath
+    // lowercases the whole path before hitting m_assetNameToBundleInfoMap,
+    // and all 1779 avg/characters/*.ab entries are already lowercase.
     //
     // Only the map key is folded. `name`, `image` and `face` stay verbatim --
     // they are real asset paths and the renderer matches `entry.name` against

--- a/tests/context.spec.ts
+++ b/tests/context.spec.ts
@@ -1,0 +1,78 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import { normalizeCharacterMap } from "../src/widgets/StoryPlayer/context";
+
+describe("normalizeCharacterMap", () => {
+  it("keys the link map by the lowercased base so mixed-case entries resolve", () => {
+    const linkMap = normalizeCharacterMap({
+      char_259_Jessica_1: {
+        array: [
+          {
+            alias: "",
+            group: -1,
+            image: "char_259_Jessica_1/1$1",
+            name: "1$1",
+          },
+        ],
+        groups: [],
+        pos: { x: 0, y: 0 },
+        size: { x: 0, y: 0 },
+      },
+    });
+
+    // resolveCharacterName / resolveCharacterSelection lowercase the story ref
+    // before the lookup, so the original-cased key was unreachable.
+    expect(Object.keys(linkMap)).toEqual(["char_259_jessica_1"]);
+  });
+
+  it("keeps name and image verbatim because they are asset paths", () => {
+    const linkMap = normalizeCharacterMap({
+      AVG_char_501_Durin_1: {
+        array: [
+          {
+            alias: "",
+            group: -1,
+            image: "AVG_char_501_Durin_1/AVG_char_501_Durin_1",
+            name: "AVG_char_501_Durin_1",
+          },
+        ],
+        groups: [],
+        pos: { x: 0, y: 0 },
+        size: { x: 0, y: 0 },
+      },
+    });
+
+    expect(linkMap.avg_char_501_durin_1?.array[0]).toMatchObject({
+      image: "AVG_char_501_Durin_1/AVG_char_501_Durin_1",
+      name: "AVG_char_501_Durin_1",
+    });
+  });
+
+  it("preserves face-overlay groups when folding the key", () => {
+    const linkMap = normalizeCharacterMap({
+      npc_2004_Alty: {
+        array: [{ alias: "", face: "npc_2004_Alty/1", group: 0, name: "1$1" }],
+        groups: [
+          {
+            base: "npc_2004_Alty/base",
+            faceRect: { h: 80, w: 100, x: 120, y: 40 },
+            mode: "face_overlay",
+          },
+        ],
+        pos: { x: 0, y: 0 },
+        size: { x: 0, y: 0 },
+      },
+    });
+
+    expect(linkMap.npc_2004_alty?.groups[0]).toMatchObject({
+      base: "npc_2004_Alty/base",
+      mode: "face_overlay",
+    });
+    expect(linkMap.npc_2004_alty?.array[0]).toMatchObject({
+      face: "npc_2004_Alty/1",
+      name: "1$1",
+    });
+  });
+});


### PR DESCRIPTION
`resolveCharacterName` / `resolveCharacterSelection` 都先把 story ref 转小写再查 `linkMap`,但 `normalizeCharacterMap` 是按 `character.json` 的原始 key 存的。线上 1792 个 key 里有 27 个带大写:

```
AVG_char_501_Durin_1  avg_1029_Yato2_1   avg_274_Astesia_1   avg_4145_Ulpia_1
avg_4215_buddyC_1     avg_4215_buddyD_1  avg_502_Yato_1      avg_6D5_1
char_1507_Mephisto_1  char_1508_Faust_1  char_214_Kafka_1    char_240_Vanilla_1
char_254_Shamare_1    char_259_Jessica_1 char_264_Mountain_1 char_336_Scene_1
char_362_Saga         char_373_Leonhardt_1  char_440_Pinecone
npc_2001_Aya_1        npc_2001_Aya_rock  npc_2002_Dan_1      npc_2002_Dan_rock
npc_2003_Frost_1      npc_2003_Frost_rock  npc_2004_Alty     npc_2004_Alty_rock
```

这些角色永远查不到 → **立绘不显示,且资源不预载**,与 #327 是同一个症状。

### 原生为什么没这个问题:资源层大小写不敏感

`AVGCharacterSlot._LoadImage` 和 `ResourceRouter.GetCharacterPath` 确实保留大小写,但那不是它能工作的原因。真正的原因在资源层——`Torappu.Resource.AB.ABResourceManager._PreprocessAssetPath`:

```c
v10 = System::String::ToLower(path, nullptr);   // 整条路径先转小写
...                                             // 再查 m_assetNameToBundleInfoMap
```

配合 hot_update_list 实测:`avg/characters/` 下 **1779 个 .ab 全部是小写命名,0 个带大写**;27 个带大写的 `character.json` key 里,**26 个**在小写路径下有对应 bundle(`char_259_Jessica_1` → `avg/characters/char_259_jessica_1.ab`),**0 个**在原大小写路径下有(剩下 1 个 `avg_1029_Yato2_1` 在该版本 bundle 集里整个不存在,与大小写无关)。

所以原生的语义就是**大小写不敏感**,折叠 key 正是与原生对齐的做法,而不是绕过它。

### 实测影响面

拿 5 个 gamedata 快照共 5525 个 story txt、10329 条去重 character ref,对线上 `avg/character.json` 跑解析:

| 策略 | 解析失败数 |
| --- | --- |
| 现状(ref 小写 / key 原样) | 108 |
| 两边都不转小写 | 34 |
| **key 也一并转小写(本 PR,与原生语义一致)** | **2** |

本 PR 覆盖其中 106 条。中间那行说明了为什么"原样传递"不是答案:真实脚本里就有 34 条 ref 的大小写跟 asset key 对不上(`avg_NPC_017_3`、`avg_1012_skadiSP_1` 等),它们在游戏里能显示,靠的正是资源层的 `ToLower`。

剩余 2 条与本改动无关:`left` 是我提取脚本的噪声,`$ill_amiya_normal` 在 `character.json` 里压根不存在。

### 改动范围

只折叠顶层 map key。`name` / `image` / `face` **保持原样**——它们是真实资源路径,而且渲染侧是拿 `entry.name` 跟原始大小写的 `expression` 比较的,折叠了会同时打断 URL 拼接和表情匹配。

已核对:1792 个 key 小写化后**无冲突**。

顺带把 `normalizeCharacterMap` 导出以便单测,新增 `tests/context.spec.ts` 三条用例(key 折叠、资源路径原样保留、face_overlay group 不受影响)。

---

背景见 #327 的 review comment。
