### PR TITLE
refactor(story-player): 角色 ref 解析改为直接移植原生算法

### DIFF
--- a/src/widgets/StoryPlayer/engine/characterRef.ts
+++ b/src/widgets/StoryPlayer/engine/characterRef.ts
@@ -1,0 +1,185 @@
+import type { StoryLinkNode } from "./types";
+
+/**
+ * Native provenance: `Torappu.AVG.AVGCharacterSlot._LoadImage` and the three
+ * private helpers it inlines -- `_TryParseBody` (`$`), `_TryParseAlias` (`@`)
+ * and `_TryParseIndex` (`#`).
+ *
+ * The native parse is three independent right-to-left strips, each a
+ * `LastIndexOf` + `Substring` + `Int32.TryParse`. That shape is not expressible
+ * as one anchored regex: a regex alternation can only carry a single suffix in
+ * a fixed order, so forms like `name@alias$1` (both suffixes) or an index that
+ * overflows Int32 silently fall out of it. Porting the loop directly removes
+ * that whole class of divergence.
+ *
+ * Mapping the parsed (group, index) pair onto `character.json` entries is a web
+ * asset-pipeline adaptation -- native indexes into the AB's sprite arrays.
+ */
+export interface NativeCharacterRef {
+  /** Native keeps the leading `@`; `_TryParseAlias` uses `Substring(idx)`. */
+  alias: string | null;
+  base: string;
+  /** 0-based, `null` when no `$N` suffix parsed. */
+  group: number | null;
+  /** 0-based, defaults to 0. */
+  index: number;
+}
+
+export interface CharacterRefSelection {
+  base: string;
+  expression: string;
+}
+
+/** `System.Number.IsWhite`: 0x20 and 0x09..0x0D only -- no NBSP, no U+3000. */
+function isDotNetWhite(text: string, at: number): boolean {
+  const code = text.codePointAt(at) ?? -1;
+  return code === 0x20 || (code >= 0x09 && code <= 0x0d);
+}
+
+/**
+ * `System.Int32.TryParse(String, out Int32)`, i.e. `NumberStyles.Integer` =
+ * `AllowLeadingWhite | AllowTrailingWhite | AllowLeadingSign`. Returns `null`
+ * where the BCL returns false, which includes Int32 overflow.
+ *
+ * The whitespace tolerance is not incidental: it is what absorbs authoring
+ * typos like `avg_4236_tmslot_1#3 $1` in native, so the port has to keep it.
+ */
+export function tryParseInt32(text: string): number | null {
+  let i = 0;
+  while (i < text.length && isDotNetWhite(text, i)) i++;
+
+  let negative = false;
+  if (text[i] === "+" || text[i] === "-") {
+    negative = text[i] === "-";
+    i++;
+  }
+
+  const digitsStart = i;
+  while (i < text.length && text[i]! >= "0" && text[i]! <= "9") i++;
+  if (i === digitsStart) return null;
+
+  const magnitude = Number(text.slice(digitsStart, i));
+
+  while (i < text.length && isDotNetWhite(text, i)) i++;
+  if (i !== text.length) return null;
+
+  const value = negative ? -magnitude : magnitude;
+  if (value < -2147483648 || value > 2147483647) return null;
+  return value;
+}
+
+/**
+ * Port of the `_LoadImage` suffix parse. Deliberately does not trim: native
+ * does not either, and every trailing space observed in the story corpus sits
+ * inside a numeric suffix where `Int32.TryParse` already absorbs it.
+ */
+export function parseNativeCharacterRef(
+  ref: string,
+): NativeCharacterRef | null {
+  if (!ref) return null;
+
+  let value = ref;
+
+  // _TryParseBody -- `$N` carries the group and is stripped first.
+  let group: number | null = null;
+  const dollar = value.lastIndexOf("$");
+  if (dollar !== -1) {
+    const parsed = tryParseInt32(value.slice(dollar + 1));
+    if (parsed !== null) {
+      group = parsed - 1;
+      value = value.slice(0, dollar);
+    }
+  }
+
+  // _TryParseAlias -- an alias short-circuits the index parse entirely.
+  const at = value.lastIndexOf("@");
+  if (at !== -1) {
+    return {
+      alias: value.slice(at),
+      base: value.slice(0, at),
+      group,
+      index: 0,
+    };
+  }
+
+  // _TryParseIndex -- a `#N` that fails to parse is left on the base.
+  let index = 0;
+  const hash = value.lastIndexOf("#");
+  if (hash !== -1) {
+    const parsed = tryParseInt32(value.slice(hash + 1));
+    if (parsed !== null) {
+      index = parsed - 1;
+      value = value.slice(0, hash);
+    }
+  }
+
+  return { alias: null, base: value, group, index };
+}
+
+/**
+ * Resolves a story character reference against the `character.json` link map.
+ *
+ * Case folding stands in for native's resource layer: `_LoadImage` preserves
+ * case, but `ABResourceManager._PreprocessAssetPath` lowercases the whole path
+ * before the bundle lookup and every `avg/characters/*.ab` entry is lowercase,
+ * so the effective native semantics are case-insensitive.
+ */
+export function resolveCharacterSelection(
+  linkMap: Record<string, StoryLinkNode>,
+  rawRef: string,
+): CharacterRefSelection | null {
+  if (!rawRef) return null;
+  const normalized = rawRef.toLowerCase();
+
+  const directLink = linkMap[normalized];
+  if (directLink?.array[0]?.name)
+    return { base: normalized, expression: directLink.array[0].name };
+
+  // Web-only form: `base-expression` names an entry outright. Native has no
+  // such syntax; it is kept for scripts authored against the wiki player.
+  for (const [base, link] of Object.entries(linkMap)) {
+    const prefix = `${base}-`;
+    if (!normalized.startsWith(prefix)) continue;
+
+    const expression = normalized.slice(prefix.length);
+    if (!expression) continue;
+
+    const found = link.array.find(
+      (item) => item.name.toLowerCase() === expression,
+    );
+    if (found) return { base, expression: found.name };
+  }
+
+  const parsed = parseNativeCharacterRef(normalized);
+  if (!parsed) return null;
+
+  const link = linkMap[parsed.base];
+  if (!link) return null;
+
+  if (parsed.alias !== null) {
+    // Deviation from native, on purpose. `_TryParseAlias` keeps the leading
+    // `@`, and AVGCharacterSpriteHub.SetImage compares that `@`-prefixed string
+    // against SpriteConfig.alias with ordinal equality -- but the stored
+    // aliases carry no `@` ("angry", "QAQ", ...), so native always misses and
+    // falls back to sprites[0] with "[AVG] No alias {0} for character holder
+    // {1}, use default instead.". Matching the alias is more useful than
+    // reproducing that, and no story in the corpus uses the `@` form at all.
+    const wanted = parsed.alias.slice(1);
+    const found = link.array.find(
+      (item) => String(item.alias).toLowerCase() === wanted,
+    );
+    const expression = found?.name ?? link.array[0]?.name;
+    return expression ? { base: parsed.base, expression } : null;
+  }
+
+  if (parsed.group !== null) {
+    const suffix = `$${parsed.group + 1}`;
+    const grouped = link.array.filter((entry) => entry.name.endsWith(suffix));
+    if (grouped.length === 0) return null;
+    const picked = grouped[Math.max(0, parsed.index)] ?? grouped[0];
+    return picked?.name ? { base: parsed.base, expression: picked.name } : null;
+  }
+
+  const entry = link.array[Math.max(0, parsed.index)] ?? link.array[0];
+  return entry?.name ? { base: parsed.base, expression: entry.name } : null;
+}

