### PR TITLE
fix(story-player): verticalbg 接入 largebgtween 与 initposmode/错误路径对齐

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -623,8 +623,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   /**
-   * Port scope: `Torappu.AVG.LargeBackgroundPanel._ExecuteGridBG` and
-   * `_LoadImage`, including all-or-nothing asset loading and replacement.
+   * Port scope: `Torappu.AVG.LargeBackgroundPanel._ExecuteGridBG` /
+   * `_ExecuteVerticalBG` / `_ExecuteImage` (selected via the `layout` input)
+   * and `_LoadImage`, including all-or-nothing asset loading and replacement.
    * `Container` composition is the Web adaptation of Unity RectTransforms.
    */
   async setGridBackground(input: GridBackgroundInput): Promise<void> {
@@ -637,19 +638,33 @@ export class PixiStoryRenderer implements StoryRenderer {
     );
     if (!this.app || sessionId !== this.gridBackgroundSessionId) return;
 
-    if (textures.some((texture) => !texture)) return;
+    if (textures.some((texture) => !texture)) {
+      // Native `_LoadImage` logs "Failed to load background: [key]" per tile
+      // and then the command-level "An error occurred when load image {n}."
+      // error before `_ResetPanel()` fails the whole command, wiping whatever
+      // was on screen (all-or-nothing).
+      this.onWarning?.("grid background tiles failed to load; cleared");
+      this.largeBackgroundRoot = null;
+      const stale = [...this.gridBackgroundLayer.children];
+      for (const child of stale) child.removeFromParent();
+      return;
+    }
 
     const root = this.buildGridBackgroundRoot(input, textures as Texture[]);
     const previous = [...this.gridBackgroundLayer.children];
-    this.largeBackgroundRoot = input.layout === "large" ? root : null;
+    // The whole family (largebg / verticalbg / gridbg) shares one `_offset`
+    // container in native, so `largebgtween` must be able to pan vertical and
+    // grid compositions as well; register the root for every layout.
+    this.largeBackgroundRoot = root;
 
     root.alpha = input.fadeMs > 0 ? 0 : 1;
     this.gridBackgroundLayer.addChild(root);
+    // Native runs `_ResetImages()` before the new composition fades in, so a
+    // replacement drops the previous root immediately instead of crossfading
+    // against it; the background layer shows through during the fade.
+    for (const child of previous) child.removeFromParent();
 
-    if (input.fadeMs <= 0) {
-      for (const child of previous) child.removeFromParent();
-      return;
-    }
+    if (input.fadeMs <= 0) return;
 
     const run = this.tween(
       input.fadeMs,
@@ -660,7 +675,6 @@ export class PixiStoryRenderer implements StoryRenderer {
       () => {
         if (!this.app || sessionId !== this.gridBackgroundSessionId) return;
         root.alpha = 1;
-        for (const child of previous) child.removeFromParent();
       },
     );
 
@@ -2164,8 +2178,9 @@ export class PixiStoryRenderer implements StoryRenderer {
       case "cg": {
         return [this.imageLayer];
       }
-      // `LargeBackgroundPanel._PostDisplayKey` registers ck_lbg_1..4 over its
-      // `_images` list, which only `largebg` fills.
+      // `LargeBackgroundPanel._PostDisplayKey` registers ck_lbg_1..4 over the
+      // family-shared `_images` list, which `_LoadImage` fills for largebg /
+      // verticalbg / gridbg alike.
       case "lbg": {
         return this.largeBackgroundRoot ? [this.largeBackgroundRoot] : [];
       }

--- a/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
@@ -22,8 +22,43 @@ function largeBackgroundInitOffset(input: GridBackgroundInput): {
   x: number;
   y: number;
 } {
-  if (input.layout !== "large" || input.initPositionMode === undefined)
-    return { x: 0, y: 0 };
+  if (input.initPositionMode === undefined) return { x: 0, y: 0 };
+
+  if (input.layout === "vertical") {
+    // `_ExecuteVerticalBG` builds widthList = [solidwidth, solidwidth] and
+    // passes the full height list, but the shared `_InitPosition*` helpers
+    // only read entries [0]+[1] (2.7.61: 0x183e7a3b4 / 0x183e7a4fa) — the
+    // same two-tile truncation as the sizeDelta quirk in the builder below.
+    const width = input.solidWidths[0] ?? 0;
+    const heightSum =
+      (input.solidHeights[0] ?? 0) + (input.solidHeights[1] ?? 0);
+    // The conversion baseline is `_offset.sizeDelta.y` (the quirk value
+    // h0+h1), matching the pivot set in the vertical branch of the builder.
+    const centeredY = (nativeY: number) => nativeY + heightSum / 2;
+    switch (input.initPositionMode) {
+      case "center": {
+        return { x: 0, y: centeredY(0) };
+      }
+      case "upperleft": {
+        return {
+          x: (width * 2 - STORY_WIDTH) / 2,
+          y: centeredY((STORY_HEIGHT - heightSum) / 2),
+        };
+      }
+      case "lowercenter": {
+        return { x: 0, y: centeredY((heightSum - STORY_HEIGHT) / 2) };
+      }
+      default: {
+        // default = (width[1] / 2, -height[1] / 2) over the full list.
+        return {
+          x: width / 2,
+          y: centeredY(-(input.solidHeights[1] ?? 0) / 2),
+        };
+      }
+    }
+  }
+
+  if (input.layout !== "large") return { x: 0, y: 0 };
 
   const widths = input.solidWidths;
   const height = input.solidHeights[0] ?? 0;

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1055,13 +1055,27 @@ export class StoryRuntime {
 
       case "verticalbg": {
         // Native port: Torappu.AVG.LargeBackgroundPanel._ExecuteVerticalBG.
-        // It accepts one width and up to four vertically stacked tiles; fadetime
+        // It accepts one solidwidth float and up to four vertically stacked
+        // tiles; fadetime stays literal (unscaled) like the rest of the family.
+        // `initposmode` is always read (default "default") and its offset is
+        // written unconditionally at the end of the load branch
+        // (2.7.61: 0x183e79e3e-0x183e79f8d).
         const imageGroup = toString(this.exactArg(args, "imagegroup"));
         const cgGroup = toString(this.exactArg(args, "cggroup"));
         const groupSelection = resolveGroupedAssetSelection(
           imageGroup,
           cgGroup,
         );
+        const initPositionModeArg = toString(
+          this.exactArg(args, "initposmode"),
+          "default",
+        );
+        const initPositionMode =
+          initPositionModeArg === "center" ||
+          initPositionModeArg === "lowercenter" ||
+          initPositionModeArg === "upperleft"
+            ? initPositionModeArg
+            : "default";
         const fadeMs = Math.max(
           0,
           toNumber(this.exactArg(args, "fadetime"), 0) * 1000,
@@ -1085,7 +1099,16 @@ export class StoryRuntime {
         ).slice(0, imageKeys.length);
 
         if (imageKeys.length === 0) {
-          this.warn("parse", "verticalbg imagegroup is empty");
+          // Native logs "[AVG.VerticalBG] Image {0} of VerticalBG is Empty."
+          // then `_ResetPanel()` wipes the current composition before the
+          // command fails, so mirror the instant clear here.
+          this.warn(
+            "parse",
+            "verticalbg imagegroup is empty",
+            line.lineNumber,
+            line.command,
+          );
+          await this.renderer.clearGridBackground(0, false);
           return "continue";
         }
 
@@ -1094,11 +1117,30 @@ export class StoryRuntime {
           solidWidths.length !== 1 ||
           solidHeights.length !== imageKeys.length
         ) {
+          // Same native error path: LogError ("Image Count ... incorrect." /
+          // "Height of Image ... is empty/incorrect.") + `_ResetPanel()` (an
+          // instant reset without any fade), clearing the previous backdrop.
           this.warn(
             "parse",
             `verticalbg expects width_count * height_count === image_count, got ${solidWidths.length} * ${solidHeights.length} !== ${imageKeys.length}`,
+            line.lineNumber,
+            line.command,
           );
+          await this.renderer.clearGridBackground(0, false);
           return "continue";
+        }
+
+        if (imageKeys.length === 1) {
+          // Native reads heightList[1] for the panel sizeDelta with a raw
+          // get_Item (2.7.61: 0x183e79b2f-0x183e79b7a), so a single tile
+          // aborts with ArgumentOutOfRangeException. We keep rendering with
+          // the quirk-tolerant pivot but warn to stay observable.
+          this.warn(
+            "parse",
+            "verticalbg with a single tile would crash the native client",
+            line.lineNumber,
+            line.command,
+          );
         }
 
         await this.renderer.setGridBackground({
@@ -1106,6 +1148,7 @@ export class StoryRuntime {
           block,
           fadeMs,
           imageKeys,
+          initPositionMode,
           layout: "vertical",
           scaleX: toNumber(this.exactArg(args, "xScale"), 1),
           scaleY: toNumber(this.exactArg(args, "yScale"), 1),

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -311,6 +311,136 @@ describe("PixiStoryRenderer", () => {
     ]);
   });
 
+  it("applies verticalbg initposmode offsets with the two-tile height sum", () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+
+    const build = (initPositionMode: GridBackgroundInput["initPositionMode"]) =>
+      renderer.buildGridBackgroundRoot(
+        {
+          ...createGridBackgroundInput(),
+          imageKeys: ["v1", "v2"],
+          initPositionMode,
+          layout: "vertical",
+          solidHeights: [1454, 1454],
+          solidWidths: [1280],
+          x: 0,
+          y: 0,
+        },
+        [Texture.EMPTY, Texture.EMPTY],
+      );
+
+    const positionOf = (
+      initPositionMode: GridBackgroundInput["initPositionMode"],
+    ) => {
+      const { x, y } = build(initPositionMode).position;
+      return { x, y };
+    };
+
+    // Native builds widthList = [solidwidth, solidwidth] and passes the full
+    // height list, but _InitPosition* only reads entries [0]+[1]; the Pixi
+    // conversion baseline is the same quirk sum (h0+h1) used for the pivot.
+    // center: (0, 0) -> root.position = (640, 360 - 1454).
+    expect(positionOf("center")).toEqual({ x: 640, y: -1094 });
+    // default: (width/2, -height[1]/2) -> root.position = (1280, 360 - 727).
+    expect(positionOf("default")).toEqual({ x: 1280, y: -367 });
+    // lowercenter: (0, (h0+h1-720)/2) -> root.position = (640, 360 - 2548).
+    expect(positionOf("lowercenter")).toEqual({ x: 640, y: -2188 });
+    // upperleft: ((2w-1280)/2, (720-(h0+h1))/2) -> root.position = (1280, 0).
+    expect(positionOf("upperleft")).toEqual({ x: 1280, y: 0 });
+  });
+
+  it("pans verticalbg compositions with largebgtween", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setGridBackground({
+      ...createGridBackgroundInput(),
+      imageKeys: ["v1", "v2"],
+      layout: "vertical",
+      solidHeights: [720, 720],
+      solidWidths: [1280],
+      x: 0,
+      y: 0,
+    });
+
+    // The whole family shares one `_offset` container in native, so the
+    // vertical composition must be registered for largebgtween as well.
+    const root = renderer.gridBackgroundLayer.children[0];
+    expect(renderer.largeBackgroundRoot).toBe(root);
+
+    await renderer.setLargeBackgroundTween({
+      block: false,
+      durationMs: 0,
+      yFrom: 0,
+      yTo: 600,
+    });
+
+    // duration 0 snaps to the target: applyCenteredTransform maps y=600 to
+    // position.y = 360 - 600.
+    expect(root.position.y).toBe(-240);
+  });
+
+  it("clears the layer when a grid background tile fails to load", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    const warnings: string[] = [];
+    renderer.onWarning = (detail: string) => warnings.push(detail);
+    renderer.textureForImageKey = vi
+      .fn()
+      .mockResolvedValueOnce(Texture.EMPTY)
+      .mockResolvedValueOnce(Texture.EMPTY)
+      .mockResolvedValueOnce(Texture.EMPTY)
+      .mockResolvedValue(null);
+
+    const input: GridBackgroundInput = {
+      ...createGridBackgroundInput(),
+      imageKeys: ["v1", "v2"],
+      layout: "vertical",
+      solidHeights: [720, 720],
+      solidWidths: [1280],
+      x: 0,
+      y: 0,
+    };
+    await renderer.setGridBackground(input);
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+
+    await renderer.setGridBackground(input);
+
+    // Native _LoadImage failure logs both errors then _ResetPanel() wipes the
+    // previous composition (all-or-nothing).
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(0);
+    expect(renderer.largeBackgroundRoot).toBeNull();
+    expect(warnings).toContain("grid background tiles failed to load; cleared");
+  });
+
+  it("drops the previous composition immediately when replacing with a fade", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    renderer.tween = vi.fn(async () => {});
+
+    const input: GridBackgroundInput = {
+      ...createGridBackgroundInput(),
+      imageKeys: ["v1", "v2"],
+      layout: "vertical",
+      solidHeights: [720, 720],
+      solidWidths: [1280],
+      x: 0,
+      y: 0,
+    };
+    await renderer.setGridBackground(input);
+    const first = renderer.gridBackgroundLayer.children[0];
+
+    await renderer.setGridBackground({ ...input, fadeMs: 1000 });
+
+    // Native runs _ResetImages() before the new composition fades in, so the
+    // old root is gone at once and the new one starts fully transparent.
+    expect(first.parent).toBeNull();
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+    expect(renderer.gridBackgroundLayer.children[0].alpha).toBe(0);
+  });
+
   it("lays out largebg as exactly two horizontal tiles", () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const textures = [

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1875,6 +1875,7 @@ describe("StoryRuntime", () => {
         block: false,
         fadeMs: 1000,
         imageKeys: ["66_i15_4", "66_i15_3", "66_i15_2", "66_i15_1"],
+        initPositionMode: "default",
         layout: "vertical",
         scaleX: 0.9,
         scaleY: 0.9,
@@ -1907,6 +1908,7 @@ describe("StoryRuntime", () => {
         block: false,
         fadeMs: 0,
         imageKeys: ["69_i12_1", "69_i12_2"],
+        initPositionMode: "default",
         layout: "vertical",
         scaleX: 1,
         scaleY: 1,
@@ -1937,6 +1939,7 @@ describe("StoryRuntime", () => {
         block: false,
         fadeMs: 0,
         imageKeys: ["47_g14_skyovercast_l1", "47_g14_skyovercast_r1"],
+        initPositionMode: "default",
         layout: "vertical",
         scaleX: 1,
         scaleY: 1,
@@ -1964,6 +1967,82 @@ describe("StoryRuntime", () => {
         block: true,
         fadeMs: 3000,
       },
+    ]);
+  });
+
+  it("reads verticalbg initposmode and falls back to default", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[verticalbg(imagegroup="66_i15_4/66_i15_3",solidwidth=1280,solidheight="720/720",initposmode="upperleft")]',
+        '[verticalbg(imagegroup="66_i15_4/66_i15_3",solidwidth=1280,solidheight="720/720",initposmode="diagonal")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // POSITION_INIT_FUNCTION only knows default/center/lowercenter/upperleft;
+    // anything else still lands on the "default" math.
+    expect(
+      renderer.gridBackgroundCalls.map((input) => input.initPositionMode),
+    ).toEqual(["upperleft", "default"]);
+  });
+
+  it("clears the layer when verticalbg validation fails", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        // Five tiles exceed native's SafeCount > 4 check; _ResetPanel() wipes
+        // the previous composition without any fade.
+        '[verticalbg(imagegroup="a/b/c/d/e",solidwidth=1280,solidheight="720/720/720/720/720")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    expect(renderer.gridBackgroundCalls).toEqual([]);
+    expect(renderer.gridBackgroundClearCalls).toEqual([
+      { block: false, fadeMs: 0 },
+    ]);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        command: "verticalbg",
+        type: "parse",
+      }),
+    ]);
+  });
+
+  it("warns but still renders a single-tile verticalbg", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[verticalbg(imagegroup="solo",solidwidth=1280,solidheight="720")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    // Native crashes on heightList[1] (raw get_Item in the sizeDelta quirk);
+    // the web port keeps rendering and only reports the divergence.
+    expect(renderer.gridBackgroundCalls).toHaveLength(1);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        command: "verticalbg",
+        type: "parse",
+      }),
     ]);
   });
 


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `verticalbg` 命令移植中的行为差异（P0×1、P1×1、P2×4、P3 注释×1）。依据是对明日方舟官服客户端（2.7.61 / build 2761，Unity IL2CPP）GameAssembly.dll 的 IDA 反编译复核，关键结论在下文直接给出，不依赖外部文档。

