### PR TITLE
fix(story-player): multiline 累积缓冲 skip 重置与 dialogue 空正文顺序

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -269,7 +269,12 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.context = context;
     this.onWarning = onWarning;
     this.videoPanel = new VideoPanel(this.uiLayer, onWarning);
-    this.dialogPanel = new DialogPanel(this.uiLayer, onWarning);
+    this.dialogPanel = new DialogPanel(
+      this.uiLayer,
+      onWarning,
+      (durationMs, update, complete) =>
+        this.tween(durationMs, update, complete),
+    );
     this.decisionPanel = new DecisionPanel(this.uiLayer);
     this.interludePanel = new InterludePanel(
       this.cutinLayer,

--- a/src/widgets/StoryPlayer/engine/rendering/panels/DialogPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/DialogPanel.ts
@@ -24,6 +24,8 @@ export class DialogPanel {
   private panel: Sprite | null = null;
   private speaker: Text | null = null;
   private topGradient: Sprite | null = null;
+  private readonly baseAlphas = new Map<Container, number>();
+  private fadeSessionId = 0;
 
   private static readonly BOTTOM_HEIGHT = 182;
   private static readonly NAME_LEFT = 20.7501;
@@ -37,10 +39,16 @@ export class DialogPanel {
   private static readonly MESSAGE_WIDTH = 735;
   private static readonly MESSAGE_MAX_HEIGHT = 89;
   private static readonly NAME_MAX_HEIGHT = 65;
+  private static readonly HIDE_FADE_MS = 150;
 
   constructor(
     private readonly layer: Container,
     private readonly warn?: (detail: string) => void,
+    private readonly tween?: (
+      durationMs: number,
+      step: (progress: number) => void,
+      done?: () => void,
+    ) => Promise<void>,
   ) {}
 
   async mount(): Promise<void> {
@@ -113,6 +121,9 @@ export class DialogPanel {
     this.panel = panel;
     this.speaker = speaker;
     this.dialogue = dialogue;
+    for (const item of [top, bottom, panel, speaker, dialogue]) {
+      if (item) this.baseAlphas.set(item, item.alpha);
+    }
     if (top) this.layer.addChild(top);
     if (bottom) this.layer.addChild(bottom);
     this.layer.addChild(speaker, dialogue);
@@ -132,16 +143,43 @@ export class DialogPanel {
       this.dialogue.text = text;
     }
     this.applyLayout();
-    const visible = Boolean(speaker || text);
-    for (const item of [
+    const items: Container[] = [
       this.topGradient,
       this.bottomGradient,
       this.panel,
       this.speaker,
       this.dialogue,
-    ]) {
-      if (item) item.visible = visible;
+    ].flatMap((item) => (item ? [item] : []));
+    // Cancel any fade-out still in flight before applying the new visibility.
+    this.fadeSessionId += 1;
+    if (speaker || text) {
+      for (const item of items) {
+        item.alpha = this.baseAlphas.get(item) ?? 1;
+        item.visible = true;
+      }
+      return;
     }
+    // Native port: set_isHidden(true) fades the panel's CanvasGroup out over
+    // 150ms (Linear, unscaled time) instead of hiding it instantly.
+    if (!this.tween) {
+      for (const item of items) item.visible = false;
+      return;
+    }
+    const session = this.fadeSessionId;
+    const startAlphas = items.map((item) => item.alpha);
+    void this.tween(
+      DialogPanel.HIDE_FADE_MS,
+      (progress) => {
+        if (session !== this.fadeSessionId) return;
+        for (const [i, item] of items.entries()) {
+          item.alpha = startAlphas[i]! * (1 - progress);
+        }
+      },
+      () => {
+        if (session !== this.fadeSessionId) return;
+        for (const item of items) item.visible = false;
+      },
+    );
   }
 
   destroy(): void {
@@ -179,6 +217,16 @@ export class DialogPanel {
         STORY_HEIGHT -
         DialogPanel.MESSAGE_TOP -
         Math.max(0, height - DialogPanel.MESSAGE_MAX_HEIGHT);
+      // Native port: _CalcMessageLayoutDelta/_ApplyTextContainerHeight grow
+      // sprite_frame_bottom upward from 182 once the message exceeds the
+      // 89px max height, in step with the message moving up.
+      if (this.bottomGradient) {
+        const bottomHeight =
+          DialogPanel.BOTTOM_HEIGHT +
+          Math.max(0, height - DialogPanel.MESSAGE_MAX_HEIGHT);
+        this.bottomGradient.height = bottomHeight;
+        this.bottomGradient.position.set(0, STORY_HEIGHT - bottomHeight);
+      }
     }
     if (this.speaker) {
       const height = this.speaker.text

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -560,6 +560,10 @@ export class StoryRuntime {
     await this.renderer.clearSpellStickers();
 
     this.cancelTyping();
+    // Native ShouldResetOnSkip → DialogPanel.OnReset → typeWriter.OnReset()
+    // clears the message and cursor, so a multiline block that starts right at
+    // the skip landing point must not append to the pre-skip text.
+    this.resetMultiline();
     if (shouldResume) {
       this.state = "running";
     } else if (!hadActiveProcessLoop) {
@@ -700,12 +704,12 @@ export class StoryRuntime {
         }
 
         if (line.kind === "dialogue") {
-          this.resetMultiline();
           if (!line.text) {
             this.cancelTyping();
             this.renderer.setDialogue("", "");
             continue;
           }
+          this.resetMultiline();
           this.displayedLineIndex = line.lineNumber;
           this.waitForDialogueInput(line.speaker, line.text);
           return;

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -349,6 +349,12 @@ export class StoryRuntime {
   private typingSessionId = 0;
   private quickSpeedLevel = 0;
   private currentMessageLength = 0;
+  /**
+   * Native port: `AVGTypeWriterText.messageLength` is the raw string length
+   * including rich-text tag characters; `RaiseAutoClick` waits on it. The
+   * visible-char `currentMessageLength` drives the multiline cursor instead.
+   */
+  private currentRawMessageLength = 0;
   private currentTypingComplete = false;
   private state: PlayerState = "idle";
   private multilineText = "";
@@ -429,7 +435,7 @@ export class StoryRuntime {
       return;
     }
     if (mode !== "default" && this.currentTypingComplete)
-      this.scheduleAutoClick(this.currentMessageLength);
+      this.scheduleAutoClick(this.currentRawMessageLength);
   }
 
   setAutoPlaySpeedLevel(level: number): void {
@@ -444,7 +450,7 @@ export class StoryRuntime {
 
     this.cancelAutoClick();
     if (this.autoPlayMode !== "default" && this.currentTypingComplete)
-      this.scheduleAutoClick(this.currentMessageLength);
+      this.scheduleAutoClick(this.currentRawMessageLength);
   }
 
   canSkipNode(): boolean {
@@ -501,6 +507,10 @@ export class StoryRuntime {
 
     if (this.finishTypingNow()) {
       this.onTypingComplete();
+      // Native port: _OnClicked checks m_multilineEnd after both branches, so
+      // an `end=true` run is reset by the click that finishes typing too, not
+      // only by the click that actually advances.
+      if (this.multilineEnd) this.resetMultiline();
       return;
     }
     if (this.renderer.finishTextTyping()) {
@@ -2536,8 +2546,10 @@ export class StoryRuntime {
     this.cancelTyping();
 
     const translatedSpeaker = this.translateText(speaker);
-    const richChars = parseRichChars(this.translateText(text));
+    const translatedText = this.translateText(text);
+    const richChars = parseRichChars(translatedText);
     this.currentMessageLength = richChars.length;
+    this.currentRawMessageLength = translatedText.length;
     this.currentTypingComplete = false;
     const initialDelayMs = this.getTypeWriterDelayMs(delayScale);
     const from = clamp(startIndex, 0, richChars.length);
@@ -2621,7 +2633,7 @@ export class StoryRuntime {
 
   private onTypingComplete(): void {
     this.currentTypingComplete = true;
-    this.scheduleAutoClick(this.currentMessageLength);
+    this.scheduleAutoClick(this.currentRawMessageLength);
   }
 
   private finishTypingNow(): boolean {


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `multiline` 命令移植中的全部可修复行为差异(共 6 项)。依据是对明日方官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的逆向分析,关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 multiline 机制(2.7.61 逆向结论)

- `Torappu.AVG.DialogPanel._ExecuteMultiline`:首行判定只看 `m_ismultiline`,首条 multiline 执行 `typeWriter.OnReset()`;后续连续 multiline 走 `typeWriter.AppendText(content)` 累积拼接,打字游标(`m_cachedMultilineTextLenth`)只打新增字符。
- `_ResetMultiline`:清 `m_ismultiline`/`m_multilineEnd`/累积缓冲。`dialog`/`aside`/`endtip` 命令 **content 非空**分支会调它(打断 multiline 累积);content 空分支(如空正文 `[name="X"]` 行、`[Dialog]`)**不调**。
- skip 链路:skip → `ShouldResetOnSkip` → `DialogPanel.OnReset` → `typeWriter.OnReset()`(清空消息与游标)⇒ 即使 `m_ismultiline` 残留为 1,skip 落点后的下一条 multiline 的 `AppendText` 也从空消息拼接,**等价于全新开始**。
- 布局:`_CalcMessageLayoutDelta`/`_GetTextContainerHeightOffset`/`_ApplyTextContainerHeight`:正文高过 89px 时底图 `sprite_frame_bottom` 从 182 向上增高,正文同步上移。
- 隐藏:`set_isHidden(true)` → CanvasGroup **150ms Linear 淡出**(unscaled 时间),非瞬时隐藏。
- 点击:`_OnClicked` 打字中分支(`TryFinish`)与推进分支**末尾都**检查 `m_multilineEnd` 并 `_ResetMultiline`。
- 自动播放:`_OnTypeWriterEnd → RaiseAutoClick(typeWriter.messageLength)`,`messageLength` = 原始串长度(**含富文本 tag 字符**)。

## 修改内容

### 1. `skipNode()` 不重置 multiline 累积(P1)

- **前端问题**:`runtime.ts` 的 `skipNode()` 未调 `resetMultiline()`,累积文本与游标跨 skip 存活;skip 落点直接踩到 `[multiline]` 块(中间无 `[name]` 行打断)时,新块文本会**拼接 skip 前的旧文本**。
- **修复**:在 `cancelTyping()` 旁补 `this.resetMultiline()`。

### 2. 对话框底栏不随累积文本长高(P2)

- **前端问题**:DialogPanel 的 `BOTTOM_HEIGHT` 固定 182,multiline 累积到 3 行以上时文字上移但黑条不增高,文字溢出黑条上缘。
- **修复**:`applyLayout` 按测得文本高度(`max(0, height - 89)`)同步增高 `bottomGradient` 并保持底边锚定。

### 3. 空 content 分支隐藏是瞬时的(P2)

- **前端问题**:`setDialogue("","")` 直接 `visible=false`。
- **修复**:DialogPanel 接入 renderer 的 tween,隐藏改为 150ms Linear alpha 渐隐(各元素按各自基准 alpha 等比淡出,渐隐期间再次显示会取消渐隐并立即恢复)。

### 4. 打字中点击(且 `end=true`)不立即 reset(P3)

- **前端问题**:仅真正推进的那次点击才 reset。
- **修复**:`advanceFromClick` 的 `finishTypingNow` 分支补 `if (this.multilineEnd) this.resetMultiline()`,对齐 `_OnClicked` 两分支均检查的语义。

### 5. dialogue 行空正文时误清 multiline(P3)

- **前端问题**:`dialogue` 分支先 `resetMultiline()` 再判空正文,顺序反了(native 空 content 分支不调 `_ResetMultiline`)。
- **修复**:把 `resetMultiline()` 移到空正文判断之后。

### 6. 自动播放等待时长按可见字符计数(P3)

- **前端问题**:`scheduleAutoClick` 用 RichChar 可见字符数;native 用原始串长度(含富文本 tag 字符)。
- **修复**:新增 `currentRawMessageLength`(翻译后原始串长度)供 `scheduleAutoClick` 使用;可见字符计数(`currentMessageLength`)仍用于 multiline 游标续打,不受影响。

## 验证用剧情文件

生产剧情文件位于本地 `torappu/storage/asset/gamedata/latest/story`:

- **修复 1(skip 重置)**:`obt/main/level_main_17-17_end.txt` —— 主线中唯一同时含 `[skipnode]` 锚点与多个 `[multiline]` 块的文件(如 138-140、160-162 行连续 multiline 块)。验证方式:播放该关,在第一个 multiline 块显示中点 skip,确认 skip 落点后的 multiline 文本不包含 skip 前的旧文本。
- **修复 1 回归(游标续打,确认未破坏正常路径)**:`obt/main/level_main_10-01_end.txt` 676-681 行 —— `multiline(name="？？？")或者，` 后接 `[character]`/`[Character]` 命令再接 `multiline(name="号角",end=true)`,验证第二条仍从已上屏内容续打(不整段重打)。
- **修复 2 + 3(底栏增高与渐隐)**:`obt/main/level_main_10-01_end.txt` 419-423 行 —— 两段 multiline 累积成 3 行以上,观察黑条随文本增高、文字不溢出;其后 424 行 `[name=...]` 普通对话打断时无渐隐,而 682 行 `[Dialog]`(空 content)应看到对话框 150ms 淡出而非瞬间消失。
- **修复 4(打字中点击)**:`obt/main/level_main_10-01_end.txt` 678-681 行,在 `end=true` 那条还在打字时点一下(瞬显),再点一下推进,确认中间状态正确。
- **修复 5(空正文 dialogue)**:生产数据中「multiline 块后紧跟空正文 `[name="X"]` 行」的样本极罕见,此项主要由代码顺序对齐保证;`obt/memory/story_brigid_1_1.txt` 等文件含空正文 `[name]` 行,可用于确认空正文行为(隐藏对话框)不变。
- **修复 6(自动播放等待)**:任意含富文本标签的剧情在自动播放下对比点击节奏即可(数值差异极小,主要是语义对齐)。

## 测试

- `pnpm test`:20 个文件 222 个用例全部通过。
- `vue-tsc -b` 通过。