--- a/src/widgets/StoryPlayer/engine/preload.ts
+++ b/src/widgets/StoryPlayer/engine/preload.ts
@@ -6,6 +6,7 @@ import {
   resolveStoryAudioByKey,
   resolveStoryCharacterAssetByKey,
 } from "./asset";
+import { resolveCharacterSelection } from "./characterRef";
 import { parseScript } from "./parser";
 import { DIALOG_FRAME_URL } from "./renderer";
 
@@ -170,99 +171,6 @@ function addScriptAudioUrls(urls: Set<string>, context: Context): void {
   }
 }
 
-/**
- * Native provenance: `Torappu.AVG.AVGCharacterslotPanel` character-reference
- * resolution and `Torappu.ResourceRouter.GetCharacterPath`.
- *
- * Ports the story-facing name forms needed to identify character assets. The
- * `character.json` link-map representation and face-overlay reconstruction are
- * web asset-pipeline adaptations, not a direct native data structure.
- *
- */
-function resolveCharacterSelection(
-  context: Context,
-  rawRef: string,
-): { base: string; expression: string } | null {
-  const cleaned = rawRef.trim();
-  if (!cleaned) return null;
-  const normalized = cleaned.toLowerCase();
-
-  const directLink = context.linkMap[normalized];
-  if (directLink?.array[0]?.name) {
-    return {
-      base: normalized,
-      expression: directLink.array[0].name,
-    };
-  }
-
-  for (const [base, link] of Object.entries(context.linkMap)) {
-    const prefix = `${base}-`;
-    if (!normalized.startsWith(prefix)) continue;
-
-    const expression = normalized.slice(prefix.length);
-    if (!expression) continue;
-
-    const found = link.array.find(
-      (item) => item.name.toLowerCase() === expression,
-    );
-    if (!found) continue;
-
-    return { base, expression: found.name };
-  }
-
-  const match = normalized.match(
-    /^([^@#$]+)(?:#\s*(\d+)\s*(?:\$\s*(\d+)\s*)?|@([\w-]+)|\$\s*(\d+)\s*)?$/,
-  );
-  if (!match) return null;
-
-  const base = match[1];
-  const link = context.linkMap[base];
-  if (!link) return null;
-
-  const hashIndex = match[2] ? Number.parseInt(match[2], 10) : undefined;
-  const hashGroup = match[3] ? Number.parseInt(match[3], 10) : undefined;
-  const alias = match[4];
-  const dollarGroup = match[5] ? Number.parseInt(match[5], 10) : undefined;
-
-  const pickInGroup = (group: number, index = 1): string | null => {
-    const grouped = link.array.filter((entry) =>
-      entry.name.endsWith(`$${group}`),
-    );
-    if (grouped.length === 0) return null;
-    return grouped[Math.max(0, index - 1)]?.name ?? grouped[0].name;
-  };
-
-  if (alias) {
-    const found = link.array.find(
-      (item) => String(item.alias).toLowerCase() === alias,
-    );
-    const expression = found?.name ?? link.array[0]?.name ?? null;
-    if (!expression) return null;
-    return { base, expression };
-  }
-
-  if (hashGroup) {
-    const expression = pickInGroup(hashGroup, hashIndex || 1);
-    if (!expression) return null;
-    return { base, expression };
-  }
-
-  if (dollarGroup) {
-    const expression = pickInGroup(dollarGroup, 1);
-    if (!expression) return null;
-    return { base, expression };
-  }
-
-  if (hashIndex) {
-    const found = link.array[Math.max(0, hashIndex - 1)] ?? link.array[0];
-    if (!found?.name) return null;
-    return { base, expression: found.name };
-  }
-
-  if (!link.array[0]?.name) return null;
-  return { base, expression: link.array[0].name };
-}
-
 function addCharacterUrls(
   urls: Set<string>,
   context: Context,
@@ -317,7 +225,7 @@ function addCharacterUrls(
     for (const nameRef of refs) {
       if (!nameRef) continue;
 
-      const resolved = resolveCharacterSelection(context, nameRef);
+      const resolved = resolveCharacterSelection(context.linkMap, nameRef);
       if (!resolved) continue;
 
       const link = context.linkMap[resolved.base];

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1,4 +1,5 @@
 import { resolveStoryAudioByKey, resolveStoryVideoByKey } from "./asset";
+import { resolveCharacterSelection } from "./characterRef";
 import { CommandRegistry } from "./commandRegistry";
 import { parseScript } from "./parser";
 import {
@@ -788,88 +789,7 @@ export class StoryRuntime {
   private resolveCharacterName(
     ref: string,
   ): { base: string; expression: string } | null {
-    const cleaned = ref.trim();
-    if (!cleaned) return null;
-    const normalized = cleaned.toLowerCase();
-
-    const directLink = this.context.linkMap[normalized];
-    if (directLink?.array[0]?.name) {
-      return {
-        base: normalized,
-        expression: directLink.array[0].name,
-      };
-    }
-
-    for (const [base, link] of Object.entries(this.context.linkMap)) {
-      const prefix = `${base}-`;
-      if (!normalized.startsWith(prefix)) continue;
-
-      const expression = normalized.slice(prefix.length);
-      if (!expression) continue;
-
-      const found = link.array.find(
-        (item) => item.name.toLowerCase() === expression,
-      );
-      if (!found) continue;
-
-      return { base, expression: found.name };
-    }
-
-    const match = normalized.match(
-      /^([^@#$]+)(?:#\s*(\d+)\s*(?:\$\s*(\d+)\s*)?|@([\w-]+)|\$\s*(\d+)\s*)?$/,
-    );
-    if (!match) return null;
-
-    const base = match[1];
-    const link = this.context.linkMap[base];
-    if (!link) return null;
-
-    const hashIndex = match[2] ? Number.parseInt(match[2], 10) : undefined;
-    const hashGroup = match[3] ? Number.parseInt(match[3], 10) : undefined;
-    const alias = match[4];
-    const dollarGroup = match[5] ? Number.parseInt(match[5], 10) : undefined;
-
-    const pickInGroup = (group: number, index?: number): string | null => {
-      const grouped = link.array.filter((entry) =>
-        entry.name.endsWith(`$${group}`),
-      );
-      if (grouped.length === 0) return null;
-      const picked = grouped[Math.max(0, (index ?? 1) - 1)] ?? grouped[0];
-      return picked?.name ?? null;
-    };
-
-    if (alias) {
-      const entry = link.array.find(
-        (item) => String(item.alias).toLowerCase() === alias.toLowerCase(),
-      );
-      const expression = entry?.name ?? link.array[0]?.name ?? null;
-      if (!expression) return null;
-      return { base, expression };
-    }
-
-    if (hashGroup) {
-      const expression = pickInGroup(hashGroup, hashIndex);
-      if (!expression) return null;
-      return { base, expression };
-    }
-
-    if (dollarGroup) {
-      const expression = pickInGroup(dollarGroup, 1);
-      if (!expression) return null;
-      return { base, expression };
-    }
-
-    if (hashIndex) {
-      const entry = link.array[Math.max(0, hashIndex - 1)] ?? link.array[0];
-      if (!entry?.name) return null;
-      return { base, expression: entry.name };
-    }
-
-    if (!link.array[0]?.name) return null;
-    return {
-      base,
-      expression: link.array[0].name,
-    };
+    return resolveCharacterSelection(this.context.linkMap, ref);
   }
 
   private executeCommand(line: ParsedCommandLine): Promise<CommandResult> {

--- a/tests/characterRef.spec.ts
+++ b/tests/characterRef.spec.ts
@@ -1,0 +1,203 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+
+import {
+  parseNativeCharacterRef,
+  resolveCharacterSelection,
+  tryParseInt32,
+} from "../src/widgets/StoryPlayer/engine/characterRef";
+
+import type { StoryLinkNode } from "../src/widgets/StoryPlayer/engine/types";
+
+const linkMap: Record<string, StoryLinkNode> = {
+  avg_npc_1: {
+    array: [
+      { alias: "angry", group: -1, image: "avg_npc_1/1$1", name: "1$1" },
+      { alias: "calm", group: -1, image: "avg_npc_1/2$1", name: "2$1" },
+      { alias: "", group: -1, image: "avg_npc_1/1$2", name: "1$2" },
+      { alias: "", group: -1, image: "avg_npc_1/2$2", name: "2$2" },
+    ],
+    groups: [],
+    pos: { x: 0, y: 0 },
+    size: { x: 0, y: 0 },
+  },
+};
+
+describe("tryParseInt32", () => {
+  it("accepts the whitespace .NET's number parser accepts", () => {
+    // Number.IsWhite: 0x20 and 0x09..0x0D.
+    for (const pad of [" ", "\t", "\n", "\r", "\v", "\f"]) {
+      expect(tryParseInt32(`${pad}3`)).toBe(3);
+      expect(tryParseInt32(`3${pad}`)).toBe(3);
+    }
+  });
+
+  it("rejects whitespace .NET does not treat as whitespace", () => {
+    // JS \s matches these, which is exactly why the old regex over-tolerated.
+    expect(tryParseInt32("3 ")).toBeNull(); // NBSP
+    expect(tryParseInt32("　3")).toBeNull(); // ideographic space
+    expect(tryParseInt32("3﻿")).toBeNull(); // BOM
+  });
+
+  it("accepts a leading sign", () => {
+    expect(tryParseInt32("+3")).toBe(3);
+    expect(tryParseInt32("-3")).toBe(-3);
+    expect(tryParseInt32(" +3 ")).toBe(3);
+  });
+
+  it("fails on Int32 overflow like TryParse does", () => {
+    expect(tryParseInt32("2147483647")).toBe(2147483647);
+    expect(tryParseInt32("-2147483648")).toBe(-2147483648);
+    expect(tryParseInt32("2147483648")).toBeNull();
+    expect(tryParseInt32("99999999999")).toBeNull();
+  });
+
+  it("rejects anything that is not exactly one integer", () => {
+    for (const bad of ["", " ", "abc", "1#3", "3.5", "3 4", "1,000"])
+      expect(tryParseInt32(bad)).toBeNull();
+  });
+});
+
+describe("parseNativeCharacterRef", () => {
+  it("parses the plain suffix forms", () => {
+    expect(parseNativeCharacterRef("avg_npc_1")).toEqual({
+      alias: null,
+      base: "avg_npc_1",
+      group: null,
+      index: 0,
+    });
+    expect(parseNativeCharacterRef("avg_npc_1#3")).toMatchObject({
+      base: "avg_npc_1",
+      group: null,
+      index: 2,
+    });
+    expect(parseNativeCharacterRef("avg_npc_1$2")).toMatchObject({
+      base: "avg_npc_1",
+      group: 1,
+      index: 0,
+    });
+    expect(parseNativeCharacterRef("avg_npc_1#3$2")).toMatchObject({
+      base: "avg_npc_1",
+      group: 1,
+      index: 2,
+    });
+  });
+
+  it("absorbs whitespace inside the suffix, as Int32.TryParse does", () => {
+    // The one real-world case: level_act53side_03_end.txt.
+    expect(parseNativeCharacterRef("avg_4236_tmslot_1#3 $1")).toMatchObject({
+      base: "avg_4236_tmslot_1",
+      group: 0,
+      index: 2,
+    });
+    expect(parseNativeCharacterRef("avg_npc_1# 3")).toMatchObject({
+      base: "avg_npc_1",
+      index: 2,
+    });
+    expect(parseNativeCharacterRef("avg_npc_1$ 2")).toMatchObject({
+      base: "avg_npc_1",
+      group: 1,
+    });
+  });
+
+  // The four cases below are the reason this is a loop and not a regex: a
+  // single anchored alternation cannot express independent right-to-left strips.
+  it("strips both an alias and a group, in that order", () => {
+    expect(parseNativeCharacterRef("avg_npc_1@angry$2")).toEqual({
+      alias: "@angry",
+      base: "avg_npc_1",
+      group: 1,
+      index: 0,
+    });
+  });
+
+  it("leaves an unparseable $ segment on the base and still strips #", () => {
+    expect(parseNativeCharacterRef("avg_npc_1$1#3")).toMatchObject({
+      base: "avg_npc_1$1",
+      group: null,
+      index: 2,
+    });
+  });
+
+  it("leaves an overflowing index on the base", () => {
+    expect(parseNativeCharacterRef("avg_npc_1#99999999999")).toMatchObject({
+      base: "avg_npc_1#99999999999",
+      index: 0,
+    });
+  });
+
+  it("accepts a signed index", () => {
+    expect(parseNativeCharacterRef("avg_npc_1#+3")).toMatchObject({
+      base: "avg_npc_1",
+      index: 2,
+    });
+  });
+
+  it("leaves a non-numeric # segment on the base", () => {
+    expect(parseNativeCharacterRef("avg_npc_1#abc")).toMatchObject({
+      base: "avg_npc_1#abc",
+      index: 0,
+    });
+  });
+
+  it("keeps the leading @ on the alias, like _TryParseAlias", () => {
+    expect(parseNativeCharacterRef("avg_npc_1@angry")?.alias).toBe("@angry");
+  });
+
+  it("returns null only for an empty ref", () => {
+    expect(parseNativeCharacterRef("")).toBeNull();
+  });
+});
+
+describe("resolveCharacterSelection", () => {
+  it("picks by index when there is no group", () => {
+    expect(resolveCharacterSelection(linkMap, "avg_npc_1#2")).toEqual({
+      base: "avg_npc_1",
+      expression: "2$1",
+    });
+  });
+
+  it("picks the nth entry within a group", () => {
+    expect(resolveCharacterSelection(linkMap, "avg_npc_1#2$2")).toEqual({
+      base: "avg_npc_1",
+      expression: "2$2",
+    });
+  });
+
+  it("takes the first of a group when only $N is given", () => {
+    expect(resolveCharacterSelection(linkMap, "avg_npc_1$2")).toEqual({
+      base: "avg_npc_1",
+      expression: "1$2",
+    });
+  });
+
+  it("folds case, standing in for _PreprocessAssetPath's ToLower", () => {
+    expect(resolveCharacterSelection(linkMap, "AVG_NPC_1#2")).toEqual({
+      base: "avg_npc_1",
+      expression: "2$1",
+    });
+  });
+
+  it("resolves an alias, deliberately diverging from native", () => {
+    // Native compares the "@"-prefixed string against the bare stored alias, so
+    // it always misses and falls back to sprites[0]. We match instead.
+    expect(resolveCharacterSelection(linkMap, "avg_npc_1@calm")).toEqual({
+      base: "avg_npc_1",
+      expression: "2$1",
+    });
+  });
+
+  it("falls back to the first entry for an unknown alias", () => {
+    expect(resolveCharacterSelection(linkMap, "avg_npc_1@nope")).toEqual({
+      base: "avg_npc_1",
+      expression: "1$1",
+    });
+  });
+
+  it("returns null for an unknown base or an empty group", () => {
+    expect(resolveCharacterSelection(linkMap, "avg_npc_404")).toBeNull();
+    expect(resolveCharacterSelection(linkMap, "avg_npc_1$9")).toBeNull();
+    expect(resolveCharacterSelection(linkMap, "")).toBeNull();
+  });
+});


### PR DESCRIPTION
接 #327 review 里第 4 条的讨论。

## 为什么正则做不到严格对齐

`AVGCharacterSlot._LoadImage` 的后缀解析是**三次独立的、从右往左的剥离**,每次都是 `LastIndexOf` + `Substring` + `Int32.TryParse`:

```
_TryParseBody  → LastIndexOf('$') → Int32.TryParse → 剥掉
_TryParseAlias → LastIndexOf('@') → Substring(idx) → 剥掉   (保留 '@')
_TryParseIndex → LastIndexOf('#') → Int32.TryParse → 剥掉
```

一条锚定正则的 alternation 只能表达"固定顺序里的一个后缀",所以下面四类在结构上就够不着,再补多少 `\s*` 也没用:

| 写法 | 原生 | 旧正则 |
| --- | --- | --- |
| `name@alias$1` | 先剥 `$1` 再剥 `@alias`,两者都生效 | 不匹配 |
| `name$1#3` | `$` 段 parse 失败→不剥;`#3` 生效,base 留 `name$1` | 不匹配 |
| `name#99999999999` | Int32 溢出→TryParse 失败→不剥,index 0 | 当成合法 index |
| `name#+3` | `AllowLeadingSign`,index = 2 | 不匹配 |

## 改动

把那段循环直接移植过来,放进新的 `engine/characterRef.ts`,`runtime.ts` 和 `preload.ts` 两份重复实现合并到这一份(顺带解决 #327 review 里第 3 条提的漂移问题)。

`tryParseInt32` 精确实现 `NumberStyles.Integer`:

- 空白集只有 `0x20` 和 `0x09..0x0D` —— **不含** NBSP / U+3000 / BOM,这正是旧正则用 JS `\s` 时过宽的地方;
- 支持前导 `+` / `-`;
- Int32 溢出返回 `null`(BCL 返回 false)。

## 验证

对 5 个 gamedata 快照共 5525 个 story txt、**10329 条去重 ref**:

| 对比对象 | 结果 |
| --- | --- |
| 独立编写的原生参考模型 | **0 处解析差异** |
| 当前 main(已含 #327) | **0 处行为变化** |

也就是说 rebase 到 #327 之后,**本 PR 是一次纯粹的等价重构**:行为一字不变,换掉的是表达方式。

(rebase 之前基于旧 main 跑时,唯一一处差异正是 `avg_4236_tmslot_1#3 $1` —— 本 PR 独立地也修好了 #327 的目标 ref。)

新增 `tests/characterRef.spec.ts` 21 条用例,把上表四类"正则表达不了"的写法、`Int32.TryParse` 的空白/符号/溢出边界都固化下来。全量 189 tests / `vue-tsc` / eslint 均通过。

## 有意保留的偏离(代码里都写了注释)

1. **`@alias` 匹配** —— 这条是**故意不对齐**。`_TryParseAlias` 用的是 `Substring(idx)` 而非 `idx+1`,alias 带着 `@`;而 `AVGCharacterSpriteHub.SetImage` 拿它跟 `SpriteConfig.alias` 做序数比较,存的却是不带 `@` 的 `angry` / `QAQ` / `aggrieved fake`。所以原生这个比较必然失配,永远回落 `sprites[0]` 并打 `[AVG] No alias {0} for character holder {1}, use default instead.`。能匹配上比复刻这个 bug 有用,且全语料 **0 条 ref 用 `@`**,两边都是死代码。

   > 该结论仅来自反编译阅读,因为这条路径在真实剧本里从未被走到,无法从实际表现反证。

2. **大小写折叠** —— 对应资源层 `ABResourceManager._PreprocessAssetPath` 的 `path.ToLower()`,详见 #330。

3. **不再 `trim()`** —— 原生也不 trim。语料里 54 条带首尾空白的 ref,全部由 `TryParse` 的空白容忍吸收,实测**改前改后解析结果一致**。这条算行为变更,单独拎出来请留意:若更希望保留这份宽容,回退一行即可。

4. **`base-expression` 前缀写法** —— 原生没有这个语法,是 web 侧自有的,保留未动。

## 与 #327 / #330 的关系

已 rebase 到两者合并后的 main。#327 加的那两条测试原封不动跑在移植后的实现上,全部通过 —— 这本身也是一个不错的等价性佐证。

全量 **194 tests** / `vue-tsc` / eslint 均通过。