## 背景：native 的 LargeBackgroundPanel 家族（2.7.61 逆向结论）

- 家族四命令（largebg / largebgtween / verticalbg / gridbg）共享**同一个 `_offset` RectTransform 容器**；`largebgtween` 的 executor `Torappu.AVG.LargeBackgroundPanel._ExecuteImageTween`（VA `0x183e777a0`）直接对 `_offset` 做 `DOLocalMove`/`DOScale`，**不区分拼图来自哪个命令**——verticalbg 拼好的长图同样能被卷动。
- `_ExecuteVerticalBG`（VA `0x183e79030`）：参数为 `fadetime`/`block`/`imagegroup`/`solidwidth`（**单浮点**，带引号数字串经 `Convert.ToSingle` 也可读，`0x183e458d0`）/`solidheight`（字符串列表，`Single.TryParse` 允许千分位）/`x`/`y`/`xScale`/`yScale`/`initposmode`（默认 `"default"`）。
- **错误路径**：块数 > 4（`0x183e799e0`）、子图空、高度解析失败、任一 `_LoadImage` 失败，都是 LogError + **`_ResetPanel()`**（= `_ResetImages` + CanvasGroup `alpha=0`，**清掉当前显示**）+ 返回 false。
- **加载分支**先 `_ResetImages()`（旧拼图瞬间消失）再整体 alpha 0→1 淡入，**不是 crossfade**。
- **initposmode**（`0x183e79e3e`–`0x183e79f8d`）：**无条件**写 `_initOffset.localPosition`（key 不匹配也写 (0,0)）；构造 `widthList = [solidwidth, solidwidth]`、传完整 heightList，但 `_InitPosition*`（`0x183e7a160`/`0x183e7a220`/`0x183e7a320`/`0x183e7a410`）的求和固定为 `get_Item(0)+get_Item(1)` **不遍历列表**：`center=(0,0)`、`default=(width[1]/2, -height[1]/2)`、`lowercenter=(0,(h0+h1-720)/2)`、`upperleft=((w0+w1-1280)/2,(720-(h0+h1))/2)`。
- **sizeDelta quirk**：`_offset.sizeDelta=(solidwidth, heightList[0]+heightList[1])`（`0x183e79b2f`–`0x183e79b7a`，裸 `get_Item`）——N==1 时 `get_Item(1)` 越界、命令中断；N=3/4 时面板高只含前两块。

