### PR TITLE
fix(story-player): align log decision branches with runtime

### DIFF
--- a/src/widgets/StoryPlayer/components/LogAllList.vue
+++ b/src/widgets/StoryPlayer/components/LogAllList.vue
@@ -54,6 +54,15 @@ function hasRouteContent(routes: LogAllDecisionRoute[]): boolean {
   return routes.some((route) => route.entries.length > 0);
 }
 
+/** 单选项或所有选项拥有同一去向时，不需要渲染可折叠的分支层。 */
+function isNonBranching(routes: LogAllDecisionRoute[]): boolean {
+  return groupRoutes(routes).length <= 1;
+}
+
+function commonRouteEntries(routes: LogAllDecisionRoute[]): LogAllEntry[] {
+  return routes[0]?.entries ?? [];
+}
+
 /** 某条 line entry 是否对应当前屏幕正在显示的源行 */
 function isActiveLine(entry: LogAllEntry & { kind: "line" }): boolean {
   return (
@@ -118,9 +127,11 @@ function routeActiveLineIndex(group: RouteGroup): number | null {
         </span>
       </div>
 
-      <!-- 所有选项都立即汇合时，压成静态记录，不制造空折叠层。 -->
+      <!-- 单选项或所有选项去向相同时，压成静态记录，不制造无意义的折叠层。 -->
       <div
-        v-else-if="!hasRouteContent(entry.routes)"
+        v-else-if="
+          !hasRouteContent(entry.routes) || isNonBranching(entry.routes)
+        "
         class="border-l-2 py-1 pl-3"
       >
         <div class="text-sm">
@@ -135,6 +146,16 @@ function routeActiveLineIndex(group: RouteGroup): number | null {
         <div v-if="entry.shared.length > 0" class="mt-2 pl-3">
           <LogAllList
             :entries="entry.shared"
+            :active-line-index="activeLineIndex"
+            :decision-select-value="decisionSelectValue"
+          />
+        </div>
+        <div
+          v-if="commonRouteEntries(entry.routes).length > 0"
+          class="mt-2 pl-3"
+        >
+          <LogAllList
+            :entries="commonRouteEntries(entry.routes)"
             :active-line-index="activeLineIndex"
             :decision-select-value="decisionSelectValue"
           />

--- a/src/widgets/StoryPlayer/components/LogAllList.vue
+++ b/src/widgets/StoryPlayer/components/LogAllList.vue
@@ -50,15 +50,15 @@ function groupRoutes(routes: LogAllDecisionRoute[]): RouteGroup[] {
   return groups;
 }
 
-function hasRouteContent(routes: LogAllDecisionRoute[]): boolean {
-  return routes.some((route) => route.entries.length > 0);
-}
-
-/** 单选项或所有选项拥有同一去向时，不需要渲染可折叠的分支层。 */
+/**
+ * 单选项、所有选项去向相同、以及所有选项都没有专属文本（此时各 route 同样等价）
+ * 三种情况都不需要渲染可折叠的分支层。
+ */
 function isNonBranching(routes: LogAllDecisionRoute[]): boolean {
   return groupRoutes(routes).length <= 1;
 }
 
+/** 仅在 isNonBranching 为真时有意义：各 route 等价，取任意一条即可。 */
 function commonRouteEntries(routes: LogAllDecisionRoute[]): LogAllEntry[] {
   return routes[0]?.entries ?? [];
 }
@@ -129,9 +129,7 @@ function routeActiveLineIndex(group: RouteGroup): number | null {
 
       <!-- 单选项或所有选项去向相同时，压成静态记录，不制造无意义的折叠层。 -->
       <div
-        v-else-if="
-          !hasRouteContent(entry.routes) || isNonBranching(entry.routes)
-        "
+        v-else-if="isNonBranching(entry.routes)"
         class="border-l-2 py-1 pl-3"
       >
         <div class="text-sm">

--- a/src/widgets/StoryPlayer/engine/logAll.ts
+++ b/src/widgets/StoryPlayer/engine/logAll.ts
@@ -124,6 +124,23 @@ function toStringList(value: unknown): string[] {
 }
 
 /**
+ * 某个 decisionSelectValue 是否能通过 references 闸门。
+ *
+ * Native provenance: `Torappu.AVG.DecisionCommandPredicator.NeedToExecuteCommand`
+ * ——`references` 为空、或选值仍是初始的 0 时一律放行。
+ */
+function valuePassesGate(value: number, references: number[] | null): boolean {
+  if (references === null || references.length === 0) return true;
+
+  return value === 0 || references.includes(value);
+}
+
+/** 所有可能的选值都能通过闸门（即这段脚本对每条玩家路径都会执行） */
+function passesGate(values: Set<number>, references: number[] | null): boolean {
+  return [...values].every((value) => valuePassesGate(value, references));
+}
+
+/**
  * 静态预扫脚本，按 runtime 实际过滤行为整理 decision/predicate 分支。
  *
  * 用一个 target 栈跟踪「当前文本应落入的数组」：
@@ -221,17 +238,11 @@ export function buildLogAll(
           shared: [],
         };
         currentTarget().push(decision);
-        const decisionIsUnconditional =
-          currentReferences === null ||
-          currentReferences.length === 0 ||
-          [...possibleValues].every((value) =>
-            currentReferences!.includes(value),
-          );
-        const retainedValues = decisionIsUnconditional
-          ? []
-          : [...possibleValues].filter(
-              (value) => !currentReferences!.includes(value),
-            );
+        // 被闸门挡住的路径不会执行这条 decision，其选值原样保留；能通过闸门的
+        // 路径则被新 decision 的选项值覆盖。
+        const retainedValues = [...possibleValues].filter(
+          (value) => !valuePassesGate(value, currentReferences),
+        );
         possibleValues = new Set([
           ...retainedValues,
           ...options.map((option) => option.value),
@@ -261,20 +272,37 @@ export function buildLogAll(
 
         const references = toNumberList(line.args.references);
         currentReferences = references;
-        const owner = currentDecision();
-        if (references.length === 0 || !owner) break; // 无 enclosing decision 或 references 为空：忽略
+        if (references.length === 0) break; // references 为空：忽略
 
-        // references 覆盖当前 decision 的全部选项时，这是显式汇合点。
+        // 全部可能取值都能通过闸门时，这是显式汇合点。
         // Runtime 只保存一组 decisionSelectValue/decisionReferences：新 decision
         // 会覆盖旧选择，而不会在内层 decision 结束后恢复外层选择。因此这里
         // 必须退出全部静态嵌套层，不能只返回父 decision。否则 07-03 这类
         // “分支内出现新 decision，随后全选项汇合”的脚本会把余下整篇剧情
         // 错挂到最早的某个选项下面。
-        if ([...possibleValues].every((value) => references.includes(value))) {
+        if (passesGate(possibleValues, references)) {
           targetStack.length = 1;
           decisionStack.length = 1;
           break;
         }
+
+        // references 引用的取值未必属于栈顶 decision：内层 decision 可能被闸门
+        // 整个跳过，此时后续 predicate 指回的是某个更外层 decision 的取值。
+        // 不退到真正拥有这些取值的那一层，分支就会挂在投影不出它的 decision 下
+        // （routes 只收 references 命中 owner 选项值的分支），整段文本会从
+        // Log All 面板里消失。
+        while (
+          decisionStack.length > 1 &&
+          decisionStack
+            .at(-1)!
+            .options.every((option) => !references.includes(option.value))
+        ) {
+          targetStack.pop();
+          decisionStack.pop();
+        }
+
+        const owner = currentDecision();
+        if (!owner) break; // 无 enclosing decision：忽略
 
         // references 映射回所属 decision 的选项文本（value -> label）
         const labelByValue = new Map(

--- a/src/widgets/StoryPlayer/engine/logAll.ts
+++ b/src/widgets/StoryPlayer/engine/logAll.ts
@@ -143,6 +143,12 @@ export function buildLogAll(
   const targetStack: LogAllEntry[][] = [root];
   /** 与 targetStack 并行：每层对应的 decision 节点（栈底为 null） */
   const decisionStack: (LogAllDecisionEntry | null)[] = [null];
+  // Runtime has one mutable selected value. Keep the set of values that can be
+  // present across all player histories so a convergence is only lifted to the
+  // root when *every* history passes the predicate (including histories that
+  // skipped a gated nested decision).
+  let possibleValues = new Set([0]);
+  let currentReferences: number[] | null = null;
 
   const currentTarget = (): LogAllEntry[] => targetStack.at(-1)!;
   const currentDecision = (): LogAllDecisionEntry | null =>
@@ -215,6 +221,22 @@ export function buildLogAll(
           shared: [],
         };
         currentTarget().push(decision);
+        const decisionIsUnconditional =
+          currentReferences === null ||
+          currentReferences.length === 0 ||
+          [...possibleValues].every((value) =>
+            currentReferences!.includes(value),
+          );
+        const retainedValues = decisionIsUnconditional
+          ? []
+          : [...possibleValues].filter(
+              (value) => !currentReferences!.includes(value),
+            );
+        possibleValues = new Set([
+          ...retainedValues,
+          ...options.map((option) => option.value),
+        ]);
+        currentReferences = null;
         // 新 decision 的执行会覆盖 runtime 中上一组选值，但它本身仍受执行前的
         // predicate 闸门约束。因此若它出现在某个分支段内，结构上必须留在该
         // 分支路径里；随后再以新 decision 为 owner 解释它自己的 predicate。
@@ -228,6 +250,7 @@ export function buildLogAll(
 
         // 裸 [predicate]（无 references）：runtime 设 decisionReferences=null，结束分支模式
         if (!line.paramPresent || line.args.references === undefined) {
+          currentReferences = null;
           // 弹出当前 decision 层（若有），回到外层流
           if (targetStack.length > 1) {
             targetStack.pop();
@@ -237,17 +260,19 @@ export function buildLogAll(
         }
 
         const references = toNumberList(line.args.references);
+        currentReferences = references;
         const owner = currentDecision();
         if (references.length === 0 || !owner) break; // 无 enclosing decision 或 references 为空：忽略
 
-        // references 覆盖当前 decision 的全部选项时，这是常见的显式汇合点。
-        // 从这里开始的内容对所有选项都相同，应回到 decision 的父级流；
-        // 否则紧随其后的新 decision 会被错误显示成每条选项路径的子节点。
-        if (
-          owner.options.every((option) => references.includes(option.value))
-        ) {
-          targetStack.pop();
-          decisionStack.pop();
+        // references 覆盖当前 decision 的全部选项时，这是显式汇合点。
+        // Runtime 只保存一组 decisionSelectValue/decisionReferences：新 decision
+        // 会覆盖旧选择，而不会在内层 decision 结束后恢复外层选择。因此这里
+        // 必须退出全部静态嵌套层，不能只返回父 decision。否则 07-03 这类
+        // “分支内出现新 decision，随后全选项汇合”的脚本会把余下整篇剧情
+        // 错挂到最早的某个选项下面。
+        if ([...possibleValues].every((value) => references.includes(value))) {
+          targetStack.length = 1;
+          decisionStack.length = 1;
           break;
         }
 

--- a/tests/logAll.spec.ts
+++ b/tests/logAll.spec.ts
@@ -236,7 +236,7 @@ describe("buildLogAll", () => {
     );
   });
 
-  it("returns an inner all-options convergence to its enclosing option path", () => {
+  it("keeps inner convergence in the outer path when another history skipped the inner decision", () => {
     const entries = run([
       '[decision(options="外A;外B", values="1;2")]',
       '[predicate(references="1")]',
@@ -249,8 +249,39 @@ describe("buildLogAll", () => {
     if (entries[0].kind !== "decision") return;
     const outerARoute = entries[0].routes[0].entries;
     expect(outerARoute[0]).toMatchObject({ kind: "decision" });
-    expect(outerARoute[1]).toMatchObject({ kind: "line", speaker: "内层汇合" });
+    const inner = outerARoute[0];
+    if (inner.kind !== "decision") return;
+    expect(inner.routes[0].entries[0]).toMatchObject({
+      kind: "line",
+      speaker: "内层汇合",
+    });
+    expect(inner.routes[1].entries[0]).toMatchObject({
+      kind: "line",
+      speaker: "内层汇合",
+    });
     expect(entries[0].routes[1].entries).toEqual([]);
+  });
+
+  it("returns the 07-03 nested decision sequence to the root flow", () => {
+    const entries = run([
+      '[decision(options="阿米娅;沉默;凯尔希", values="1;2;3")]',
+      '[predicate(references="1")]',
+      '[name="A"]外层一',
+      '[predicate(references="2")]',
+      '[name="B"]外层二',
+      '[predicate(references="3")]',
+      '[name="C"]外层三',
+      '[decision(options="计划？", values="1")]',
+      '[predicate(references="1")]',
+      '[name="阿米娅"]询问哪方面',
+      '[decision(options="办法;怎么去;直接问好", values="1;2;3")]',
+      '[predicate(references="1;2;3")]',
+      '[name="凯尔希"]罗德岛确实有自己的方法',
+      '[name="后续"]荒野场景',
+    ]);
+
+    expect(entries.at(-2)).toMatchObject({ kind: "line", speaker: "凯尔希" });
+    expect(entries.at(-1)).toMatchObject({ kind: "line", speaker: "后续" });
   });
 
   it("keeps an explicit empty route for an option without a matching predicate", () => {

--- a/tests/logAll.spec.ts
+++ b/tests/logAll.spec.ts
@@ -284,6 +284,73 @@ describe("buildLogAll", () => {
     expect(entries.at(-1)).toMatchObject({ kind: "line", speaker: "后续" });
   });
 
+  it("returns a predicate to the outer decision that owns its references", () => {
+    // act3fun_03_end 形状：外层选项 1 的分支里出现一个内层 decision，随后的
+    // predicate 指回外层的 2 / 3。内层 decision 对选了 2/3 的玩家从未执行，
+    // 这些段落必须挂在外层 decision 上，否则会落到投影不出它们的内层节点下。
+    const entries = run([
+      '[decision(options="外1;外2;外3", values="1;2;3")]',
+      '[predicate(references="1")]',
+      '[decision(options="内", values="4")]',
+      '[predicate(references="4")]',
+      '[name="内层"]只有选外1的人看得到',
+      '[predicate(references="2")]',
+      '[name="外2专属"]选外2才看得到',
+      '[predicate(references="3")]',
+      '[name="外3专属"]选外3才看得到',
+    ]);
+
+    if (entries[0].kind !== "decision") return;
+    const outer = entries[0];
+    expect(outer.branches.map((branch) => branch.references)).toEqual([
+      [1],
+      [2],
+      [3],
+    ]);
+    expect(outer.routes[1].entries[0]).toMatchObject({
+      kind: "line",
+      speaker: "外2专属",
+    });
+    expect(outer.routes[2].entries[0]).toMatchObject({
+      kind: "line",
+      speaker: "外3专属",
+    });
+  });
+
+  it("keeps every branch segment reachable from some route", () => {
+    const entries = run([
+      '[decision(options="外1;外2;外3", values="1;2;3")]',
+      '[predicate(references="1")]',
+      '[decision(options="内", values="4")]',
+      '[predicate(references="4")]',
+      '[name="内层"]内层文本',
+      '[predicate(references="2")]',
+      '[name="外2专属"]外层文本',
+    ]);
+
+    const inBranches = new Set<string>();
+    const inRoutes = new Set<string>();
+    const walk = (
+      list: ReturnType<typeof run>,
+      all: Set<string>,
+      shown: Set<string>,
+    ) => {
+      for (const entry of list) {
+        if (entry.kind === "line") {
+          all.add(entry.speaker);
+          shown.add(entry.speaker);
+          continue;
+        }
+        walk(entry.shared, all, shown);
+        for (const branch of entry.branches)
+          walk(branch.entries, all, new Set());
+        for (const route of entry.routes) walk(route.entries, new Set(), shown);
+      }
+    };
+    walk(entries, inBranches, inRoutes);
+    expect([...inBranches].filter((s) => !inRoutes.has(s))).toEqual([]);
+  });
+
   it("keeps an explicit empty route for an option without a matching predicate", () => {
     const entries = run([
       '[decision(options="A;B", values="1;2")]',


### PR DESCRIPTION
## Summary

- track possible runtime decision values when calculating Log All convergence
- prevent nested decisions from trapping the remaining story under an obsolete outer route
- render single-option and identical-route decisions as compact, non-branching records
- add regression coverage for the 07-03 nested decision sequence

## Verification

- `pnpm vitest run tests/logAll.spec.ts`
- `pnpm exec eslint src/widgets/StoryPlayer/engine/logAll.ts tests/logAll.spec.ts src/widgets/StoryPlayer/components/LogAllList.vue`
- `pnpm exec vue-tsc -b --pretty false`

https://prts.wiki/w/%E8%AF%9D%E9%A2%98:Zjyxh7zdw29tatc1
https://prts.wiki/w/7-4_%E5%B9%B6%E8%82%A9%E4%B9%8B%E7%BA%A6-1/BEG
obt/main/level_main_07-03_beg.txt