### PR TITLE
fix(story-player): enter 且 transtype 缺省时立绘瞬切，对齐原生

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1521,8 +1521,16 @@ export class PixiStoryRenderer implements StoryRenderer {
     // is unchanged. Cross-fading two copies of the same body sprite causes a
     // visible brightness dip, so expression/focus changes must swap at once.
     const fadeIdentity = input.fadeIdentity ?? input.characterKey;
-    const imageFadeMs =
-      previous?.fadeIdentity === fadeIdentity ? 0 : durationMs;
+    // Two independent native paths zero only the image fade: same identity
+    // (`dontFadeIfSameChar` above), and the enter branch of `_ProcessSlot`,
+    // which routes the duration through `_ProcessDurationWithTransType` -- it
+    // returns 0 for `ECharTransType.NONE`, and `transtype`'s default is NONE.
+    // So an explicit `enter` without `transtype` swaps the image instantly
+    // even for a different character; the non-enter branch passes
+    // `param.duration` straight to `Set`, hence the `enterFrom` guard.
+    const sameIdentity = previous?.fadeIdentity === fadeIdentity;
+    const instantEnterSwap = Boolean(input.enterFrom) && !input.transType;
+    const imageFadeMs = sameIdentity || instantEnterSwap ? 0 : durationMs;
     // An explicit enter still moves for the requested duration even when the
     // same character's expression is swapped instantly.
     const moveMs = input.enterFrom ? durationMs : 0;

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1715,6 +1715,10 @@ export class StoryRuntime {
         const nameRef = toString(args.name);
         const name2Ref = toString(args.name2);
         const focus = toNumber(args.focus, 0);
+        // Native reads `transtype` once per command via GetOrDefault<int>
+        // (default 0 = ECharTransType.NONE) and shares it across all three
+        // slots.
+        const transType = Math.trunc(toNumber(args.transtype, 0));
         const durationMs = this.calculateFadeMs(args.fadetime, 0.15);
         // Native port: Torappu.AVG.CharacterPanel._ExecuteCharacter. It reads
         // `isblock`, not `block`, and returns it raw without registering any tween
@@ -1780,6 +1784,7 @@ export class StoryRuntime {
             expression: resolved.expression,
             fadeIdentity: nativeCharacterFadeIdentity(update.name),
             slot: update.slot,
+            transType,
           });
         }
 

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -168,6 +168,15 @@ export interface CharacterSlotInput {
   slot: string;
   stop?: boolean;
   times?: number;
+  /**
+   * Native `CharacterPanel.ECharTransType` read from the `transtype` param of
+   * the `character` command (0 NONE, 1 ALPHA_IN, 2 ALPHA_OUT). The enter
+   * branch of `_ProcessSlot` routes the fade duration through
+   * `_ProcessDurationWithTransType`, which returns 0 for NONE -- the param
+   * default -- so an explicit `enter` without `transtype` swaps the image
+   * instantly; only the position still tweens.
+   */
+  transType?: number;
 }
 
 export interface CharacterActionInput {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -128,6 +128,68 @@ describe("PixiStoryRenderer", () => {
     expect(current.root.alpha).toBe(0);
   });
 
+  it("swaps the image instantly for an explicit enter without transtype", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      fadeIdentity: "avg_test$1",
+      slot: "m",
+    });
+    const previous = renderer.characterSlots.get("m");
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 150,
+      enterFrom: "left",
+      expression: "2$1",
+      fadeIdentity: "avg_test$2",
+      slot: "m",
+    });
+
+    // Native `_ProcessSlot`'s enter branch feeds the fade duration through
+    // `_ProcessDurationWithTransType`, and `transtype`'s default NONE returns
+    // 0 there: the image swaps at once even for a different character -- the
+    // outgoing root is disposed and the incoming one is opaque from frame 0 --
+    // while the move tween still runs for the full duration.
+    const current = renderer.characterSlots.get("m");
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+    expect(previous.root.parent).toBeNull();
+    expect(current.root.alpha).toBe(1);
+  });
+
+  it("still fades an explicit enter when transtype is ALPHA_IN", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      fadeIdentity: "avg_test$1",
+      slot: "m",
+    });
+    const previous = renderer.characterSlots.get("m");
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 150,
+      enterFrom: "left",
+      expression: "2$1",
+      fadeIdentity: "avg_test$2",
+      slot: "m",
+      transType: 1,
+    });
+
+    // `_ProcessDurationWithTransType` only zeroes the duration for NONE, so an
+    // explicit ALPHA_IN keeps fading while entering.
+    const current = renderer.characterSlots.get("m");
+    expect(renderer.tween).toHaveBeenCalled();
+    expect(previous.root.parent).not.toBeNull();
+    expect(current.root.alpha).toBe(0);
+  });
+
   it("keeps the large background behind the background regardless of update order", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const input = createGridBackgroundInput();

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1199,6 +1199,7 @@ describe("StoryRuntime", () => {
         expression: "1$1",
         fadeIdentity: "avg_npc_1",
         slot: "m",
+        transType: 0,
       },
     ]);
     expect(sleep).not.toHaveBeenCalledWith(200);
@@ -1232,6 +1233,7 @@ describe("StoryRuntime", () => {
         expression: "1$1",
         fadeIdentity: "avg_npc_1",
         slot: "l",
+        transType: 0,
       },
       {
         absolutePosition: { x: undefined, y: undefined },
@@ -1245,9 +1247,30 @@ describe("StoryRuntime", () => {
         expression: "1$1",
         fadeIdentity: "avg_npc_1",
         slot: "r",
+        transType: 0,
       },
     ]);
     expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("passes the native transtype through to the renderer", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[character(name="avg_npc_1",enter="left",transtype=1,fadetime=0.5)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // Native reads `transtype` once per command and shares it across all
+    // slots; the default is 0 (ECharTransType.NONE).
+    expect(renderer.characterCalls).toEqual([
+      expect.objectContaining({ enterFrom: "left", transType: 1 }),
+    ]);
   });
 
   it("keeps name2 in the right slot when the primary name is empty", async () => {


### PR DESCRIPTION
在review #340 时发现

https://prts.wiki/w/%E5%81%87%E6%97%A5%E5%A8%81%E9%BE%99%E9%99%88/%E5%B9%B2%E5%91%98%E5%AF%86%E5%BD%95/2 有一个`[character(name="char_empty",name2="avg_npc_194",enter2="left",fadetime=2.5)]` 2.5s的fade很显眼
原生 CharacterPanel._ProcessSlot 的 enter 分支把淡入时长送进
_ProcessDurationWithTransType，该函数在 ECharTransType.NONE 时返回 0， 而 transtype 参数默认就是 NONE（全量语料 0 次使用）。因此显式
enter 不带 transtype 时图片应瞬切，仅位移按原始 duration 滑入；
非 enter 分支才把 duration 直传 Set 正常淡入。

- runtime 透传 transtype（int，默认 0，三 slot 共享，对应原生 GetOrDefault<int> 读取）
- renderer 在同角色抑制之外，对 enterFrom && !transType 同样把 imageFadeMs 归零
- 补 renderer 瞬切/ALPHA_IN 淡入两条用例与 runtime 透传用例