## 修复内容

### 1. P0：verticalbg 之后 `largebgtween` 失效

- **native 行为**：`_ExecuteImageTween` 对家族共享 `_offset` 生效；主线 16-18 章全部 9 处 N=4 verticalbg 都紧跟 `[largebgtween]` 做长图卷动。
- **前端问题**：`setGridBackground` 仅在 `layout === "large"` 时登记 `largeBackgroundRoot`，vertical/grid 布局显式置 null，`setLargeBackgroundTween` 随即空操作，卷动动画全部丢失。
- **修复**：对所有 layout 登记 root（`isActiveLargeBackground` 原有的 `root.parent === gridBackgroundLayer` 会话守卫继续生效）。

### 2. P1：`initposmode` 未实现

- **native 行为**：恒读该参数（默认 `"default"`），加载分支末尾无条件写 `_initOffset`；upperleft/lowercenter 只按前两块高计算。
- **前端问题**：verticalbg 分支不读该参数，`largeBackgroundInitOffset` 对 `layout !== "large"` 恒返回 `{0,0}`。
- **修复**：把 largebg 已有的 initPositionMode 通道下沉到 vertical 布局：runtime 读取并归一化（`center`/`lowercenter`/`upperleft` 之外一律回落 `default`）；`SceneGeometry` 新增 vertical 分支，按 native `[0]+[1]` 截断公式计算，y 换算基线取 quirk 值 `h0+h1`（与 pivot 的 sizeDelta 复刻一致）。

