### PR TITLE
fix(story-player): 对齐 character 命令 native 语义（enter 滑入/transtype/层级）

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -2646,6 +2646,9 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     let sourceWidth: number;
     let sourceHeight: number;
+    // Sprites that make up the character pixels; the black gradient is
+    // clipped per-pixel against each of these textures.
+    const maskTargets: Sprite[] = [];
 
     if (item.group === -1 && "image" in item && item.image) {
       const texture = await this.textureForCharacterKey(item.image);
@@ -2654,6 +2657,7 @@ export class PixiStoryRenderer implements StoryRenderer {
       const sprite = new Sprite(texture);
       sprite.anchor.set(0, 0);
       content.addChild(sprite);
+      maskTargets.push(sprite);
       sourceWidth = texture.width;
       sourceHeight = texture.height;
     } else if (item.group >= 0 && "face" in item && item.face) {
@@ -2682,6 +2686,7 @@ export class PixiStoryRenderer implements StoryRenderer {
       faceSprite.width = group.faceRect.w;
       faceSprite.height = group.faceRect.h;
       content.addChild(faceSprite);
+      maskTargets.push(faceSprite);
 
       sourceWidth = baseTexture.width;
       sourceHeight = baseTexture.height;
@@ -2692,7 +2697,7 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     this.applyCharacterBlackGradient(
       visual,
-      content,
+      maskTargets,
       sourceWidth,
       sourceHeight,
       blackStart,
@@ -2849,7 +2854,7 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   private applyCharacterBlackGradient(
     visual: Container,
-    content: Container,
+    maskTargets: Sprite[],
     width: number,
     height: number,
     blackStart = Number.NaN,
@@ -2876,10 +2881,27 @@ export class PixiStoryRenderer implements StoryRenderer {
       type: "linear",
     });
 
-    const overlay = new Graphics();
-    overlay.rect(0, 0, width, overlayHeight).fill(gradient);
-    overlay.mask = content;
-    visual.addChild(overlay);
+    // Native applies the gradient inside the character shader
+    // (`avgCharSplitShader` material floats `_BlackStart`/`_BlackEnd` on the
+    // sprite's own material, AlphaSplitImageHolder.SetSprite), so it darkens
+    // character pixels only and never leaks into transparent regions. The
+    // web port must clip the overlay per-pixel: a Pixi `Container` mask is a
+    // stencil mask (quad geometry, alpha ignored) and would show the full
+    // rectangle, so mask each overlay with a `Sprite` that shares the
+    // character texture (alpha mask, per-pixel).
+    for (const target of maskTargets) {
+      const overlay = new Graphics();
+      overlay.rect(0, 0, width, overlayHeight).fill(gradient);
+      const maskSprite = new Sprite(target.texture);
+      maskSprite.anchor.set(0, 0);
+      maskSprite.x = target.x;
+      maskSprite.y = target.y;
+      maskSprite.width = target.width;
+      maskSprite.height = target.height;
+      visual.addChild(maskSprite);
+      visual.addChild(overlay);
+      overlay.mask = maskSprite;
+    }
   }
 
   private characterSlotFromTransform(

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -86,6 +86,18 @@ function clamp01(value: number): number {
 }
 
 /**
+ * `_GenPosition`'s per-slot term: it cancels each slot's own offset from the
+ * panel centre so a horizontal enter starts at the same absolute x everywhere.
+ */
+const SLOT_ENTER_COMPENSATION: Record<string, number> = { l: 200, r: -200 };
+
+/** DOTween `Ease.OutCubic`, used by `AVGCharacterSlot.SetCharPos`. */
+function easeOutCubic(progress: number): number {
+  const remaining = 1 - progress;
+  return 1 - remaining * remaining * remaining;
+}
+
+/**
  * Canvas 渲染分辨率：逻辑坐标系固定 1280x720，实际像素数按宿主 CSS 尺寸
  * × devicePixelRatio 反推，避免画布被 CSS 拉伸发糊。取宽高比例的较大值，
  * 宿主短暂偏离 16:9 时也不会欠采样。
@@ -1492,7 +1504,11 @@ export class PixiStoryRenderer implements StoryRenderer {
     // Match legacy char layout semantics in 1280x720 space.
     const targetX = (slotBaseX[slot] ?? slotBaseX.m) - sizeX / 2 + offsetX;
     const targetY = STORY_HEIGHT - sizeY / 2 - offsetY;
-    const enterOffset = this.enterOffset(input.enterFrom, input.enterPosition);
+    const enterOffset = this.enterOffset(
+      slot,
+      input.enterFrom,
+      input.enterPosition,
+    );
     const root = new Container();
     const motionLayer = new Container();
     const rotationLayer = new Container();
@@ -1592,7 +1608,10 @@ export class PixiStoryRenderer implements StoryRenderer {
         animationMs,
         (progress) => {
           root.alpha = imageFadeMs > 0 ? progress : 1;
-          const moveProgress = moveMs > 0 ? progress : 1;
+          // Native `SetCharPos` runs the slide as
+          // `DOLocalMove(...).SetEase(Ease.OutCubic)`; the shared tween runner
+          // is linear, so ease the move -- and only the move -- here.
+          const moveProgress = moveMs > 0 ? easeOutCubic(progress) : 1;
           root.x = targetX + enterOffset.x * (1 - moveProgress);
           root.y = targetY + enterOffset.y * (1 - moveProgress);
         },
@@ -2647,9 +2666,12 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     let sourceWidth: number;
     let sourceHeight: number;
-    // Sprites that make up the character pixels; the black gradient is
-    // clipped per-pixel against each of these textures.
-    const maskTargets: Sprite[] = [];
+    // Every sprite that contributes character pixels, in draw order. Native
+    // composites the face into the *same* material as the body (`SetSprite`
+    // feeds the face through `_HGDynamicTex`) and only then applies
+    // `_BlackStart`/`_BlackEnd`, so the gradient must be baked over the whole
+    // stack -- baking the face alone would leave the body its original colour.
+    const contentSprites: Sprite[] = [];
 
     if (item.group === -1 && "image" in item && item.image) {
       const texture = await this.textureForCharacterKey(item.image);
@@ -2658,7 +2680,7 @@ export class PixiStoryRenderer implements StoryRenderer {
       const sprite = new Sprite(texture);
       sprite.anchor.set(0, 0);
       content.addChild(sprite);
-      maskTargets.push(sprite);
+      contentSprites.push(sprite);
       sourceWidth = texture.width;
       sourceHeight = texture.height;
     } else if (item.group >= 0 && "face" in item && item.face) {
@@ -2679,6 +2701,7 @@ export class PixiStoryRenderer implements StoryRenderer {
       const baseSprite = new Sprite(baseTexture);
       baseSprite.anchor.set(0, 0);
       content.addChild(baseSprite);
+      contentSprites.push(baseSprite);
 
       const faceSprite = new Sprite(faceTexture);
       faceSprite.anchor.set(0, 0);
@@ -2687,7 +2710,7 @@ export class PixiStoryRenderer implements StoryRenderer {
       faceSprite.width = group.faceRect.w;
       faceSprite.height = group.faceRect.h;
       content.addChild(faceSprite);
-      maskTargets.push(faceSprite);
+      contentSprites.push(faceSprite);
 
       sourceWidth = baseTexture.width;
       sourceHeight = baseTexture.height;
@@ -2698,7 +2721,7 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     this.applyCharacterBlackGradient(
       content,
-      maskTargets,
+      contentSprites,
       sourceWidth,
       sourceHeight,
       blackStart,
@@ -2855,7 +2878,7 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   private applyCharacterBlackGradient(
     content: Container,
-    maskTargets: Sprite[],
+    contentSprites: Sprite[],
     width: number,
     height: number,
     blackStart = Number.NaN,
@@ -2870,7 +2893,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     const startY = height * Math.min(start, end);
     const endY = height * Math.max(start, end);
     const texture = this.bakeDarkenedCharacterTexture(
-      maskTargets,
+      contentSprites,
       width,
       height,
       startY,
@@ -2888,14 +2911,14 @@ export class PixiStoryRenderer implements StoryRenderer {
     // composite, yielding dst * (1 - a * p) instead of dst * (1 - a) * p --
     // the shading would fade in with the character and only look right at
     // the end of the fade.
-    for (const target of maskTargets) target.removeFromParent();
+    for (const sprite of contentSprites) sprite.removeFromParent();
     const darkened = new Sprite(texture);
     darkened.anchor.set(0, 0);
     content.addChild(darkened);
   }
 
   private bakeDarkenedCharacterTexture(
-    targets: Sprite[],
+    sprites: Sprite[],
     width: number,
     height: number,
     startY: number,
@@ -2907,21 +2930,25 @@ export class PixiStoryRenderer implements StoryRenderer {
     const ctx = canvas.getContext("2d");
     if (!ctx) return null;
 
-    for (const target of targets) {
-      const resource = target.texture?.source?.resource as
+    for (const sprite of sprites) {
+      const resource = sprite.texture?.source?.resource as
         CanvasImageSource | undefined;
-      if (!resource) continue;
-      const frame = target.texture.frame;
+      // The caller drops the originals in favour of the baked texture, so a
+      // sprite we cannot draw has to abort the whole bake -- skipping it would
+      // silently erase that part of the character instead of just leaving it
+      // undarkened.
+      if (!resource) return null;
+      const frame = sprite.texture.frame;
       ctx.drawImage(
         resource,
         frame.x,
         frame.y,
         frame.width,
         frame.height,
-        target.x,
-        target.y,
-        target.width,
-        target.height,
+        sprite.x,
+        sprite.y,
+        sprite.width,
+        sprite.height,
       );
     }
 
@@ -3076,27 +3103,42 @@ export class PixiStoryRenderer implements StoryRenderer {
     );
   }
 
+  /**
+   * Port of `CharacterPanel._GenPosition`, which returns the slide-in start as
+   * an `_offset.localPosition` -- a slot-local delta that `SetCharPos(0, 0,
+   * duration)` then tweens back to zero, not an absolute screen position.
+   *
+   * ```
+   * v = slot == LEFT ? 200 : slot == RIGHT ? -200 : 0
+   * "left"  -> (v - 1152, 0)   "right" -> (v + 1152, 0)
+   * "up"    -> (0, 1072)       "down"  -> (0, -1072)
+   * ```
+   *
+   * The LEFT +200 / RIGHT -200 term cancels each slot's own resting offset
+   * from the panel centre (`slotBaseX` is 440/640/840, i.e. 200 apart), so
+   * every slot starts a horizontal enter at the same absolute off-screen x.
+   * Unity y is up while the renderer is y-down, hence the flipped vertical
+   * constants.
+   */
   private enterOffset(
+    slot: string,
     direction?: CharacterSlotInput["enterFrom"],
     position?: { x: number; y: number },
   ): {
     x: number;
     y: number;
   } {
-    // Explicit xpos/ypos: a slot-local slide-in start, replacing the
-    // direction default (native `_GenPosition` only reads them for a legal
-    // `enter`, and only when both coordinates exist).
+    // Explicit xpos/ypos replace `_GenPosition` wholesale -- slot
+    // compensation included -- and native only applies the result for a legal
+    // `enter`, with both coordinates present.
     if (direction && position) return position;
-    // Direction defaults use the native constants HORIZONTAL_OUTSCREEN_DELTA
-    // = 1152 and VERTICAL_OUTSCREEN_DELTA = 1072 (plus the LEFT +200 /
-    // RIGHT -200 slot compensation, which folds into the slot base positions
-    // used for targetX/targetY above).
+    const slotCompensation = SLOT_ENTER_COMPENSATION[slot] ?? 0;
     switch (direction) {
       case "left": {
-        return { x: -1152, y: 0 };
+        return { x: slotCompensation - 1152, y: 0 };
       }
       case "right": {
-        return { x: 1152, y: 0 };
+        return { x: slotCompensation + 1152, y: 0 };
       }
       case "up": {
         return { x: 0, y: -1072 };
@@ -3115,22 +3157,24 @@ export class PixiStoryRenderer implements StoryRenderer {
    * non-middle slot (ECharSlot LEFT = 1 / RIGHT = 2). With the native
    * processing order MIDDLE -> LEFT -> RIGHT the resulting bottom-to-top
    * sibling order is: focus 1 -> [r, m, l], focus 2 -> [l, m, r],
-   * otherwise -> [l, r, m]. Roots mid cross-fade are not tracked slots and
-   * keep their relative place below the active ones.
+   * otherwise -> [l, r, m].
+   *
+   * Raising each tracked root to the top in that order also keeps roots that
+   * are mid cross-fade below the live ones: they are no longer tracked slots,
+   * so nothing lifts them back up. Computing fixed target indices instead
+   * would not -- `setChildIndex` splices, so each move shifts the indices the
+   * later moves were computed against, and an outgoing root ends up wedged
+   * between two live slots.
    */
   private applyCharacterZOrder(focus: number): void {
     const ufocus = focus >>> 0;
     let order = ["l", "r", "m"];
     if (ufocus === 1) order = ["r", "m", "l"];
     else if (ufocus === 2) order = ["l", "m", "r"];
-    const states = order
-      .map((slot) => this.characterSlots.get(slot))
-      .filter((state): state is CharacterRenderState => Boolean(state));
-    const total = this.charLayer.children.length;
-    for (let i = 0; i < states.length; i++) {
-      const root = states[i].root;
-      if (root.parent !== this.charLayer) continue;
-      this.charLayer.setChildIndex(root, total - states.length + i);
+    for (const slot of order) {
+      const root = this.characterSlots.get(slot)?.root;
+      if (!root || root.parent !== this.charLayer) continue;
+      this.charLayer.setChildIndex(root, this.charLayer.children.length - 1);
     }
   }
 

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1489,12 +1489,9 @@ export class PixiStoryRenderer implements StoryRenderer {
     const offsetY = link.pos.y || 0;
 
     // Match legacy char layout semantics in 1280x720 space.
-    const targetX =
-      input.absolutePosition?.x ??
-      (slotBaseX[slot] ?? slotBaseX.m) - sizeX / 2 + offsetX;
-    const targetY =
-      input.absolutePosition?.y ?? STORY_HEIGHT - sizeY / 2 - offsetY;
-    const enterOffset = this.enterOffset(input.enterFrom);
+    const targetX = (slotBaseX[slot] ?? slotBaseX.m) - sizeX / 2 + offsetX;
+    const targetY = STORY_HEIGHT - sizeY / 2 - offsetY;
+    const enterOffset = this.enterOffset(input.enterFrom, input.enterPosition);
     const root = new Container();
     const motionLayer = new Container();
     const rotationLayer = new Container();
@@ -1521,8 +1518,16 @@ export class PixiStoryRenderer implements StoryRenderer {
     // is unchanged. Cross-fading two copies of the same body sprite causes a
     // visible brightness dip, so expression/focus changes must swap at once.
     const fadeIdentity = input.fadeIdentity ?? input.characterKey;
+    // Native `_ProcessSlot`: with an `enter`, the image fade duration goes
+    // through `_ProcessDurationWithTransType(duration, transtype)`, which
+    // returns 0 for ECharTransType.NONE (0) -- i.e. the default enter is a
+    // pure slide with no fade; only ALPHA_IN/ALPHA_OUT fade while sliding.
+    // Without `enter` the raw duration is used. `dontFadeIfSameChar` can
+    // still zero the fade in both paths.
+    const fadeMsForNewImage =
+      input.enterFrom && !input.transType ? 0 : durationMs;
     const imageFadeMs =
-      previous?.fadeIdentity === fadeIdentity ? 0 : durationMs;
+      previous?.fadeIdentity === fadeIdentity ? 0 : fadeMsForNewImage;
     // An explicit enter still moves for the requested duration even when the
     // same character's expression is swapped instantly.
     const moveMs = input.enterFrom ? durationMs : 0;
@@ -1574,6 +1579,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     if (previous && imageFadeMs <= 0) this.disposeCharacterState(previous);
     this.characterSlots.set(slot, state);
     this.charLayer.addChild(root);
+    this.applyCharacterZOrder(input.focus ?? 0);
 
     if (previous && imageFadeMs > 0)
       void this.fadeOutAndRemove(previous.root, imageFadeMs, () =>
@@ -3009,26 +3015,61 @@ export class PixiStoryRenderer implements StoryRenderer {
     );
   }
 
-  private enterOffset(direction?: CharacterSlotInput["enterFrom"]): {
+  private enterOffset(
+    direction?: CharacterSlotInput["enterFrom"],
+    position?: { x: number; y: number },
+  ): {
     x: number;
     y: number;
   } {
+    // Explicit xpos/ypos: a slot-local slide-in start, replacing the
+    // direction default (native `_GenPosition` only reads them for a legal
+    // `enter`, and only when both coordinates exist).
+    if (direction && position) return position;
+    // Direction defaults use the native constants HORIZONTAL_OUTSCREEN_DELTA
+    // = 1152 and VERTICAL_OUTSCREEN_DELTA = 1072 (plus the LEFT +200 /
+    // RIGHT -200 slot compensation, which folds into the slot base positions
+    // used for targetX/targetY above).
     switch (direction) {
       case "left": {
-        return { x: -STORY_WIDTH, y: 0 };
+        return { x: -1152, y: 0 };
       }
       case "right": {
-        return { x: STORY_WIDTH, y: 0 };
+        return { x: 1152, y: 0 };
       }
       case "up": {
-        return { x: 0, y: -STORY_HEIGHT };
+        return { x: 0, y: -1072 };
       }
       case "down": {
-        return { x: 0, y: STORY_HEIGHT };
+        return { x: 0, y: 1072 };
       }
       default: {
         return { x: 0, y: 0 };
       }
+    }
+  }
+
+  /**
+   * Native `_ProcessSlot` raises MIDDLE via SetAsLastSibling, then the focused
+   * non-middle slot (ECharSlot LEFT = 1 / RIGHT = 2). With the native
+   * processing order MIDDLE -> LEFT -> RIGHT the resulting bottom-to-top
+   * sibling order is: focus 1 -> [r, m, l], focus 2 -> [l, m, r],
+   * otherwise -> [l, r, m]. Roots mid cross-fade are not tracked slots and
+   * keep their relative place below the active ones.
+   */
+  private applyCharacterZOrder(focus: number): void {
+    const ufocus = focus >>> 0;
+    let order = ["l", "r", "m"];
+    if (ufocus === 1) order = ["r", "m", "l"];
+    else if (ufocus === 2) order = ["l", "m", "r"];
+    const states = order
+      .map((slot) => this.characterSlots.get(slot))
+      .filter((state): state is CharacterRenderState => Boolean(state));
+    const total = this.charLayer.children.length;
+    for (let i = 0; i < states.length; i++) {
+      const root = states[i].root;
+      if (root.parent !== this.charLayer) continue;
+      this.charLayer.setChildIndex(root, total - states.length + i);
     }
   }
 

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1,6 +1,7 @@
 import {
   Application,
   Assets,
+  CanvasSource,
   ColorMatrixFilter,
   Container,
   FillGradient,
@@ -2868,40 +2869,75 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     const startY = height * Math.min(start, end);
     const endY = height * Math.max(start, end);
-    const overlayHeight = Math.max(1, endY);
-    const gradient = new FillGradient({
-      colorStops: [
-        { color: "rgba(0, 0, 0, 1)", offset: 0 },
-        { color: "rgba(0, 0, 0, 1)", offset: startY / overlayHeight },
-        { color: "rgba(0, 0, 0, 0)", offset: 1 },
-      ],
-      end: { x: 0, y: 1 },
-      start: { x: 0, y: 0 },
-      textureSpace: "local",
-      type: "linear",
-    });
+    const texture = this.bakeBlackSilhouetteTexture(
+      maskTargets,
+      width,
+      height,
+      startY,
+      endY,
+    );
+    if (!texture) return;
 
     // Native applies the gradient inside the character shader
     // (`avgCharSplitShader` material floats `_BlackStart`/`_BlackEnd` on the
-    // sprite's own material, AlphaSplitImageHolder.SetSprite), so it darkens
-    // character pixels only and never leaks into transparent regions. The
-    // web port must clip the overlay per-pixel: a Pixi `Container` mask is a
-    // stencil mask (quad geometry, alpha ignored) and would show the full
-    // rectangle, so mask each overlay with a `Sprite` that shares the
-    // character texture (alpha mask, per-pixel).
-    for (const target of maskTargets) {
-      const overlay = new Graphics();
-      overlay.rect(0, 0, width, overlayHeight).fill(gradient);
-      const maskSprite = new Sprite(target.texture);
-      maskSprite.anchor.set(0, 0);
-      maskSprite.x = target.x;
-      maskSprite.y = target.y;
-      maskSprite.width = target.width;
-      maskSprite.height = target.height;
-      visual.addChild(maskSprite);
-      visual.addChild(overlay);
-      overlay.mask = maskSprite;
+    // sprite's own material, AlphaSplitImageHolder.SetSprite), darkening
+    // character pixels only. The web port bakes that as a black silhouette
+    // sprite whose alpha = character alpha x gradient alpha: compositing
+    // black with alpha `a` over color `c` yields `c * (1 - a)`, the same
+    // lerp-to-black the native shader performs. Pixi's mask pipeline cannot
+    // express this: a Container mask is stencil (quad-only, ignores alpha)
+    // and a Sprite alpha mask multiplies by the mask texture's RED channel
+    // (mask.frag `masky.r`), which would key the shading to the character's
+    // own colors.
+    const silhouette = new Sprite(texture);
+    silhouette.anchor.set(0, 0);
+    visual.addChild(silhouette);
+  }
+
+  private bakeBlackSilhouetteTexture(
+    targets: Sprite[],
+    width: number,
+    height: number,
+    startY: number,
+    endY: number,
+  ): Texture | null {
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(width));
+    canvas.height = Math.max(1, Math.round(height));
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+
+    for (const target of targets) {
+      const resource = target.texture?.source?.resource as
+        CanvasImageSource | undefined;
+      if (!resource) continue;
+      const frame = target.texture.frame;
+      ctx.drawImage(
+        resource,
+        frame.x,
+        frame.y,
+        frame.width,
+        frame.height,
+        target.x,
+        target.y,
+        target.width,
+        target.height,
+      );
     }
+
+    ctx.globalCompositeOperation = "source-in";
+    const overlayHeight = Math.max(1, endY);
+    const gradient = ctx.createLinearGradient(0, 0, 0, overlayHeight);
+    gradient.addColorStop(0, "rgba(0, 0, 0, 1)");
+    gradient.addColorStop(
+      Math.min(1, startY / overlayHeight),
+      "rgba(0, 0, 0, 1)",
+    );
+    gradient.addColorStop(1, "rgba(0, 0, 0, 0)");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    return new Texture({ source: new CanvasSource({ resource: canvas }) });
   }
 
   private characterSlotFromTransform(

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -2697,7 +2697,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     }
 
     this.applyCharacterBlackGradient(
-      visual,
+      content,
       maskTargets,
       sourceWidth,
       sourceHeight,
@@ -2854,7 +2854,7 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   private applyCharacterBlackGradient(
-    visual: Container,
+    content: Container,
     maskTargets: Sprite[],
     width: number,
     height: number,
@@ -2869,7 +2869,7 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     const startY = height * Math.min(start, end);
     const endY = height * Math.max(start, end);
-    const texture = this.bakeBlackSilhouetteTexture(
+    const texture = this.bakeDarkenedCharacterTexture(
       maskTargets,
       width,
       height,
@@ -2880,21 +2880,21 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     // Native applies the gradient inside the character shader
     // (`avgCharSplitShader` material floats `_BlackStart`/`_BlackEnd` on the
-    // sprite's own material, AlphaSplitImageHolder.SetSprite), darkening
-    // character pixels only. The web port bakes that as a black silhouette
-    // sprite whose alpha = character alpha x gradient alpha: compositing
-    // black with alpha `a` over color `c` yields `c * (1 - a)`, the same
-    // lerp-to-black the native shader performs. Pixi's mask pipeline cannot
-    // express this: a Container mask is stencil (quad-only, ignores alpha)
-    // and a Sprite alpha mask multiplies by the mask texture's RED channel
-    // (mask.frag `masky.r`), which would key the shading to the character's
-    // own colors.
-    const silhouette = new Sprite(texture);
-    silhouette.anchor.set(0, 0);
-    visual.addChild(silhouette);
+    // sprite's own material, AlphaSplitImageHolder.SetSprite), darkening the
+    // texture BEFORE the vertex color multiplies it (fade-in alpha, focus
+    // dim tint). The web port must bake the darkening into the texture
+    // itself: an overlay/mask sibling cannot reproduce that order, because
+    // Pixi multiplies container alpha into each child before the children
+    // composite, yielding dst * (1 - a * p) instead of dst * (1 - a) * p --
+    // the shading would fade in with the character and only look right at
+    // the end of the fade.
+    for (const target of maskTargets) target.removeFromParent();
+    const darkened = new Sprite(texture);
+    darkened.anchor.set(0, 0);
+    content.addChild(darkened);
   }
 
-  private bakeBlackSilhouetteTexture(
+  private bakeDarkenedCharacterTexture(
     targets: Sprite[],
     width: number,
     height: number,
@@ -2925,7 +2925,10 @@ export class PixiStoryRenderer implements StoryRenderer {
       );
     }
 
-    ctx.globalCompositeOperation = "source-in";
+    // source-atop lerps the existing pixels toward the gradient color while
+    // keeping their alpha: out = black * g + c * (1 - g), identical to the
+    // native shader's lerp-to-black.
+    ctx.globalCompositeOperation = "source-atop";
     const overlayHeight = Math.max(1, endY);
     const gradient = ctx.createLinearGradient(0, 0, 0, overlayHeight);
     gradient.addColorStop(0, "rgba(0, 0, 0, 1)");

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1723,14 +1723,17 @@ export class StoryRuntime {
         // ever write `block=`, which is not a key this command reads, so the
         // command is effectively never blocking. Reproduce that, not the deadlock.
         const block = false;
+        // ECharTransType: 0 = NONE, 1 = ALPHA_IN, 2 = ALPHA_OUT. Native default 0.
+        const transType = Math.trunc(toNumber(args.transtype, 0));
         const hasRightCharacter = Boolean(name2Ref);
+        // Native processes slots MIDDLE -> LEFT -> RIGHT (same frame, sync).
         const updates = [
           {
             blackEnd: args.blackend,
             blackStart: args.blackstart,
             enter: args.enter,
-            name: hasRightCharacter ? nameRef : "",
-            slot: "l",
+            name: nameRef && !name2Ref ? nameRef : "",
+            slot: "m",
             x: args.xpos1,
             y: args.ypos1,
           },
@@ -1738,8 +1741,8 @@ export class StoryRuntime {
             blackEnd: args.blackend,
             blackStart: args.blackstart,
             enter: args.enter,
-            name: nameRef && !name2Ref ? nameRef : "",
-            slot: "m",
+            name: hasRightCharacter ? nameRef : "",
+            slot: "l",
             x: args.xpos1,
             y: args.ypos1,
           },
@@ -1765,21 +1768,36 @@ export class StoryRuntime {
             void this.renderer.clearCharacters(update.slot, durationMs);
             continue;
           }
+          const enterFrom = this.parseEnterDirection(update.enter);
+          // Native `_GenPosition`: xpos/ypos are only read as the slide-in
+          // start (a slot-local offset relative to the resting position) when
+          // `enter` is a legal direction, and both coordinates must exist.
+          // Without `enter` the values are never applied. Unity y is up while
+          // the renderer is y-down, so flip y.
+          const enterPosition =
+            enterFrom && update.x !== undefined && update.y !== undefined
+              ? {
+                  x: toNumber(update.x, 0),
+                  y: -toNumber(update.y, 0),
+                }
+              : undefined;
           await this.renderer.setCharacter({
-            absolutePosition: {
-              x: update.x === undefined ? undefined : toNumber(update.x, 0),
-              y: update.y === undefined ? undefined : toNumber(update.y, 0),
-            },
             blackEnd: toNumber(update.blackEnd, Number.NaN),
             blackStart: toNumber(update.blackStart, Number.NaN),
             block,
             characterKey: resolved.base,
-            dimmed: update.slot === "r" ? ![0, 2].includes(focus) : focus > 1,
+            // Native: LEFT/MIDDLE use `(unsigned)focus <= 1 -> focusColor`,
+            // RIGHT uses `(focus & 0xFFFFFFFD) == 0 -> focusColor`.
+            dimmed:
+              update.slot === "r" ? ![0, 2].includes(focus) : focus >>> 0 > 1,
             durationMs,
-            enterFrom: this.parseEnterDirection(update.enter),
+            enterFrom,
+            enterPosition,
             expression: resolved.expression,
             fadeIdentity: nativeCharacterFadeIdentity(update.name),
+            focus,
             slot: update.slot,
+            transType,
           });
         }
 
@@ -2647,14 +2665,11 @@ export class StoryRuntime {
   }
 
   private parseEnterDirection(value: unknown): CharacterSlotInput["enterFrom"] {
-    const normalized = toString(value).toLowerCase();
-    if (
-      normalized === "left" ||
-      normalized === "right" ||
-      normalized === "up" ||
-      normalized === "down"
-    )
-      return normalized;
+    // Native compares the raw string ordinally against the four literals
+    // left/right/up/down; anything else (including "middle") means no enter.
+    const raw = toString(value);
+    if (raw === "left" || raw === "right" || raw === "up" || raw === "down")
+      return raw;
     return undefined;
   }
 

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1769,16 +1769,18 @@ export class StoryRuntime {
             continue;
           }
           const enterFrom = this.parseEnterDirection(update.enter);
-          // Native `_GenPosition`: xpos/ypos are only read as the slide-in
-          // start (a slot-local offset relative to the resting position) when
-          // `enter` is a legal direction, and both coordinates must exist.
-          // Without `enter` the values are never applied. Unity y is up while
-          // the renderer is y-down, so flip y.
+          // Native `_ProcessSlotWithParam` takes xpos/ypos as the slide-in
+          // start -- a slot-local offset that `SetCharPos` tweens back to
+          // (0,0) -- but only when `TryGetParam` finds *both*; otherwise it
+          // falls back to `_GenPosition`. Either way `_ProcessSlot` applies
+          // the position only on the `enter` branch, so without a legal
+          // `enter` the values never reach the screen. They are read as
+          // Int32, and Unity y is up while the renderer is y-down.
           const enterPosition =
             enterFrom && update.x !== undefined && update.y !== undefined
               ? {
-                  x: toNumber(update.x, 0),
-                  y: -toNumber(update.y, 0),
+                  x: Math.trunc(toNumber(update.x, 0)),
+                  y: -Math.trunc(toNumber(update.y, 0)),
                 }
               : undefined;
           await this.renderer.setCharacter({

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -136,7 +136,6 @@ export interface RuntimeWarning {
 }
 
 export interface CharacterSlotInput {
-  absolutePosition?: { x?: number; y?: number };
   action?:
     "jump" | "move" | "rotate" | "setpos" | "shake" | "shakemove" | "zoom";
   angle?: number;
@@ -150,8 +149,10 @@ export interface CharacterSlotInput {
   dimmed?: boolean;
   durationMs?: number;
   enterFrom?: "down" | "left" | "right" | "up";
+  enterPosition?: { x: number; y: number };
   expression?: string;
   fadeIdentity?: string;
+  focus?: number;
   focusMode?: "current_only" | "none" | "subset";
   focusSlots?: string[];
   inverse?: boolean;
@@ -168,6 +169,7 @@ export interface CharacterSlotInput {
   slot: string;
   stop?: boolean;
   times?: number;
+  transType?: number;
 }
 
 export interface CharacterActionInput {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -52,6 +52,41 @@ function createCharacterRenderer(): any {
   return renderer;
 }
 
+function labelled(label: string): Container {
+  const container = new Container();
+  (container as any).label = label;
+  return container;
+}
+
+/** A `face_overlay` character: one body texture plus a face patch. */
+function createFaceOverlayRenderer(baked: Texture): any {
+  const context: Context = {
+    linkMap: {
+      avg_test: {
+        array: [{ alias: "", face: "face-1", group: 0, name: "1$1" }],
+        groups: [
+          {
+            base: "body-1",
+            faceRect: { h: 40, w: 50, x: 10, y: 20 },
+            mode: "face_overlay",
+          },
+        ],
+        pos: { x: 0, y: 0 },
+        size: { x: 100, y: 200 },
+      },
+    },
+    script: [],
+  } as unknown as Context;
+  const renderer = new PixiStoryRenderer(context) as any;
+  const textures: Record<string, Texture> = {
+    "body-1": new Texture({ source: { height: 200, width: 100 } as any }),
+    "face-1": new Texture({ source: { height: 40, width: 50 } as any }),
+  };
+  renderer.textureForCharacterKey = vi.fn(async (key: string) => textures[key]);
+  renderer.bakeDarkenedCharacterTexture = vi.fn(() => baked);
+  return renderer;
+}
+
 describe("PixiStoryRenderer", () => {
   it("bakes the black gradient into the character texture, replacing the sprites", () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
@@ -92,6 +127,47 @@ describe("PixiStoryRenderer", () => {
     } finally {
       bakeSpy.mockRestore();
     }
+  });
+
+  it("bakes the black gradient over the body as well as the face", async () => {
+    const baked = new Texture();
+    const renderer = createFaceOverlayRenderer(baked);
+
+    const built = await renderer.buildCharacterVisual("avg_test", "1$1", 0, 1);
+
+    // Native composites the face into the same material as the body
+    // (`AlphaSplitImageHolder.SetSprite` binds it as `_HGDynamicTex`) and only
+    // then applies `_BlackStart`/`_BlackEnd`, so the darkening covers the
+    // whole character. Baking the face alone would leave the body at its
+    // original colour with a darkened patch over the face.
+    const [sprites] = renderer.bakeDarkenedCharacterTexture.mock.calls[0];
+    const bodyTexture = await renderer.textureForCharacterKey("body-1");
+    const faceTexture = await renderer.textureForCharacterKey("face-1");
+    expect(sprites.map((sprite: Sprite) => sprite.texture)).toEqual([
+      bodyTexture,
+      faceTexture,
+    ]);
+    // Draw order matters: the body goes down first, the face patch on top.
+    expect(sprites.map((sprite: Sprite) => [sprite.x, sprite.y])).toEqual([
+      [0, 0],
+      [10, 20],
+    ]);
+
+    const content = built.visual.children[0] as Container;
+    expect(content.children.length).toBe(1);
+    expect((content.children[0] as Sprite).texture).toBe(baked);
+  });
+
+  it("keeps every content sprite when one of them cannot be baked", async () => {
+    const renderer = createFaceOverlayRenderer(new Texture());
+    renderer.bakeDarkenedCharacterTexture = vi.fn(() => null);
+
+    const built = await renderer.buildCharacterVisual("avg_test", "1$1", 0, 1);
+
+    // The originals are only dropped in favour of a baked texture; when the
+    // bake fails the character must stay drawable, just undarkened.
+    const content = built.visual.children[0] as Container;
+    expect(content.children.length).toBe(2);
   });
 
   it("dims unfocused characters with tint without making them transparent", () => {
@@ -167,6 +243,142 @@ describe("PixiStoryRenderer", () => {
     expect(renderer.tween).toHaveBeenCalled();
     expect(previous.root.parent).not.toBeNull();
     expect(current.root.alpha).toBe(0);
+  });
+
+  it("swaps the image instantly for an explicit enter without transtype", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      fadeIdentity: "avg_test$1",
+      slot: "m",
+    });
+    const previous = renderer.characterSlots.get("m");
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 150,
+      enterFrom: "left",
+      expression: "2$1",
+      fadeIdentity: "avg_test$2",
+      slot: "m",
+    });
+
+    // Native `_ProcessSlot`'s enter branch feeds the fade duration through
+    // `_ProcessDurationWithTransType`, and `transtype`'s default NONE returns
+    // 0 there: the image swaps at once even for a different character -- the
+    // outgoing root is disposed and the incoming one is opaque from frame 0 --
+    // while the move tween still runs for the full duration.
+    const current = renderer.characterSlots.get("m");
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+    expect(previous.root.parent).toBeNull();
+    expect(current.root.alpha).toBe(1);
+  });
+
+  it("still fades an explicit enter when transtype is ALPHA_IN", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      fadeIdentity: "avg_test$1",
+      slot: "m",
+    });
+    const previous = renderer.characterSlots.get("m");
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 150,
+      enterFrom: "left",
+      expression: "2$1",
+      fadeIdentity: "avg_test$2",
+      slot: "m",
+      transType: 1,
+    });
+
+    // `_ProcessDurationWithTransType` only zeroes the duration for NONE, so an
+    // explicit ALPHA_IN keeps fading while entering.
+    const current = renderer.characterSlots.get("m");
+    expect(renderer.tween).toHaveBeenCalled();
+    expect(previous.root.parent).not.toBeNull();
+    expect(current.root.alpha).toBe(0);
+  });
+
+  it("offsets the horizontal enter start by each slot's own resting offset", () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+
+    // `_GenPosition` adds +200 for LEFT and -200 for RIGHT before the
+    // 1152 horizontal delta, cancelling the slot's own offset from the panel
+    // centre so all three start at the same absolute off-screen x. The
+    // vertical delta has no such term, and Unity y-up flips to y-down.
+    expect(renderer.enterOffset("l", "left")).toEqual({ x: -952, y: 0 });
+    expect(renderer.enterOffset("m", "left")).toEqual({ x: -1152, y: 0 });
+    expect(renderer.enterOffset("r", "left")).toEqual({ x: -1352, y: 0 });
+    expect(renderer.enterOffset("l", "right")).toEqual({ x: 1352, y: 0 });
+    expect(renderer.enterOffset("r", "right")).toEqual({ x: 952, y: 0 });
+    expect(renderer.enterOffset("l", "up")).toEqual({ x: 0, y: -1072 });
+    expect(renderer.enterOffset("r", "down")).toEqual({ x: 0, y: 1072 });
+    expect(renderer.enterOffset("l", undefined)).toEqual({ x: 0, y: 0 });
+    // Explicit xpos/ypos replace `_GenPosition` outright, slot term included.
+    expect(renderer.enterOffset("l", "left", { x: 12, y: 34 })).toEqual({
+      x: 12,
+      y: 34,
+    });
+  });
+
+  it("eases the enter slide with OutCubic and leaves the fade linear", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 150,
+      enterFrom: "left",
+      expression: "1$1",
+      fadeIdentity: "avg_test$1",
+      slot: "m",
+      transType: 1,
+    });
+
+    const root = renderer.characterSlots.get("m").root;
+    const baseX = root.x + 1152;
+    const [, step] = renderer.tween.mock.calls[0];
+    step(0.5);
+
+    // Native `SetCharPos` slides with `Ease.OutCubic`; at the halfway point
+    // that is 1 - 0.5^3 = 0.875 of the way home, not 0.5.
+    expect(root.x).toBeCloseTo(baseX - 1152 * (1 - 0.875), 5);
+    expect(root.alpha).toBe(0.5);
+  });
+
+  it("keeps a cross-fading character root below the live slots", () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const l = labelled("l");
+    const m = labelled("m");
+    const r = labelled("r");
+    const outgoing = labelled("outgoing");
+    renderer.charLayer.addChild(l, m, outgoing, r);
+    renderer.characterSlots.set("l", { root: l });
+    renderer.characterSlots.set("m", { root: m });
+    renderer.characterSlots.set("r", { root: r });
+
+    const order = () =>
+      renderer.charLayer.children.map((child: any) => child.label);
+
+    // Bottom-to-top: middle always on top, then the focused side slot. The
+    // root left behind by a cross-fade is not a tracked slot, so it must sink
+    // below all three rather than get wedged between them.
+    renderer.applyCharacterZOrder(0);
+    expect(order()).toEqual(["outgoing", "l", "r", "m"]);
+    renderer.applyCharacterZOrder(1);
+    expect(order()).toEqual(["outgoing", "r", "m", "l"]);
+    renderer.applyCharacterZOrder(2);
+    expect(order()).toEqual(["outgoing", "l", "m", "r"]);
+    // `focus` is compared unsigned, so a negative value focuses nothing.
+    renderer.applyCharacterZOrder(-1);
+    expect(order()).toEqual(["outgoing", "l", "r", "m"]);
   });
 
   it("keeps the large background behind the background regardless of update order", async () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1,4 +1,4 @@
-import { Container, Graphics, Sprite, Texture } from "pixi.js";
+import { Container, Sprite, Texture } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 
 import { PixiStoryRenderer } from "../src/widgets/StoryPlayer/engine/renderer";
@@ -53,13 +53,12 @@ function createCharacterRenderer(): any {
 }
 
 describe("PixiStoryRenderer", () => {
-  it("clips the black gradient per-pixel with sprite masks, never containers", () => {
+  it("bakes the black gradient into a silhouette sprite instead of masking", () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
-    // The gradient build needs a real 2D canvas context; only the mask
-    // structure matters here, so stub the pixel rasterization.
-    const fillSpy = vi
-      .spyOn(Graphics.prototype, "fill")
-      .mockReturnValue(undefined as never);
+    const baked = new Texture();
+    const bakeSpy = vi
+      .spyOn(renderer, "bakeBlackSilhouetteTexture")
+      .mockReturnValue(baked);
     const visual = new Container();
     const texture = new Texture();
     const body = new Sprite(texture);
@@ -69,18 +68,26 @@ describe("PixiStoryRenderer", () => {
     try {
       renderer.applyCharacterBlackGradient(visual, [body], 100, 200, 0.2, 0.7);
 
-      expect(visual.children.length).toBe(2);
-      const [, overlay] = visual.children;
       // Native darkens character pixels inside the character shader
-      // (`_BlackStart`/`_BlackEnd` material floats); the web overlay must be
-      // alpha-masked by a Sprite sharing the character texture. A Container
-      // mask would fall back to stencil (quad-only) and leak a black
-      // rectangle over transparent regions.
-      expect(overlay.mask).toBeInstanceOf(Sprite);
-      expect(overlay.mask).not.toBe(body);
-      expect((overlay.mask as Sprite).texture).toBe(texture);
+      // (`_BlackStart`/`_BlackEnd` material floats). The web port bakes a
+      // black silhouette (character alpha x gradient alpha) as one sprite;
+      // Pixi masks must not be used -- a Container mask is stencil (quad
+      // only) and a Sprite alpha mask multiplies by the texture's RED
+      // channel, keying the shading to the character's own colors.
+      expect(bakeSpy).toHaveBeenCalledWith(
+        [body],
+        100,
+        200,
+        200 * 0.2,
+        200 * 0.7,
+      );
+      expect(visual.children.length).toBe(1);
+      const silhouette = visual.children[0] as Sprite;
+      expect(silhouette).toBeInstanceOf(Sprite);
+      expect(silhouette.texture).toBe(baked);
+      expect(silhouette.mask ?? null).toBeNull();
     } finally {
-      fillSpy.mockRestore();
+      bakeSpy.mockRestore();
     }
   });
 

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -53,27 +53,30 @@ function createCharacterRenderer(): any {
 }
 
 describe("PixiStoryRenderer", () => {
-  it("bakes the black gradient into a silhouette sprite instead of masking", () => {
+  it("bakes the black gradient into the character texture, replacing the sprites", () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const baked = new Texture();
     const bakeSpy = vi
-      .spyOn(renderer, "bakeBlackSilhouetteTexture")
+      .spyOn(renderer, "bakeDarkenedCharacterTexture")
       .mockReturnValue(baked);
+    const content = new Container();
     const visual = new Container();
+    visual.addChild(content);
     const texture = new Texture();
     const body = new Sprite(texture);
     body.width = 100;
     body.height = 200;
+    content.addChild(body);
 
     try {
-      renderer.applyCharacterBlackGradient(visual, [body], 100, 200, 0.2, 0.7);
+      renderer.applyCharacterBlackGradient(content, [body], 100, 200, 0.2, 0.7);
 
-      // Native darkens character pixels inside the character shader
-      // (`_BlackStart`/`_BlackEnd` material floats). The web port bakes a
-      // black silhouette (character alpha x gradient alpha) as one sprite;
-      // Pixi masks must not be used -- a Container mask is stencil (quad
-      // only) and a Sprite alpha mask multiplies by the texture's RED
-      // channel, keying the shading to the character's own colors.
+      // Native darkens the texture inside the character shader
+      // (`_BlackStart`/`_BlackEnd` material floats) BEFORE vertex color
+      // (fade alpha / dim tint) multiplies it. The web port must therefore
+      // bake the darkening into the texture: any overlay/mask sibling would
+      // have its alpha scaled by the fade progress (dst * (1 - a * p)),
+      // losing the shading at the start of the fade-in.
       expect(bakeSpy).toHaveBeenCalledWith(
         [body],
         100,
@@ -81,11 +84,11 @@ describe("PixiStoryRenderer", () => {
         200 * 0.2,
         200 * 0.7,
       );
-      expect(visual.children.length).toBe(1);
-      const silhouette = visual.children[0] as Sprite;
-      expect(silhouette).toBeInstanceOf(Sprite);
-      expect(silhouette.texture).toBe(baked);
-      expect(silhouette.mask ?? null).toBeNull();
+      expect(content.children.length).toBe(1);
+      const darkened = content.children[0] as Sprite;
+      expect(darkened).toBeInstanceOf(Sprite);
+      expect(darkened.texture).toBe(baked);
+      expect(body.parent).toBeNull();
     } finally {
       bakeSpy.mockRestore();
     }

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1,4 +1,4 @@
-import { Container, Texture } from "pixi.js";
+import { Container, Graphics, Sprite, Texture } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 
 import { PixiStoryRenderer } from "../src/widgets/StoryPlayer/engine/renderer";
@@ -53,6 +53,37 @@ function createCharacterRenderer(): any {
 }
 
 describe("PixiStoryRenderer", () => {
+  it("clips the black gradient per-pixel with sprite masks, never containers", () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    // The gradient build needs a real 2D canvas context; only the mask
+    // structure matters here, so stub the pixel rasterization.
+    const fillSpy = vi
+      .spyOn(Graphics.prototype, "fill")
+      .mockReturnValue(undefined as never);
+    const visual = new Container();
+    const texture = new Texture();
+    const body = new Sprite(texture);
+    body.width = 100;
+    body.height = 200;
+
+    try {
+      renderer.applyCharacterBlackGradient(visual, [body], 100, 200, 0.2, 0.7);
+
+      expect(visual.children.length).toBe(2);
+      const [, overlay] = visual.children;
+      // Native darkens character pixels inside the character shader
+      // (`_BlackStart`/`_BlackEnd` material floats); the web overlay must be
+      // alpha-masked by a Sprite sharing the character texture. A Container
+      // mask would fall back to stencil (quad-only) and leak a black
+      // rectangle over transparent regions.
+      expect(overlay.mask).toBeInstanceOf(Sprite);
+      expect(overlay.mask).not.toBe(body);
+      expect((overlay.mask as Sprite).texture).toBe(texture);
+    } finally {
+      fillSpy.mockRestore();
+    }
+  });
+
   it("dims unfocused characters with tint without making them transparent", () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const root = new Container();

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1256,6 +1256,26 @@ describe("StoryRuntime", () => {
     expect(runtime.getState()).toBe("waiting_input");
   });
 
+  it("passes the native transtype through to the renderer", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[character(name="avg_npc_1",enter="left",transtype=1,fadetime=0.5)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // Native reads `transtype` once per command via GetOrDefault<int> and
+    // shares it across all three slots; the default is 0 (ECharTransType.NONE).
+    expect(renderer.characterCalls).toEqual([
+      expect.objectContaining({ enterFrom: "left", transType: 1 }),
+    ]);
+  });
+
   it("keeps name2 in the right slot when the primary name is empty", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1188,7 +1188,6 @@ describe("StoryRuntime", () => {
     // executor never registers a completion callback, so the command never waits.
     expect(renderer.characterCalls).toEqual([
       {
-        absolutePosition: { x: undefined, y: undefined },
         blackEnd: 0.8,
         blackStart: 0.2,
         block: false,
@@ -1196,9 +1195,12 @@ describe("StoryRuntime", () => {
         dimmed: false,
         durationMs: 200,
         enterFrom: "left",
+        enterPosition: undefined,
         expression: "1$1",
         fadeIdentity: "avg_npc_1",
+        focus: 0,
         slot: "m",
+        transType: 0,
       },
     ]);
     expect(sleep).not.toHaveBeenCalledWith(200);
@@ -1221,7 +1223,6 @@ describe("StoryRuntime", () => {
     expect(renderer.clearedSlots).toEqual([{ fadeMs: 150, slot: "m" }]);
     expect(renderer.characterCalls).toEqual([
       {
-        absolutePosition: { x: undefined, y: undefined },
         blackEnd: Number.NaN,
         blackStart: Number.NaN,
         block: false,
@@ -1229,12 +1230,14 @@ describe("StoryRuntime", () => {
         dimmed: false,
         durationMs: 150,
         enterFrom: undefined,
+        enterPosition: undefined,
         expression: "1$1",
         fadeIdentity: "avg_npc_1",
+        focus: 1,
         slot: "l",
+        transType: 0,
       },
       {
-        absolutePosition: { x: undefined, y: undefined },
         blackEnd: Number.NaN,
         blackStart: Number.NaN,
         block: false,
@@ -1242,9 +1245,12 @@ describe("StoryRuntime", () => {
         dimmed: true,
         durationMs: 150,
         enterFrom: undefined,
+        enterPosition: undefined,
         expression: "1$1",
         fadeIdentity: "avg_npc_1",
+        focus: 1,
         slot: "r",
+        transType: 0,
       },
     ]);
     expect(runtime.getState()).toBe("waiting_input");
@@ -1261,8 +1267,8 @@ describe("StoryRuntime", () => {
     await runtime.start();
 
     expect(renderer.clearedSlots).toEqual([
-      { fadeMs: 150, slot: "l" },
       { fadeMs: 150, slot: "m" },
+      { fadeMs: 150, slot: "l" },
     ]);
     expect(renderer.characterCalls).toEqual([
       expect.objectContaining({
@@ -1273,11 +1279,13 @@ describe("StoryRuntime", () => {
     ]);
   });
 
-  it("uses exact character parameter keys and explicit positions", async () => {
+  it("ignores xpos/ypos without a legal enter and applies them as slide-in offsets with one", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(
       createContext([
         '[character(name="avg_npc_1",Name2="avg_npc_1",xpos1=123,ypos1=456)]',
+        '[character(name="avg_npc_1",enter="left",xpos1=123,ypos1=456)]',
+        '[character(name="avg_npc_1",enter="left",xpos1=123)]',
         '[name="A"]ok',
       ]),
       renderer,
@@ -1286,12 +1294,33 @@ describe("StoryRuntime", () => {
 
     await runtime.start();
 
-    expect(renderer.characterCalls).toHaveLength(1);
+    expect(renderer.characterCalls).toHaveLength(3);
+    // Native `_GenPosition` never applies xpos/ypos unless `enter` is one of
+    // left/right/up/down, so the first command places normally.
     expect(renderer.characterCalls[0]).toMatchObject({
-      absolutePosition: { x: 123, y: 456 },
+      enterFrom: undefined,
+      enterPosition: undefined,
+      slot: "m",
+    });
+    // With a legal enter and both coordinates, they act as the slot-local
+    // slide-in start (Unity y up -> renderer y down flip).
+    expect(renderer.characterCalls[1]).toMatchObject({
+      enterFrom: "left",
+      enterPosition: { x: 123, y: -456 },
+      slot: "m",
+    });
+    // Both coordinates must exist; a lone xpos1 falls back to the direction
+    // default.
+    expect(renderer.characterCalls[2]).toMatchObject({
+      enterFrom: "left",
+      enterPosition: undefined,
       slot: "m",
     });
     expect(renderer.clearedSlots).toEqual([
+      { fadeMs: 150, slot: "l" },
+      { fadeMs: 150, slot: "r" },
+      { fadeMs: 150, slot: "l" },
+      { fadeMs: 150, slot: "r" },
       { fadeMs: 150, slot: "l" },
       { fadeMs: 150, slot: "r" },
     ]);


### PR DESCRIPTION
## 背景

对照 arknights-rev 逆向 review 结论（`docs/impl-review/impl-review-character-command.md`，基于 2.7.61 build 2761 GameAssembly.dll IDA 反编译复核）修复 `character` 命令的呈现层偏差。原差异 P0=0 / P1=2 / P2=2 / P3=3，本 PR 全部修复；外加一个验证中发现的 blackstart/blackend 渲染 bug（三轮修复）。

## 修复内容

| # | 严重度 | 差异 | 修复 |
|---|---|---|---|
| 1 | P1 | `transtype` 未实现，enter 时错误淡入 | 读取 `transtype`（默认 0=NONE）；带 enter 时图片淡入时长 = `_ProcessDurationWithTransType`，NONE→0 **只滑不淡**；无 enter 保持 durationMs |
| 2 | P1 | `xpos1/ypos1` 被当作绝对屏幕坐标 | 删除 `absolutePosition`，新增 `enterPosition`：仅 `enter` 为合法方向且 x/y **双双存在**时作为槽位局部滑入起点（Unity y-up→y-down 翻转），否则不应用 |
| 3 | P2 | focus 驱动 z-order 缺失 | 新增 `applyCharacterZOrder`：MIDDLE 恒置顶；focus=1→[r,m,l]、focus=2→[l,m,r]、其它→[l,r,m]（底→顶） |
| 4 | P2 | 滑入行程为整屏 ±1280/±720 | 改为 native 常量 ±1152/±1072（`HORIZONTAL/VERTICAL_OUTSCREEN_DELTA`） |
| 5-7 | P3 | focus 负数 / enter 大小写 / 槽位处理序 | `(focus>>>0)>1` 无符号比较；`parseEnterDirection` ordinal 精确匹配（`"Left"` 不再匹配）；updates 数组重排 m→l→r 并加测试锁定 |
| 8 | 新发现 | **blackstart/blackend 黑幕渲染错误（三轮修复）** | native 黑幕在角色材质着色器里逐像素乘进精灵（`AlphaSplitImageHolder.SetSprite` 设 `_BlackStart`/`_BlackEnd`），且**变黑发生在顶点色（渐入 alpha、变暗 tint）之前**。三轮演进：①Container mask 是 stencil（不测 alpha）→ 方形黑框；②Sprite alpha mask 是亮度遮罩（`mask.frag` 乘红色通道）→ 黑幕被角色颜色调制成花斑；③黑色剪影 overlay 兄弟节点在渐入中途消失（Pixi 容器 alpha 先乘入子节点再合成，`dst×(1-a·p) ≠ dst×(1-a)×p`）。最终方案：**canvas `source-atop` 把渐变直接烘焙进角色纹理**（与 native lerp-to-black 等价），烘焙纹理替换原精灵，不依赖任何 mask/blend 管线 |

## 语料影响面（2.7.61 期资源全量扫描）

- `transtype`、`xpos1/ypos1/xpos2/ypos2`：全语料 **0 处**（前瞻性对齐，已有单测锁定）
- `enter/enter2`：44 文件 113 处 — **默认路径行为变化：enter 入场从“边滑边淡”改为“只滑入不淡入”**
- `focus` z-order：如 `obt/memory/story_catap_2_1.txt` 单文件 294 条（136×focus=1 修复前层级反向），另有 4 处 `focus=-1` 负样本
- `blackstart/blackend`：**965 处**（主线 9-10 章重度使用）全部受影响，修复影响面最大

## 验证样本（story review 目录用）

- `activities/act18d3/level_act18d3_03_end.txt` — enter 滑入 + focus=1↔2 层级交替（skadiSP 与 npc_180 立绘重叠）
- `obt/memory/story_ardign_1_1.txt` — `enter="down",fadetime=2` 慢速滑入最易肉眼对比
- `obt/memory/story_catap_2_1.txt` — focus 逐行交替层级压测 + L89-96 blackstart 黑幕（？？？ 入场：渐入全程上部黑影跟随轮廓，无方框无花斑无中途褪色）
- `obt/memory/story_bldsk_1_1.txt` — 非法 `enter="middle"` 负样本（应原地淡入不滑动）

## 测试

- [x] `pnpm test` 223 通过（runtime/renderer spec 更新为修正后语义，新增 black gradient 纹理烘焙测试）
- [x] `vue-tsc -b` 通过
- [x] `pnpm lint` 通过