### PR TITLE
fix(story-player): gridbg 接入家族共享 largebgtween 根并补齐 initposmode/失败清屏

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -623,9 +623,11 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   /**
-   * Port scope: `Torappu.AVG.LargeBackgroundPanel._ExecuteGridBG` and
-   * `_LoadImage`, including all-or-nothing asset loading and replacement.
-   * `Container` composition is the Web adaptation of Unity RectTransforms.
+   * Port scope: `Torappu.AVG.LargeBackgroundPanel._ExecuteGridBG` (plus the
+   * `_ExecuteImage`/`_ExecuteVerticalBG` siblings that share this path via
+   * `layout`) and the family `_LoadImage`, including all-or-nothing asset
+   * loading. `Container` composition is the Web adaptation of Unity
+   * RectTransforms.
    */
   async setGridBackground(input: GridBackgroundInput): Promise<void> {
     const sessionId = ++this.gridBackgroundSessionId;
@@ -637,19 +639,34 @@ export class PixiStoryRenderer implements StoryRenderer {
     );
     if (!this.app || sessionId !== this.gridBackgroundSessionId) return;
 
-    if (textures.some((texture) => !texture)) return;
+    if (textures.some((texture) => !texture)) {
+      // Native `_LoadImage` failure logs "Failed to load background: [key]"
+      // and "[AVG.GridBG] An error occurred when load image {idx}." (2.7.61:
+      // 0x183e76f79-0x183e77675), then `_ResetPanel()` drops the whole
+      // puzzle instead of keeping the previous one on screen.
+      const missingKeys = input.imageKeys.filter(
+        (_, index) => !textures[index],
+      );
+      this.onWarning?.(`missing grid background: ${missingKeys.join("/")}`);
+      await this.clearGridBackground(0);
+      return;
+    }
 
     const root = this.buildGridBackgroundRoot(input, textures as Texture[]);
     const previous = [...this.gridBackgroundLayer.children];
-    this.largeBackgroundRoot = input.layout === "large" ? root : null;
+    // `_ExecuteImageTween` (largebgtween) tweens the family-shared `_offset`
+    // container regardless of which executor filled it (2.7.61: 0x183e77a94),
+    // so every layout must register itself as the tween target.
+    this.largeBackgroundRoot = root;
+    // Native calls `_ResetImages()` before assembling the new puzzle
+    // (0x183e76b21), so the old one disappears instantly and the replacement
+    // fades in over the now-empty panel — there is no cross-fade.
+    for (const child of previous) child.removeFromParent();
 
     root.alpha = input.fadeMs > 0 ? 0 : 1;
     this.gridBackgroundLayer.addChild(root);
 
-    if (input.fadeMs <= 0) {
-      for (const child of previous) child.removeFromParent();
-      return;
-    }
+    if (input.fadeMs <= 0) return;
 
     const run = this.tween(
       input.fadeMs,
@@ -660,7 +677,6 @@ export class PixiStoryRenderer implements StoryRenderer {
       () => {
         if (!this.app || sessionId !== this.gridBackgroundSessionId) return;
         root.alpha = 1;
-        for (const child of previous) child.removeFromParent();
       },
     );
 
@@ -2165,7 +2181,8 @@ export class PixiStoryRenderer implements StoryRenderer {
         return [this.imageLayer];
       }
       // `LargeBackgroundPanel._PostDisplayKey` registers ck_lbg_1..4 over its
-      // `_images` list, which only `largebg` fills.
+      // `_images` list; largebg/gridbg/verticalbg all fill those slots, so
+      // whichever family root is active is the target.
       case "lbg": {
         return this.largeBackgroundRoot ? [this.largeBackgroundRoot] : [];
       }

--- a/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
@@ -22,10 +22,49 @@ function largeBackgroundInitOffset(input: GridBackgroundInput): {
   x: number;
   y: number;
 } {
-  if (input.layout !== "large" || input.initPositionMode === undefined)
+  if (
+    (input.layout !== "large" && input.layout !== "grid") ||
+    input.initPositionMode === undefined
+  )
     return { x: 0, y: 0 };
 
   const widths = input.solidWidths;
+
+  if (input.layout === "grid") {
+    // Port of `LargeBackgroundPanel` POSITION_INIT_FUNCTION for `_ExecuteGridBG`
+    // (2.7.61: applied unconditionally at 0x183e77451-0x183e775ce). Native
+    // passes the full width list plus `heightList2 = [heightList[0],
+    // heightList[2]]`, so the `get_Item(0)+get_Item(1)` sums in
+    // `_InitPositionUpperLeft`/`_InitPositionLowerCenter` collapse to
+    // w0+w1 / h0+h1, and `_InitPositionDefault` reads
+    // `(widthList[1]/2, -heightList2[1]/2)` = (w1/2, -h1/2) — the half-tile
+    // offset that anchors the default view on the top row. The `_offset` rect
+    // (`sizeDelta` = (w0+w1, h0+h1), 0x183e76ef8) wraps the 2×2 puzzle
+    // exactly and is center-pivoted, so unlike the "large" row below there is
+    // no pivot compensation: the native Vector2 ports straight in and the
+    // position formula flips y for Pixi's downward axis.
+    const height0 = input.solidHeights[0] ?? 0;
+    const height1 = input.solidHeights[1] ?? 0;
+    const totalHeight = height0 + height1;
+    switch (input.initPositionMode) {
+      case "center": {
+        return { x: 0, y: 0 };
+      }
+      case "upperleft": {
+        return {
+          x: ((widths[0] ?? 0) + (widths[1] ?? 0) - STORY_WIDTH) / 2,
+          y: (STORY_HEIGHT - totalHeight) / 2,
+        };
+      }
+      case "lowercenter": {
+        return { x: 0, y: (totalHeight - STORY_HEIGHT) / 2 };
+      }
+      default: {
+        return { x: (widths[1] ?? 0) / 2, y: -height1 / 2 };
+      }
+    }
+  }
+
   const height = input.solidHeights[0] ?? 0;
   // Unity's children use a top-left anchor/pivot, while the flattened Pixi
   // root uses a centered pivot. The latter already contributes -height / 2,

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -997,6 +997,21 @@ export class StoryRuntime {
           imageGroup,
           cgGroup,
         );
+        // Native always reads `initposmode` (default "default", 2.7.61:
+        // 0x183e76959) and unconditionally rewrites `_initOffset.localPosition`
+        // after assembling the puzzle (0x183e77451-0x183e775ce): a key miss
+        // writes Vector2.zero, the same offset the "center" mode produces.
+        const initPositionModeArg = toString(
+          this.exactArg(args, "initposmode"),
+          "default",
+        );
+        const initPositionMode =
+          initPositionModeArg === "default" ||
+          initPositionModeArg === "upperleft" ||
+          initPositionModeArg === "lowercenter" ||
+          initPositionModeArg === "center"
+            ? initPositionModeArg
+            : "center";
         const fadeMs = Math.max(
           0,
           toNumber(this.exactArg(args, "fadetime"), 0) * 1000,
@@ -1022,6 +1037,10 @@ export class StoryRuntime {
 
         if (imageKeys.length === 0) {
           this.warn("parse", "gridbg imagegroup is empty");
+          // Native treats every empty tile name as a fatal parse error and
+          // calls `_ResetPanel()` (2.7.61: 0x183e77675), which drops the
+          // current picture instead of keeping it around.
+          await this.renderer.clearGridBackground(0);
           return "continue";
         }
 
@@ -1034,6 +1053,10 @@ export class StoryRuntime {
             "parse",
             `gridbg expects ${imageKeys.length} widths/heights, got ${solidWidths.length}/${solidHeights.length}`,
           );
+          // Native logs "[AVG.GridBG] Image Count {0} of GridBG is
+          // incorrect." / "... is empty." then clears the panel via
+          // `_ResetPanel()` and returns false (2.7.61: 0x183e76cb8-0x183e77675).
+          await this.renderer.clearGridBackground(0);
           return "continue";
         }
 
@@ -1042,6 +1065,7 @@ export class StoryRuntime {
           block,
           fadeMs,
           imageKeys,
+          initPositionMode,
           layout: "grid",
           scaleX: toNumber(this.exactArg(args, "xScale"), 1),
           scaleY: toNumber(this.exactArg(args, "yScale"), 1),

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -343,6 +343,163 @@ describe("PixiStoryRenderer", () => {
     ]);
   });
 
+  it("applies gridbg initposmode offsets in the centered pivot space", () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const build = (initPositionMode: string) =>
+      renderer.buildGridBackgroundRoot(
+        {
+          ...createGridBackgroundInput(),
+          initPositionMode,
+          layout: "grid",
+          scaleX: 1,
+          scaleY: 1,
+          solidHeights: [600, 640],
+          solidWidths: [1000, 800],
+          x: 0,
+          y: 0,
+        },
+        [Texture.EMPTY, Texture.EMPTY, Texture.EMPTY, Texture.EMPTY],
+      );
+
+    const positions = (mode: string) => {
+      const { position } = build(mode);
+      return { x: position.x, y: position.y };
+    };
+
+    // POSITION_INIT_FUNCTION ports (2.7.61: 0x183e77451): default =
+    // (w1/2, -h1/2), center = (0,0), upperleft = ((w0+w1-1280)/2,
+    // (720-(h0+h1))/2), lowercenter = (0, (h0+h1-720)/2). The `_offset` rect
+    // wraps the 2×2 puzzle exactly, so the native Vector2 needs no extra
+    // pivot compensation — only the y flip done by the position formula.
+    expect(positions("default")).toEqual({ x: 1040, y: 680 });
+    expect(positions("center")).toEqual({ x: 640, y: 360 });
+    expect(positions("upperleft")).toEqual({ x: 900, y: 620 });
+    expect(positions("lowercenter")).toEqual({ x: 640, y: 100 });
+
+    // Corpus shape (level_main_16-01_beg.txt:112): 1280/1280 × 720/720 with
+    // default mode anchors the view on the top row: the half-tile offset
+    // (640, -360) puts the puzzle's top edge exactly on the canvas top.
+    const corpusRoot = renderer.buildGridBackgroundRoot(
+      {
+        ...createGridBackgroundInput(),
+        initPositionMode: "default",
+        layout: "grid",
+        scaleX: 1,
+        scaleY: 1,
+        x: -105,
+        y: 0,
+      },
+      [Texture.EMPTY, Texture.EMPTY, Texture.EMPTY, Texture.EMPTY],
+    );
+    expect(corpusRoot.position.x).toBe(1175);
+    expect(corpusRoot.position.y).toBe(720);
+  });
+
+  it("registers every family layout as the largebgtween target", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    for (const layout of ["grid", "vertical", "large"] as const) {
+      await renderer.setGridBackground({
+        ...createGridBackgroundInput(),
+        imageKeys: ["t1", "t2", "t3", "t4"],
+        layout,
+      });
+      const root = renderer.gridBackgroundLayer.children.at(-1);
+      // `LargeBackgroundPanel._ExecuteImageTween` drives the family-shared
+      // `_offset`, so gridbg/verticalbg puzzles must be tweenable too.
+      expect(renderer.largeBackgroundRoot).toBe(root);
+      expect(root.parent).toBe(renderer.gridBackgroundLayer);
+    }
+  });
+
+  it("moves a gridbg puzzle with largebgtween", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setGridBackground({
+      ...createGridBackgroundInput(),
+      scaleX: 1,
+      scaleY: 1,
+      imageKeys: ["l1", "r1", "l2", "r2"],
+      initPositionMode: "default",
+      layout: "grid",
+      x: 0,
+      y: 0,
+    });
+
+    // level_main_16-01_beg.txt:112-113 pans the skystarry grid with
+    // [largebgtween(duration=40,yFrom=720,yTo=360)]. Native `_offset` is a
+    // child of `_initOffset`, so the tween moves only the command-space
+    // offset while the default half-tile init offset (640, -360) stays put:
+    // y=720 puts the puzzle center on the canvas top edge, i.e. the visible
+    // band becomes the bottom tile row.
+    await renderer.setLargeBackgroundTween({ durationMs: 0, yTo: 720 });
+
+    const root = renderer.largeBackgroundRoot;
+    expect(root.position.x).toBe(1280);
+    expect(root.position.y).toBe(0);
+  });
+
+  it("warns and clears the panel when a grid tile fails to load", async () => {
+    const warnings: string[] = [];
+    const renderer = new PixiStoryRenderer(createContext(), (warning) =>
+      warnings.push(warning),
+    ) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi
+      .fn()
+      .mockResolvedValueOnce(Texture.EMPTY)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue(Texture.EMPTY);
+    const staleRoot = new Container();
+    renderer.gridBackgroundLayer.addChild(staleRoot);
+    renderer.largeBackgroundRoot = staleRoot;
+
+    await renderer.setGridBackground({
+      ...createGridBackgroundInput(),
+      imageKeys: ["l1", "r1", "l2", "r2"],
+      layout: "grid",
+    });
+
+    // Native `_LoadImage` failure logs and calls `_ResetPanel()`: the stale
+    // picture is dropped instead of kept.
+    expect(warnings).toEqual(["missing grid background: r1"]);
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(0);
+    expect(renderer.largeBackgroundRoot).toBeNull();
+  });
+
+  it("removes the previous grid root before fading in the replacement", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    renderer.tween = vi.fn(() => new Promise(() => {}));
+
+    await renderer.setGridBackground({
+      ...createGridBackgroundInput(),
+      fadeMs: 1000,
+      imageKeys: ["l1", "r1", "l2", "r2"],
+      layout: "grid",
+    });
+    const firstRoot = renderer.gridBackgroundLayer.children.at(-1);
+
+    await renderer.setGridBackground({
+      ...createGridBackgroundInput(),
+      fadeMs: 1000,
+      imageKeys: ["n1", "n2", "n3", "n4"],
+      layout: "grid",
+    });
+    const secondRoot = renderer.gridBackgroundLayer.children.at(-1);
+
+    // Native `_ResetImages()` runs before assembly, so the old puzzle
+    // vanishes instantly — no cross-fade with the fading-in replacement.
+    expect(firstRoot.parent).toBeNull();
+    expect(renderer.gridBackgroundLayer.children).toEqual([secondRoot]);
+    expect(secondRoot.alpha).toBe(0);
+  });
+
   it("applies largebgtween in largebg transform space", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const root = renderer.buildGridBackgroundRoot(

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1823,6 +1823,7 @@ describe("StoryRuntime", () => {
           "47_g14_skyovercast_l2",
           "47_g14_skyovercast_r2",
         ],
+        initPositionMode: "default",
         layout: "grid",
         scaleX: 0.5,
         scaleY: 0.75,
@@ -1834,6 +1835,48 @@ describe("StoryRuntime", () => {
     ]);
     expect(renderer.gridBackgroundClearCalls).toEqual([]);
     expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("maps gridbg initposmode and treats unknown modes as zero offset", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[gridbg(imagegroup="a/b/c/d",solidwidth="1280/1280",solidheight="720/720",initposmode="upperleft")]',
+        '[gridbg(imagegroup="a/b/c/d",solidwidth="1280/1280",solidheight="720/720",initposmode="unknown")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(
+      renderer.gridBackgroundCalls.map((input) => input.initPositionMode),
+    ).toEqual(["upperleft", "center"]);
+  });
+
+  it("clears the grid panel when gridbg validation fails", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[gridbg(imagegroup="a/b/c",solidwidth="1280/1280",solidheight="720/720")]',
+        '[gridbg(imagegroup="a/b/c/d",solidwidth="1280",solidheight="720/720")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // Native `_ResetPanel()` (2.7.61: 0x183e77675) drops the current picture
+    // on every malformed grid instead of keeping the previous puzzle.
+    expect(renderer.gridBackgroundCalls).toEqual([]);
+    expect(renderer.gridBackgroundClearCalls).toEqual([
+      { block: false, fadeMs: 0 },
+      { block: false, fadeMs: 0 },
+    ]);
   });
 
   it("clears gridbg independently and supports legacy blok typo", async () => {


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `gridbg` 命令移植中的行为差异(1×P0、1×P1、3×P2),依据是对明日方舟官服客户端 2.7.61 / build 2761 GameAssembly.dll 的 IDA 反编译复核。`gridbg` 在当前 story 资源中共 206 处(103 处加载 + 103 处裸 `[gridbg]` 清屏),集中在主线 14–17 章、act49side/act46side 与 memory 剧情,是高频在用命令。

## 背景:native 的 gridbg 机制(2.7.61 / build 2761 IDA 反编译复核)

- 注册:`Torappu.AVG.LargeBackgroundPanel.GetExecutors`(VA `0x183e758e0`)在同一张 Dictionary 里注册 `largebg`/`largebgtween`/`verticalbg`/`gridbg` 四个 key,四条命令共享同一套 `_initOffset`/`_offset` 双层容器与 4 个 `_images` 槽位。
- `LargeBackgroundPanel._ExecuteGridBG`(VA `0x183e76290`):参数 `fadetime`(0)/`block`(false)/`imagegroup`("")/`solidwidth`("")/`solidheight`("")/`x`(0)/`y`(0)/`xScale`(1)/`yScale`(1)/`initposmode`("default"),明文 key、大小写敏感;`fadetime<=0` 强制非阻塞且不过 `CalculateFadetime`;2×2 校验(4 子图、宽按 `idx%2` 取、高按 `idx/2` 取);整体尺寸 `_offset.sizeDelta = (w0+w1, h0+h1)`。
- **initposmode**(`0x183e77451`-`0x183e775ce`):native 恒读该参数并在拼装末尾**无条件**写 `_initOffset.localPosition`,查 `POSITION_INIT_FUNCTION`(`.cctor` `0x183e7b120`)四种模式,传参为(widthList 完整列表, `[h0, h1]`):`default=(w1/2, -h1/2)`(半格偏移)、`center=(0,0)`、`upperleft=((w0+w1-1280)/2, (720-(h0+h1))/2)`、`lowercenter=(0, (h0+h1-720)/2)`(求和固定 `get_Item(0)+get_Item(1)`,`0x183e7a3b4`/`0x183e7a4fa`);**key 未命中也写 (0,0)**,效果同 center。grid 的 `_offset` 矩形(`sizeDelta=(w0+w1, h0+h1)`,`0x183e76ef8`)恰好包裹 2×2 拼图且中心 pivot,因此该 Vector2 可直接进 Pixi 居中 pivot 坐标系(仅翻 y),无需 large 布局那种 +h/2 pivot 补偿。
- **家族共享 `_offset`**:`_ExecuteImageTween`(largebgtween,VA `0x183e777a0`)的 tween 目标是 `this._offset`(`0x183e77a94`),不区分拼图来自哪个命令——**当前语料共 89 处 gridbg 加载后紧跟 `[largebgtween]` 做镜头卷动**(主线 14–17 章全部 gridbg 用法均如此)。
- 失败路径:count≠4 / 子图空 / `TryParse` 失败 / `_LoadImage` 失败(VA `0x183e7a570`,失败日志 2.7.61 已是 "Failed to load background: [{0}]")→ LogError + `_ResetPanel()`(= `_ResetImages` + CanvasGroup alpha=0,**清掉当前显示**)+ 返回 false(`0x183e76cb8`-`0x183e77675`)。
- 替换过渡:加载分支先 `_ResetImages()`(`0x183e76b21`,旧拼图瞬间消失),新拼图 CanvasGroup alpha 0→1 淡入,无交叉淡化。

## 修复内容

### 1. gridbg 之后 `largebgtween` 完全失效(P0)

- **前端问题**:`setGridBackground` 仅在 `layout === "large"`(largebg)时登记 `largeBackgroundRoot`,grid/vertical 布局显式置 null,`setLargeBackgroundTween` 随即 return,所有卷动动画丢失。
- **修复**:`PixiStoryRenderer.setGridBackground` 对所有 layout 登记根容器(`isActiveLargeBackground` 原有的 `gridBackgroundLayer` 挂载校验继续兜底)。`largebgtween` 经 `readCenteredTransform`/`applyCenteredTransform` 只动命令坐标系,对应 native `_offset` 是 `_initOffset` 子节点的复合关系,与修复 2 组合后取景/卷动语义完整。

### 2. `initposmode` 未实现(P1)

- **前端问题**:gridbg 分支不读该参数,`SceneGeometry.largeBackgroundInitOffset` 对 grid 布局直接返回 `{0,0}`,所有语料 gridbg 的取景比 native 偏了半格 `(w1/2, h1/2)`。
- **修复**:runtime 的 gridbg 分支读取 `initposmode`(未知值按 native 写 `Vector2.zero` 的语义映射为 "center");`SceneGeometry.largeBackgroundInitOffset` 下沉 grid 布局四种公式,并注释说明"无需 +h/2 补偿"的坐标系推导。

### 3. 校验失败不清屏(P2)

- **前端问题**:count≠4 / 子图空 / 数字解析失败时 warn 后直接 continue,旧拼图保留显示;native 是 `_ResetPanel()` 清屏 + 非阻塞返回。
- **修复**:两个校验失败分支(子图段全被过滤 / 数量校验失败)warn 后调 `clearGridBackground(0)` 立即清屏。

### 4. 加载失败静默(P2)

- **前端问题**:`setGridBackground` 在任一纹理为空时静默 return,旧内容保留、无整体失败上报。
- **修复**:补 `missing grid background: <keys>` 整体告警(renderer onWarning)+ 清屏。

### 5. 替换过渡语义(P2)

- **前端问题**:旧 root 保留到新 root 淡入完成(变成交叉淡化);native 是旧拼图瞬间消失、新拼图单独淡入。
- **修复**:新 root 加入前先移除层内旧 root。现网样本不受影响(直接替换均 fadetime=0 或发生在黑色 Blocker 之后)。

### 附带

- 更正 `resolveFocusTargets("lbg")` 上方过时注释("`_images` 仅 largebg 填充"——家族三命令都填)。
- `setGridBackground` 的 port-scope 注释补上经 `layout` 共用此路径的 `_ExecuteImage`/`_ExecuteVerticalBG`。
- P3 项(非数字段静默过滤 / 资源键小写化的 Web 适配 / 空面板清屏 block 时序)按 review 结论维持现状,未改动。

## 验证用剧情文件

生产剧情文件位于本地 torappu 语料 `storage/asset/gamedata/latest/story`:

- **修复 1(P0)**:`obt/main/level_main_16-01_beg.txt` 112–113 行——`[gridbg(...x=-105, fadetime=1)]` 紧跟 `[largebgtween(duration=40,yFrom=720,yTo=360)]`,修复前卷动完全不发生;`obt/main/level_main_16-11_end.txt` 127–128 行(duration=60);`obt/memory/story_blkkgt_1_1.txt` 8–9 行(xFrom=0→xTo=-200 横向漂移)。全语料共 89 处 gridbg 加载后紧跟 largebgtween。
- **修复 2(P1)**:story 资源中 `initposmode` 0 命中(全语料 grep 无一处),**前瞻对齐,由单测锁定**:`tests/runtime.spec.ts`「maps gridbg initposmode and treats unknown modes as zero offset」、`tests/renderer.spec.ts`「applies gridbg initposmode offsets in the centered pivot space」(含 `level_main_16-01_beg.txt:112` 参数形状的取景断言)与「moves a gridbg puzzle with largebgtween」。
- **修复 3(P2)**:语料中无坏参数 gridbg(206 处全部合规),**前瞻对齐,由单测锁定**:`tests/runtime.spec.ts`「clears the grid panel when gridbg validation fails」。
- **修复 4(P2)**:语料资源齐全、无加载失败场景,**前瞻对齐,由单测锁定**:`tests/renderer.spec.ts`「warns and clears the panel when a grid tile fails to load」。
- **修复 5(P2)**:语料中 gridbg 直接替换均为 fadetime=0 或发生在黑色 Blocker 后(如 `obt/memory/story_cetsyr_1_1.txt` 395–402 行,两次加载均无淡入且被 Blocker 遮挡),**无可见影响,由单测锁定**:`tests/renderer.spec.ts`「removes the previous grid root before fading in the replacement」。

## 测试

- `pnpm test`:20 个文件 229 个用例全部通过(基线 222 + 新增 7)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint <改动文件>`:无告警。
- `STORY_CORPUS_ROOT=<torappu story> pnpm test:story-log`(全语料 Log All 回归 + 独立 oracle 对拍):通过。