### 3. P2：校验失败不清屏

- **native 行为**：count>4 / 子图空 / 高度解析失败 → LogError + `_ResetPanel()`（瞬时清屏）+ false。
- **前端行为**：warn 后 `return "continue"`，旧长图保留。
- **修复**：这两个失败分支改为 warn + `clearGridBackground(0, false)`（瞬时清屏，无 fade），warn 同时补上 `lineNumber`/`command` 以保持可观测性。

### 4. P2：加载失败静默

- **native 行为**：`_LoadImage` 失败 → `"Failed to load background: [key]"` + `"[AVG.VerticalBG] An error occurred when load image {n}."` + `_ResetPanel()` + false。
- **前端行为**：纹理加载失败仅逐条 onWarning，`setGridBackground` 静默 return，旧内容保留。
- **修复**：`textures.some(null)` 分支补充整体失败告警并清空 `gridBackgroundLayer`、置空 `largeBackgroundRoot`（all-or-nothing）。

### 5. P2：替换过渡语义

- **native 行为**：先 `_ResetImages()`（旧长图瞬间消失）再整体 alpha 0→1 淡入。
- **前端行为**：crossfade（旧 root 保留至新 root 淡入完成）。
- **修复**：fadetime>0 直接替换时先移除旧 root 再淡入。现网样本替换均 fadetime=0（即时）或先清屏，实际无视觉变化。

### 6. P2：N==1 行为分歧

- **native 行为**：`heightList.get_Item(1)` 越界 → `ArgumentOutOfRangeException`，命令中断。
- **前端行为**：`pivotHeight = h0 + (h1 ?? 0)` 容错，N==1 正常渲染。
- **修复**：保留容错渲染（比 native 更合理，历史文档也建议不复刻崩溃），但 N==1 时打一条 warning 保持可观测性。

### 7. P3：provenance 注释补全

- runtime.ts verticalbg 注释在 "fadetime" 一词后句子截断，补全为「fadetime stays literal (unscaled)」并注明 initposmode 无条件写入语义；`setGridBackground` 的 port scope 注释补上 `_ExecuteVerticalBG`/`_ExecuteImage`；focus 目标 `lbg` 的注释更正为家族共用 `_images`（`_PostDisplayKey` 对三种拼图命令都注册 ck_lbg_1..4）。

**有意不改**：`solidwidth<=0` 被拒绝（合理防御，保留）；空面板清屏的 block 时序（现网无该组合）；`parseNumberSequence` 非数字段静默过滤（与 gridbg 共有逻辑，可接受）。

## 验证用剧情文件

生产剧情文件位于本地 `torappu/storage/asset/gamedata/latest/story`：

- **修复 1（P0，largebgtween 卷动）**：
  - `obt/main/level_main_16-18_end.txt` 356-357 行：N=4 verticalbg + `[largebgtween(duration=30, yFrom=1800, yTo=800)]`（30 秒长图上卷）；
  - 同文件 660-661 行：`duration=0` 瞬时跳位（yFrom=1240→yTo=0）；
  - `activities/act40side/level_act40side_09_end.txt` 871-872 行：`duration=60, yFrom=2160, yTo=300`；
  - `activities/act43side/level_act43side_08_end.txt` 811-812 行。
- **既有兼容回归（本 PR 不得破坏）**：
  - N=2 千分位高度：`obt/main/level_main_14-20_end.txt` 1161 行（`solidheight="1,454/1,454"`）；
  - 带引号宽度 + cggroup 路由：`activities/act46side/level_act46side_02_beg.txt` 120 行、`activities/act48side/level_act48side_08_end.txt` 447 行（`solidwidth="1600"`）；
  - 裸 `[verticalbg]` 清屏：`obt/main/level_main_16-18_end.txt` 680 行。
- **修复 2（initposmode）**：当前 story 语料中 verticalbg 带 `initposmode` 为 0 命中，**前瞻对齐，由单测锁定**：`tests/renderer.spec.ts` "applies verticalbg initposmode offsets with the two-tile height sum"（四种模式的坐标断言）、`tests/runtime.spec.ts` "reads verticalbg initposmode and falls back to default"。
- **修复 3/4/5/6**：现网语料无 >4 块、无加载失败、替换均 fadetime=0 或先清屏、无 N==1 样本，**前瞻对齐，由单测锁定**：`tests/runtime.spec.ts` "clears the layer when verticalbg validation fails"、"warns but still renders a single-tile verticalbg"；`tests/renderer.spec.ts` "clears the layer when a grid background tile fails to load"、"drops the previous composition immediately when replacing with a fade"、"pans verticalbg compositions with largebgtween"。

## 测试

- `pnpm test`：20 个文件 **229 用例全部通过**（基线 222 + 新增 7）。
- `pnpm exec vue-tsc -b`：通过。
- `pnpm exec eslint`（全部改动文件）：通过。
