### PR TITLE
fix(story-player): charslot 对齐 2.7.61 原生语义(char_empty/focus 缺省/crossfade/transform 保持/end=false)

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -95,6 +95,37 @@ function clamp01(value: number): number {
   return Math.max(0, Math.min(1, value));
 }
 
+/**
+ * Which `charslot` branches feed posfrom/posto into `SlotMoveChar`, i.e. move
+ * from the absolute `posfrom` to the absolute `posto`. `_UpdateSeqWithParam`
+ * (0x183e53940) only calls `_GenCharslotMove` when `action` is empty, and
+ * `_GenSlotActionTw` (0x183e4f3b0) re-enters it for `shakemove`, plus for
+ * `jump` when `NeedSkipAnimation(duration)` holds. `zoom` and `shake` never
+ * touch the offset, so their posfrom/posto are inert. `move`/`setpos` are Web
+ * extensions kept on the plain-move path.
+ */
+function characterSlotUsesAbsoluteMove(input: CharacterSlotInput): boolean {
+  switch (input.action) {
+    case undefined:
+    case "move":
+    case "setpos":
+    case "shakemove": {
+      return true;
+    }
+    case "jump": {
+      return (input.durationMs ?? 0) <= 0;
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+/** `action="jump"` with a real duration: CharJump lands at current + posTo. */
+function characterSlotUsesRelativeMove(input: CharacterSlotInput): boolean {
+  return input.action === "jump" && (input.durationMs ?? 0) > 0;
+}
+
 /** Raw float color channel to the 8-bit tint write (the only clamp point). */
 function tintChannel(value: number): number {
   return Math.round(clamp01(value) * 255);
@@ -252,16 +283,6 @@ export class PixiStoryRenderer implements StoryRenderer {
   private readonly context: Context;
   private readonly charLayer = this.layers.characters;
   private readonly characterSlots = new Map<string, CharacterRenderState>();
-  /**
-   * `charslot` `end=false` inputs waiting for a later end=true command on the
-   * same slot (native caches the assembled per-slot Sequence in
-   * `_GetCachedSlotSeq` and only plays it when a command with `end=true`
-   * appends to it).
-   */
-  private readonly deferredCharacterSlots = new Map<
-    string,
-    CharacterSlotInput[]
-  >();
   private readonly cutinLayer = this.layers.cutins;
   private readonly cutinPanel: CharacterCutinPanel;
 
@@ -1619,68 +1640,22 @@ export class PixiStoryRenderer implements StoryRenderer {
     }
   }
 
+  /**
+   * Native `_ExecuteCharslot` assembles every tween into the slot's cached
+   * Sequence and plays it right away: `_GetCachedSlotSeq` (0x183e4f830) hands
+   * back a fresh `DOTween.Sequence()` whenever the previous one already ran,
+   * and `DOTween.Sequence()` (0x184109110) starts it playing because
+   * `defaultAutoPlay` is `AutoPlay.All` (cctor 0x18410b0e0). `end=false` only
+   * skips the `OnComplete(_SetSeqPlayed)` + redundant `Play()` pair at
+   * 0x183e4e501, which in turn is what gates `isblock` (0x183e4e56f) -- it
+   * never defers the animation, so nothing is queued here.
+   */
   private async setCharacterSlot(input: CharacterSlotInput): Promise<void> {
     const slot = this.normalizeCharacterSlot(input.slot);
-    const pending = this.deferredCharacterSlots.get(slot) ?? [];
-    this.deferredCharacterSlots.delete(slot);
-
-    if (input.deferPlay) {
-      // Native `_ExecuteCharslot` with end=false: `_UpdateSeqWithParam` fills
-      // the cached per-slot Sequence but never calls Play. The image swap is
-      // NOT deferred (`_SlotSetCharInternal` runs immediately: the incoming
-      // sprite sits at `afrom` and the outgoing one fades out), while every
-      // tween -- afrom->ato alpha, posfrom->posto move, actions, focus color
-      // -- waits inside the sequence until a later end=true command on the
-      // same slot plays it.
-      await this.installDeferredCharacterSlot(input, slot);
-      this.deferredCharacterSlots.set(slot, [...pending, input]);
-      return;
-    }
-
-    // A triggering command plays the cached Sequence first, then appends its
-    // own tweens (native appends into the same Sequence; replaying the
-    // deferred inputs here is the Web approximation).
-    for (const deferred of pending)
-      await this.playCharacterSlot(deferred, slot, true);
-    await this.playCharacterSlot(input, slot, false);
-  }
-
-  /** end=false path: install instant state, queue the tweens for later. */
-  private async installDeferredCharacterSlot(
-    input: CharacterSlotInput,
-    slot: string,
-  ): Promise<void> {
-    let state = this.characterSlots.get(slot);
-    let swapped = false;
-    if (input.characterKey && input.expression) {
-      const built = await this.buildCharacterSlotState(input, slot, state);
-      if (built) {
-        state = built;
-        swapped = true;
-      }
-    }
-    if (!state) return;
-    // SlotSetCharWithParam's SetAlpha(foreImage, afrom) runs outside the
-    // Sequence, so a swapped-in sprite sits at `afrom` right away. A
-    // nameless SlotChangeAlpha is part of the Sequence and stays deferred.
-    if (swapped && isFiniteNumber(input.alphaFrom)) {
-      state.contentAlpha = input.alphaFrom;
-      this.updateCharacterOpacity(state);
-    }
-  }
-
-  private async playCharacterSlot(
-    input: CharacterSlotInput,
-    slot: string,
-    skipBuildIfSameVisual: boolean,
-  ): Promise<void> {
     let state = this.characterSlots.get(slot);
     const hasCharacter = Boolean(input.characterKey && input.expression);
-    const sameVisual =
-      state?.characterKey === input.characterKey &&
-      state?.expression === input.expression;
 
-    if (hasCharacter && !(skipBuildIfSameVisual && sameVisual)) {
+    if (hasCharacter) {
       const built = await this.buildCharacterSlotState(input, slot, state);
       // A failed `_LoadImage` (missing asset) only nulls m_currentKey; the
       // action/focus sections still run on the sprite the slot already
@@ -1869,9 +1844,6 @@ export class PixiStoryRenderer implements StoryRenderer {
   async clearCharacters(slot?: string, fadeMs = 0): Promise<void> {
     if (slot) {
       const normalized = this.normalizeCharacterSlot(slot);
-      // Dropping the slot also drops its cached (possibly still deferred)
-      // Sequence -- a deferred charslot never fires after its slot is gone.
-      this.deferredCharacterSlots.delete(normalized);
       const state = this.characterSlots.get(normalized);
       if (!state) return;
       this.characterSlots.delete(normalized);
@@ -1885,7 +1857,6 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     const states = [...this.characterSlots.values()];
     this.characterSlots.clear();
-    this.deferredCharacterSlots.clear();
     if (fadeMs > 0) {
       await Promise.all(
         states.map((state) =>
@@ -3198,12 +3169,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     // contentAlpha (set to `afrom` right after by the caller) and only the
     // outgoing visual gets a dedicated fade here.
     const fadeMs = Math.max(0, Math.round(input.replaceFadeMs ?? 0));
-    // end=false still swaps images now: SetAlpha(fore, afrom) is outside the
-    // Sequence, and the afrom->ato half waits for the deferred play.
-    built.visual.alpha =
-      input.deferPlay && isFiniteNumber(input.alphaFrom)
-        ? input.alphaFrom
-        : current.contentAlpha;
+    built.visual.alpha = current.contentAlpha;
     if (previousVisual && previousVisual !== built.visual && fadeMs > 0) {
       const sessionId = ++current.replaceFadeSessionId;
       const previousAlpha = previousVisual.alpha;
@@ -3350,8 +3316,10 @@ export class PixiStoryRenderer implements StoryRenderer {
     // localPosition; zoom scale lives on the fore image, which survives
     // swaps. A command without pos/zoom input therefore starts from whatever
     // transform the slot currently holds; only an explicit `posfrom` is
-    // absolute (SlotMoveChar sets localPosition = posFrom first).
-    if (input.positionFrom) {
+    // absolute (SlotMoveChar sets localPosition = posFrom first), and only on
+    // the branches that actually reach SlotMoveChar (see
+    // `characterSlotUsesAbsoluteMove`).
+    if (input.positionFrom && characterSlotUsesAbsoluteMove(input)) {
       return {
         scaleX: state.scaleX,
         scaleY: state.scaleY,
@@ -3375,15 +3343,17 @@ export class PixiStoryRenderer implements StoryRenderer {
   ): { scaleX: number; scaleY: number; x: number; y: number } {
     let toX = from.x;
     let toY = from.y;
-    // Native gates the plain move on posFrom != (1,1): a bare `posto`
-    // without `posfrom` (and without action=jump, where `posto` is the
-    // relative landing offset of CharJump) never reaches SlotMoveChar, so it
-    // is a no-op.
-    if (input.positionTo && (input.positionFrom || input.action === "jump")) {
-      if (input.positionFrom) {
+    // `_UpdateSeqWithParam` picks `_GenSlotActionTw` XOR `_GenCharslotMove`,
+    // so posfrom/posto only reach SlotMoveChar on the branches listed in
+    // `characterSlotUsesAbsoluteMove`; zoom/shake ignore them outright. The
+    // plain move is additionally gated on posFrom != (1,1), which is why a
+    // bare `posto` is a no-op. `action="jump"` is the one relative form:
+    // CharJump (0x183eb2690) lands at `localPosition + posTo`.
+    if (input.positionTo) {
+      if (characterSlotUsesAbsoluteMove(input) && input.positionFrom) {
         toX = input.positionTo.x;
         toY = input.positionTo.y;
-      } else {
+      } else if (characterSlotUsesRelativeMove(input)) {
         toX += input.positionTo.x;
         toY += input.positionTo.y;
       }
@@ -3400,8 +3370,11 @@ export class PixiStoryRenderer implements StoryRenderer {
       const pivotValid =
         !zoom || (zoom.x >= 0 && zoom.x <= 1 && zoom.y >= 0 && zoom.y <= 1);
       if (pivotValid) {
-        if (isFiniteNumber(input.scaleX)) toScaleX = input.scaleX;
-        if (isFiniteNumber(input.scaleY)) toScaleY = input.scaleY;
+        // `CharZoom(zoomPos.x, zoomPos.y, options.scale, duration)` always
+        // tweens the fore image to `options.scale`, whose GetOrDefault falls
+        // back to 1.0 (0x183e4dcea) -- a zoom without `scale` resets it.
+        toScaleX = isFiniteNumber(input.scaleX) ? input.scaleX : 1;
+        toScaleY = isFiniteNumber(input.scaleY) ? input.scaleY : 1;
         if (zoom) {
           toX += (0.5 - zoom.x) * toScaleX * state.width;
           toY += (zoom.y - 0.5) * toScaleY * state.height;
@@ -3629,7 +3602,6 @@ export class PixiStoryRenderer implements StoryRenderer {
       input.scaleX !== undefined ||
       input.scaleY !== undefined ||
       input.posZoom !== undefined ||
-      input.deferPlay !== undefined ||
       input.replaceFadeMs !== undefined ||
       input.power !== undefined ||
       input.randomness !== undefined ||

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -283,6 +283,7 @@ export class PixiStoryRenderer implements StoryRenderer {
   private readonly context: Context;
   private readonly charLayer = this.layers.characters;
   private readonly characterSlots = new Map<string, CharacterRenderState>();
+  private readonly faceOverlayTextures = new Map<string, Texture>();
   private readonly cutinLayer = this.layers.cutins;
   private readonly cutinPanel: CharacterCutinPanel;
 
@@ -556,6 +557,9 @@ export class PixiStoryRenderer implements StoryRenderer {
     for (const state of this.characterSlots.values())
       this.disposeCharacterState(state);
     this.characterSlots.clear();
+    for (const texture of this.faceOverlayTextures.values())
+      texture.destroy(true);
+    this.faceOverlayTextures.clear();
     for (const state of this.curtains.values()) this.disposeCurtainState(state);
     this.curtains.clear();
     this.resizeObserver?.disconnect();
@@ -2985,9 +2989,12 @@ export class PixiStoryRenderer implements StoryRenderer {
     let sourceHeight: number;
     // Every sprite that contributes character pixels, in draw order. Native
     // composites the face into the *same* material as the body (`SetSprite`
-    // feeds the face through `_HGDynamicTex`) and only then applies
-    // `_BlackStart`/`_BlackEnd`, so the gradient must be baked over the whole
-    // stack -- baking the face alone would leave the body its original colour.
+    // feeds the face through `_HGDynamicTex`), so alpha (`DOColor` on the fore
+    // Image's vertex colour) and `_BlackStart`/`_BlackEnd` multiply the
+    // already-composited pixels. The web port must bake the face onto the body
+    // up front for the same reason: two stacked sprites would each carry the
+    // fade alpha separately, making the face region's effective opacity
+    // 1-(1-p)^2 instead of p -- the face would fade in ahead of the body.
     const contentSprites: Sprite[] = [];
 
     if (item.group === -1 && "image" in item && item.image) {
@@ -3015,20 +3022,19 @@ export class PixiStoryRenderer implements StoryRenderer {
       ]);
       if (!baseTexture || !faceTexture) return null;
 
-      const baseSprite = new Sprite(baseTexture);
-      baseSprite.anchor.set(0, 0);
-      content.addChild(baseSprite);
-      contentSprites.push(baseSprite);
+      const texture = this.bakeFaceOverlayTexture(
+        group.base,
+        item.face,
+        baseTexture,
+        faceTexture,
+        group.faceRect,
+      );
+      if (!texture) return null;
 
-      const faceSprite = new Sprite(faceTexture);
-      faceSprite.anchor.set(0, 0);
-      faceSprite.x = group.faceRect.x;
-      faceSprite.y = group.faceRect.y;
-      faceSprite.width = group.faceRect.w;
-      faceSprite.height = group.faceRect.h;
-      content.addChild(faceSprite);
-      contentSprites.push(faceSprite);
-
+      const sprite = new Sprite(texture);
+      sprite.anchor.set(0, 0);
+      content.addChild(sprite);
+      contentSprites.push(sprite);
       sourceWidth = baseTexture.width;
       sourceHeight = baseTexture.height;
     } else {
@@ -3248,6 +3254,78 @@ export class PixiStoryRenderer implements StoryRenderer {
     const darkened = new Sprite(texture);
     darkened.anchor.set(0, 0);
     content.addChild(darkened);
+  }
+
+  /**
+   * Flattens a `face_overlay` group (body + expression face) into a single
+   * texture. Native renders both through one `avgCharSplitShader` material
+   * (`AlphaSplitImageHolder.SetSprite` 0x183ec5e60: the body is the Image's
+   * own sprite, the face rides the same material's `_HGDynamicTex` with the
+   * `faceOffset` UV transform), so the face is composited *inside* the shader
+   * before the vertex colour multiplies the result. Keeping two stacked Pixi
+   * sprites instead would fade each layer with its own copy of the alpha
+   * (`1-(1-p)^2` over the face) and double-apply `_BlackStart` shading, so the
+   * composite is baked once per (base, face) pair and cached.
+   *
+   * The face texture is stretched to `faceRect` as-is (no aspect-ratio
+   * preservation): the CDN face PNG matches what native maps through the
+   * `faceOffset` scale/offset, verified against the official client.
+   */
+  private bakeFaceOverlayTexture(
+    baseKey: string,
+    faceKey: string,
+    baseTexture: Texture,
+    faceTexture: Texture,
+    faceRect: { x: number; y: number; w: number; h: number },
+  ): Texture | null {
+    const cacheKey = `${baseKey}|${faceKey}`;
+    const cached = this.faceOverlayTextures.get(cacheKey);
+    if (cached) return cached;
+
+    const baseResource = baseTexture.source?.resource as
+      CanvasImageSource | undefined;
+    const faceResource = faceTexture.source?.resource as
+      CanvasImageSource | undefined;
+    // Mirrors bakeDarkenedCharacterTexture: a texture we cannot draw has to
+    // fail the whole bake rather than silently drop the face or the body.
+    if (!baseResource || !faceResource) return null;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(baseTexture.width));
+    canvas.height = Math.max(1, Math.round(baseTexture.height));
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+
+    const baseFrame = baseTexture.frame;
+    ctx.drawImage(
+      baseResource,
+      baseFrame.x,
+      baseFrame.y,
+      baseFrame.width,
+      baseFrame.height,
+      0,
+      0,
+      canvas.width,
+      canvas.height,
+    );
+    const faceFrame = faceTexture.frame;
+    ctx.drawImage(
+      faceResource,
+      faceFrame.x,
+      faceFrame.y,
+      faceFrame.width,
+      faceFrame.height,
+      faceRect.x,
+      faceRect.y,
+      faceRect.w,
+      faceRect.h,
+    );
+
+    const texture = new Texture({
+      source: new CanvasSource({ resource: canvas }),
+    });
+    this.faceOverlayTextures.set(cacheKey, texture);
+    return texture;
   }
 
   private bakeDarkenedCharacterTexture(

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -252,6 +252,16 @@ export class PixiStoryRenderer implements StoryRenderer {
   private readonly context: Context;
   private readonly charLayer = this.layers.characters;
   private readonly characterSlots = new Map<string, CharacterRenderState>();
+  /**
+   * `charslot` `end=false` inputs waiting for a later end=true command on the
+   * same slot (native caches the assembled per-slot Sequence in
+   * `_GetCachedSlotSeq` and only plays it when a command with `end=true`
+   * appends to it).
+   */
+  private readonly deferredCharacterSlots = new Map<
+    string,
+    CharacterSlotInput[]
+  >();
   private readonly cutinLayer = this.layers.cutins;
   private readonly cutinPanel: CharacterCutinPanel;
 
@@ -1611,22 +1621,79 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   private async setCharacterSlot(input: CharacterSlotInput): Promise<void> {
     const slot = this.normalizeCharacterSlot(input.slot);
-    let state = this.characterSlots.get(slot);
-    const hasCharacter = Boolean(input.characterKey && input.expression);
+    const pending = this.deferredCharacterSlots.get(slot) ?? [];
+    this.deferredCharacterSlots.delete(slot);
 
-    if (hasCharacter) {
-      const built = await this.buildCharacterSlotState(input, slot, state);
-      if (!built) return;
-      state = built;
-    }
-
-    if (!state) {
-      if (input.focusMode)
-        this.applyCharacterSlotFocus(input.focusMode, slot, input.focusSlots);
+    if (input.deferPlay) {
+      // Native `_ExecuteCharslot` with end=false: `_UpdateSeqWithParam` fills
+      // the cached per-slot Sequence but never calls Play. The image swap is
+      // NOT deferred (`_SlotSetCharInternal` runs immediately: the incoming
+      // sprite sits at `afrom` and the outgoing one fades out), while every
+      // tween -- afrom->ato alpha, posfrom->posto move, actions, focus color
+      // -- waits inside the sequence until a later end=true command on the
+      // same slot plays it.
+      await this.installDeferredCharacterSlot(input, slot);
+      this.deferredCharacterSlots.set(slot, [...pending, input]);
       return;
     }
 
-    this.applyCharacterSlotFocus(input.focusMode, slot, input.focusSlots);
+    // A triggering command plays the cached Sequence first, then appends its
+    // own tweens (native appends into the same Sequence; replaying the
+    // deferred inputs here is the Web approximation).
+    for (const deferred of pending)
+      await this.playCharacterSlot(deferred, slot, true);
+    await this.playCharacterSlot(input, slot, false);
+  }
+
+  /** end=false path: install instant state, queue the tweens for later. */
+  private async installDeferredCharacterSlot(
+    input: CharacterSlotInput,
+    slot: string,
+  ): Promise<void> {
+    let state = this.characterSlots.get(slot);
+    let swapped = false;
+    if (input.characterKey && input.expression) {
+      const built = await this.buildCharacterSlotState(input, slot, state);
+      if (built) {
+        state = built;
+        swapped = true;
+      }
+    }
+    if (!state) return;
+    // SlotSetCharWithParam's SetAlpha(foreImage, afrom) runs outside the
+    // Sequence, so a swapped-in sprite sits at `afrom` right away. A
+    // nameless SlotChangeAlpha is part of the Sequence and stays deferred.
+    if (swapped && isFiniteNumber(input.alphaFrom)) {
+      state.contentAlpha = input.alphaFrom;
+      this.updateCharacterOpacity(state);
+    }
+  }
+
+  private async playCharacterSlot(
+    input: CharacterSlotInput,
+    slot: string,
+    skipBuildIfSameVisual: boolean,
+  ): Promise<void> {
+    let state = this.characterSlots.get(slot);
+    const hasCharacter = Boolean(input.characterKey && input.expression);
+    const sameVisual =
+      state?.characterKey === input.characterKey &&
+      state?.expression === input.expression;
+
+    if (hasCharacter && !(skipBuildIfSameVisual && sameVisual)) {
+      const built = await this.buildCharacterSlotState(input, slot, state);
+      // A failed `_LoadImage` (missing asset) only nulls m_currentKey; the
+      // action/focus sections still run on the sprite the slot already
+      // shows, so keep the previous state instead of aborting.
+      if (built) state = built;
+    }
+
+    if (!state) {
+      if (input.focusMode) this.applyCharacterSlotFocus(input.focusSlots ?? []);
+      return;
+    }
+
+    if (input.focusMode) this.applyCharacterSlotFocus(input.focusSlots ?? []);
 
     const fromTransform = this.characterSlotFromTransform(state, input);
     const toTransform = this.characterSlotToTransform(
@@ -1642,7 +1709,13 @@ export class PixiStoryRenderer implements StoryRenderer {
     state.scaleY = fromTransform.scaleY;
     this.updateCharacterState(state);
 
-    if (input.action === "shake" || input.action === "shakemove") {
+    // `_GenSlotActionTw`: NeedSkipAnimation(duration) makes the shake branch
+    // return null -- shake (and shakemove's shake half) only exists with a
+    // positive duration.
+    if (
+      (input.action === "shake" || input.action === "shakemove") &&
+      durationMs > 0
+    ) {
       this.startShakeAction(state, {
         block: false,
         durationMs,
@@ -1668,7 +1741,10 @@ export class PixiStoryRenderer implements StoryRenderer {
         durationMs,
       );
 
-    if (input.action === "rotate" && input.angle !== undefined) {
+    // Native drives rotation from the standalone `angle` parameter segment
+    // at the tail of `_UpdateSeqWithParam`; `action="rotate"` itself is an
+    // unknown action in 2.7.61's `_GenSlotActionTw` (LogError + null).
+    if (input.angle !== undefined) {
       const sessionId = ++state.rotateSessionId;
       const fromAngle = state.rotationDeg;
       const direction = input.inverse ? -1 : 1;
@@ -1686,6 +1762,13 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     this.applyCharacterSlotOpacity(state, input, durationMs);
     if (input.action === "shake") return;
+
+    const transformUnchanged =
+      fromTransform.x === toTransform.x &&
+      fromTransform.y === toTransform.y &&
+      fromTransform.scaleX === toTransform.scaleX &&
+      fromTransform.scaleY === toTransform.scaleY;
+    if (transformUnchanged) return;
 
     const sessionId = ++state.transformSessionId;
     const transformDurationMs = input.action === "setpos" ? 0 : durationMs;
@@ -1786,6 +1869,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   async clearCharacters(slot?: string, fadeMs = 0): Promise<void> {
     if (slot) {
       const normalized = this.normalizeCharacterSlot(slot);
+      // Dropping the slot also drops its cached (possibly still deferred)
+      // Sequence -- a deferred charslot never fires after its slot is gone.
+      this.deferredCharacterSlots.delete(normalized);
       const state = this.characterSlots.get(normalized);
       if (!state) return;
       this.characterSlots.delete(normalized);
@@ -1799,6 +1885,7 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     const states = [...this.characterSlots.values()];
     this.characterSlots.clear();
+    this.deferredCharacterSlots.clear();
     if (fadeMs > 0) {
       await Promise.all(
         states.map((state) =>
@@ -3103,11 +3190,23 @@ export class PixiStoryRenderer implements StoryRenderer {
     );
     current.rotationLayer.addChild(built.visual);
 
+    // Native crossfade: `_SlotSetCharInternal` runs the outgoing sprite's
+    // fade-out immediately, while the incoming sprite's afrom->ato tween (the
+    // same tween `applyCharacterSlotOpacity` drives through contentAlpha) is
+    // the crossfade itself. Its length is `duration` -- `fadetime` is not a
+    // charslot key. The incoming visual therefore starts at the current
+    // contentAlpha (set to `afrom` right after by the caller) and only the
+    // outgoing visual gets a dedicated fade here.
     const fadeMs = Math.max(0, Math.round(input.replaceFadeMs ?? 0));
-    if (fadeMs > 0) {
+    // end=false still swaps images now: SetAlpha(fore, afrom) is outside the
+    // Sequence, and the afrom->ato half waits for the deferred play.
+    built.visual.alpha =
+      input.deferPlay && isFiniteNumber(input.alphaFrom)
+        ? input.alphaFrom
+        : current.contentAlpha;
+    if (previousVisual && previousVisual !== built.visual && fadeMs > 0) {
       const sessionId = ++current.replaceFadeSessionId;
-      const previousAlpha = previousVisual?.alpha ?? current.contentAlpha;
-      built.visual.alpha = 0;
+      const previousAlpha = previousVisual.alpha;
       void this.tween(
         fadeMs,
         (progress) => {
@@ -3116,9 +3215,7 @@ export class PixiStoryRenderer implements StoryRenderer {
             current.replaceFadeSessionId !== sessionId
           )
             return;
-          built.visual.alpha = current.contentAlpha * progress;
-          if (previousVisual && previousVisual !== built.visual)
-            previousVisual.alpha = previousAlpha * (1 - progress);
+          previousVisual.alpha = previousAlpha * (1 - progress);
         },
         () => {
           if (
@@ -3126,18 +3223,26 @@ export class PixiStoryRenderer implements StoryRenderer {
             current.replaceFadeSessionId !== sessionId
           )
             return;
-          built.visual.alpha = current.contentAlpha;
-          previousVisual?.removeFromParent();
+          previousVisual.removeFromParent();
         },
       );
     } else {
-      built.visual.alpha = current.contentAlpha;
       previousVisual?.removeFromParent();
     }
 
     return current;
   }
 
+  /**
+   * Web approximation of the greenscreen black band: native feeds
+   * bstart/bend through `CharacterParam` into
+   * `AVGCharacterSlot._LoadImage` (0x183eb4f60) -> `AVGCharacterSpriteHub::
+   * SetImage`, which passes the values to the material verbatim -- unlike
+   * `SlotChangeMask` (the dead `charslotmask` channel), which tweens
+   * `_BlackStart/_BlackEnd` as 1-x. So no inversion belongs here; the exact
+   * band geometry lives in the greenscreen shader, which the DLL cannot
+   * show, and this static top-down gradient is the approximation.
+   */
   private applyCharacterBlackGradient(
     content: Container,
     contentSprites: Sprite[],
@@ -3236,35 +3341,30 @@ export class PixiStoryRenderer implements StoryRenderer {
     state: CharacterRenderState,
     input: CharacterSlotInput,
   ): { scaleX: number; scaleY: number; x: number; y: number } {
-    // `charslot` does NOT share `character`'s key-equality guard. It reaches
-    // the slot through `AVGCharacterSlot._SlotSetCharInternal` @ 0x183eb5830,
-    // whose reset is
-    //   `if (resetOffsetPos && !IsNullOrEmpty(charName)) _offset.pos = zero`
-    // with no `m_currentKey` comparison anywhere -- unlike `Set` @ 0x183eb38a0,
-    // which wraps the same reset in `!op_Equality(m_currentKey, key)`. So a
-    // charslot carrying a name zeroes the offset whatever the character is,
-    // and `end=false` (resetOffsetPos = 0) is the only way to keep it.
-    const preserve =
-      input.resetTransform === false || input.preserveTransform === true;
-    const baseX = preserve ? state.actionX : 0;
-    const baseY = preserve ? state.actionY : 0;
-    const baseScaleX = preserve ? state.scaleX : 1;
-    const baseScaleY = preserve ? state.scaleY : 1;
-
+    // Native never resets a slot's transform between charslot commands:
+    // `_UpdateSeqWithParam` @ 0x183e53940 calls
+    // `SlotSetCharWithParam(slot, options, resetOffsetPos: false)` (literal 0
+    // at the call site), so `_SlotSetCharInternal`'s
+    // `if (resetOffsetPos && !IsNullOrEmpty(charName)) _offset.pos = zero`
+    // never fires on the charslot path and the offset keeps its
+    // localPosition; zoom scale lives on the fore image, which survives
+    // swaps. A command without pos/zoom input therefore starts from whatever
+    // transform the slot currently holds; only an explicit `posfrom` is
+    // absolute (SlotMoveChar sets localPosition = posFrom first).
     if (input.positionFrom) {
       return {
-        scaleX: baseScaleX,
-        scaleY: baseScaleY,
+        scaleX: state.scaleX,
+        scaleY: state.scaleY,
         x: input.positionFrom.x,
         y: input.positionFrom.y,
       };
     }
 
     return {
-      scaleX: baseScaleX,
-      scaleY: baseScaleY,
-      x: baseX,
-      y: baseY,
+      scaleX: state.scaleX,
+      scaleY: state.scaleY,
+      x: state.actionX,
+      y: state.actionY,
     };
   }
 
@@ -3275,7 +3375,11 @@ export class PixiStoryRenderer implements StoryRenderer {
   ): { scaleX: number; scaleY: number; x: number; y: number } {
     let toX = from.x;
     let toY = from.y;
-    if (input.positionTo) {
+    // Native gates the plain move on posFrom != (1,1): a bare `posto`
+    // without `posfrom` (and without action=jump, where `posto` is the
+    // relative landing offset of CharJump) never reaches SlotMoveChar, so it
+    // is a no-op.
+    if (input.positionTo && (input.positionFrom || input.action === "jump")) {
       if (input.positionFrom) {
         toX = input.positionTo.x;
         toY = input.positionTo.y;
@@ -3288,40 +3392,34 @@ export class PixiStoryRenderer implements StoryRenderer {
     let toScaleX = from.scaleX;
     let toScaleY = from.scaleY;
     if (input.action === "zoom") {
-      if (isFiniteNumber(input.scaleX)) toScaleX = input.scaleX;
-      if (isFiniteNumber(input.scaleY)) toScaleY = input.scaleY;
-      if (input.posZoom) {
-        toX += (0.5 - input.posZoom.x) * toScaleX * state.width;
-        toY += (input.posZoom.y - 0.5) * toScaleY * state.height;
+      // CharZoom validates the pivot first: x/y outside [0,1] => return null,
+      // skipping the whole zoom (scale change included). An absent poszoom
+      // defaults to (1,1), which is inside the valid range; the Web port
+      // keeps treating an absent pivot as "no extra shift".
+      const zoom = input.posZoom;
+      const pivotValid =
+        !zoom || (zoom.x >= 0 && zoom.x <= 1 && zoom.y >= 0 && zoom.y <= 1);
+      if (pivotValid) {
+        if (isFiniteNumber(input.scaleX)) toScaleX = input.scaleX;
+        if (isFiniteNumber(input.scaleY)) toScaleY = input.scaleY;
+        if (zoom) {
+          toX += (0.5 - zoom.x) * toScaleX * state.width;
+          toY += (zoom.y - 0.5) * toScaleY * state.height;
+        }
       }
     }
 
     return { scaleX: toScaleX, scaleY: toScaleY, x: toX, y: toY };
   }
 
-  private applyCharacterSlotFocus(
-    focusMode: CharacterSlotInput["focusMode"],
-    slot: string,
-    focusSlots?: string[],
-  ): void {
-    if (!focusMode) return;
-
-    if (focusMode === "none") {
-      const state = this.characterSlots.get(slot);
-      if (!state) return;
-      state.focusBrightness = 0.5;
-      this.updateCharacterOpacity(state);
-      return;
-    }
-
-    const active =
-      focusMode === "current_only"
-        ? new Set([slot])
-        : new Set(
-            (focusSlots ?? []).map((value) =>
-              this.normalizeCharacterSlot(value),
-            ),
-          );
+  private applyCharacterSlotFocus(focusSlots: string[]): void {
+    // Native focus is a full re-resolve on every charslot:
+    // `_ProcessFocusArray` (0x183e50b30) clears all four flags, then lights
+    // only the listed slots; unrecognized values light nothing. Brightness
+    // changes are tweens in the Sequence (SetFocus), applied instantly here.
+    const active = new Set(
+      focusSlots.map((value) => this.normalizeCharacterSlot(value)),
+    );
 
     for (const [slotKey, state] of this.characterSlots.entries()) {
       state.focusBrightness = active.has(slotKey) ? 1 : 0.5;
@@ -3531,8 +3629,7 @@ export class PixiStoryRenderer implements StoryRenderer {
       input.scaleX !== undefined ||
       input.scaleY !== undefined ||
       input.posZoom !== undefined ||
-      input.preserveTransform !== undefined ||
-      input.resetTransform !== undefined ||
+      input.deferPlay !== undefined ||
       input.replaceFadeMs !== undefined ||
       input.power !== undefined ||
       input.randomness !== undefined ||

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -96,34 +96,131 @@ function clamp01(value: number): number {
 }
 
 /**
- * Which `charslot` branches feed posfrom/posto into `SlotMoveChar`, i.e. move
- * from the absolute `posfrom` to the absolute `posto`. `_UpdateSeqWithParam`
- * (0x183e53940) only calls `_GenCharslotMove` when `action` is empty, and
- * `_GenSlotActionTw` (0x183e4f3b0) re-enters it for `shakemove`, plus for
- * `jump` when `NeedSkipAnimation(duration)` holds. `zoom` and `shake` never
- * touch the offset, so their posfrom/posto are inert. `move`/`setpos` are Web
- * extensions kept on the plain-move path.
+ * `TweenerOptions.posFrom` / `posTo` / `zoomPos` all default to `Vector2.one`
+ * (`_ExecuteCharslot` 0x183e4d752-0x183e4d7ad). The plain-move branch uses
+ * posFrom == (1,1) as its "not given" sentinel; the action branches pass the
+ * values through verbatim.
  */
-function characterSlotUsesAbsoluteMove(input: CharacterSlotInput): boolean {
+const CHARSLOT_POINT_DEFAULT = { x: 1, y: 1 } as const;
+
+interface CharacterSlotPoint {
+  x: number;
+  y: number;
+}
+
+interface CharacterSlotZoomState {
+  scaleX: number;
+  scaleY: number;
+  shiftX: number;
+  shiftY: number;
+}
+
+/**
+ * Which `charslot` branches feed posfrom/posto into `SlotMoveChar`, i.e. the
+ * `_offset.localPosition` move. `_UpdateSeqWithParam` (0x183e53940) picks
+ * `_GenSlotActionTw` XOR `_GenCharslotMove`: the plain move only runs when
+ * `action` is empty and posFrom != (1,1), and `_GenSlotActionTw`
+ * (0x183e4f3b0) re-enters SlotMoveChar for `shakemove` and for `jump` when
+ * `NeedSkipAnimation(duration)` holds -- without the sentinel gate. `zoom`
+ * and `shake` never touch the offset. `move`/`setpos` are Web extensions kept
+ * on the plain-move path. Returns null when the command moves nothing.
+ */
+function characterSlotMove(
+  state: { actionX: number; actionY: number },
+  input: CharacterSlotInput,
+): { from: CharacterSlotPoint; to: CharacterSlotPoint } | null {
+  const posTo = input.positionTo ?? CHARSLOT_POINT_DEFAULT;
   switch (input.action) {
     case undefined:
     case "move":
-    case "setpos":
+    case "setpos": {
+      // posFrom == (1,1) never reaches SlotMoveChar: a bare `posto` is a
+      // no-op rather than a relative move.
+      if (!input.positionFrom) return null;
+      return { from: input.positionFrom, to: posTo };
+    }
     case "shakemove": {
-      return true;
+      // SlotMoveChar(posFrom, posTo, duration) verbatim, sentinel included.
+      return { from: input.positionFrom ?? CHARSLOT_POINT_DEFAULT, to: posTo };
     }
     case "jump": {
-      return (input.durationMs ?? 0) <= 0;
+      if ((input.durationMs ?? 0) > 0) {
+        // CharJump (0x183eb2690): DOLocalJump to `localPosition + posTo`,
+        // and posTo defaults to (1,1) -- a bare jump drifts one unit.
+        return {
+          from: { x: state.actionX, y: state.actionY },
+          to: { x: state.actionX + posTo.x, y: state.actionY + posTo.y },
+        };
+      }
+      // NeedSkipAnimation(duration) => _GenCharslotMove => SlotMoveChar(...,
+      // 0) => `localPosition = posTo` outright.
+      return { from: input.positionFrom ?? CHARSLOT_POINT_DEFAULT, to: posTo };
     }
     default: {
-      return false;
+      return null;
     }
   }
 }
 
-/** `action="jump"` with a real duration: CharJump lands at current + posTo. */
-function characterSlotUsesRelativeMove(input: CharacterSlotInput): boolean {
-  return input.action === "jump" && (input.durationMs ?? 0) > 0;
+/**
+ * The zoom half of a `charslot`: CharZoom (0x183eb2b50) tweens the fore
+ * Image's `rectTransform.pivot` to `zoomPos` and its `localScale` to `scale`
+ * (setter `<CharZoom>b__1` 0x183ed95a0), both absolute -- re-issuing the same
+ * zoom lands on the same transform instead of stacking. The pivot move is
+ * approximated as a translation of the scaled sprite. Returns null when the
+ * command is not a zoom or CharZoom would reject the pivot.
+ */
+function characterSlotZoom(
+  state: CharacterRenderState,
+  input: CharacterSlotInput,
+): { from: CharacterSlotZoomState; to: CharacterSlotZoomState } | null {
+  if (input.action !== "zoom") return null;
+  // CharZoom validates the pivot first: x/y outside [0,1] => return null,
+  // skipping the whole zoom (scale change included). An absent poszoom
+  // defaults to (1,1), which is inside the valid range; the Web port keeps
+  // treating an absent pivot as "no extra shift".
+  const zoom = input.posZoom;
+  const pivotValid =
+    !zoom || (zoom.x >= 0 && zoom.x <= 1 && zoom.y >= 0 && zoom.y <= 1);
+  if (!pivotValid) return null;
+
+  // `CharZoom(zoomPos.x, zoomPos.y, options.scale, duration)` always tweens
+  // to `options.scale`, whose GetOrDefault falls back to 1.0 (0x183e4dcea)
+  // -- a zoom without `scale` resets it.
+  const toScaleX = isFiniteNumber(input.scaleX) ? input.scaleX : 1;
+  const toScaleY = isFiniteNumber(input.scaleY) ? input.scaleY : 1;
+  return {
+    from: {
+      scaleX: state.scaleX,
+      scaleY: state.scaleY,
+      shiftX: state.zoomShiftX,
+      shiftY: state.zoomShiftY,
+    },
+    to: {
+      scaleX: toScaleX,
+      scaleY: toScaleY,
+      shiftX: zoom ? (0.5 - zoom.x) * toScaleX * state.width : 0,
+      shiftY: zoom ? (zoom.y - 0.5) * toScaleY * state.height : 0,
+    },
+  };
+}
+
+interface FaceOverlayCacheEntry {
+  /** Live visuals drawing this bake; only unreferenced bakes are evicted. */
+  refs: number;
+  texture: Texture;
+}
+
+/**
+ * Soft cap on cached face-overlay bakes. Each one is a full base-sized
+ * canvas plus its GPU upload (CDN bases run 1024^2-1484^2, ~4-9 MB RGBA), so
+ * the cache cannot grow with the number of expressions a story shows. Three
+ * slots with an incoming and an outgoing visual each pin at most six.
+ */
+const FACE_OVERLAY_CACHE_LIMIT = 8;
+
+function faceOverlayCacheKey(baseKey: string, faceKey: string): string {
+  return `${baseKey}|${faceKey}`;
 }
 
 /** Raw float color channel to the 8-bit tint write (the only clamp point). */
@@ -224,6 +321,12 @@ interface CharacterRenderState {
   expression?: string;
   fadeIdentity?: string;
   height: number;
+  /**
+   * The previous visual while it cross-fades out. Native keeps exactly one
+   * back Image: the next swap replaces it outright, so a swap during a
+   * crossfade discards this one instead of leaving it half faded.
+   */
+  outgoingVisual: Container | null;
   jumpOffsetY: number;
   jumpSessionId: number;
   motionLayer: Container;
@@ -252,6 +355,14 @@ interface CharacterRenderState {
   transformSessionId: number;
   visual: Container;
   width: number;
+  zoomSessionId: number;
+  /**
+   * CharZoom's pivot move, as a translation in stage pixels. Kept apart from
+   * `actionX/Y` (the `_offset` position) because native stores it on the
+   * fore Image, which every successful image load resets.
+   */
+  zoomShiftX: number;
+  zoomShiftY: number;
 }
 
 interface CurtainRenderState {
@@ -283,7 +394,12 @@ export class PixiStoryRenderer implements StoryRenderer {
   private readonly context: Context;
   private readonly charLayer = this.layers.characters;
   private readonly characterSlots = new Map<string, CharacterRenderState>();
-  private readonly faceOverlayTextures = new Map<string, Texture>();
+  private readonly faceOverlayTextures = new Map<
+    string,
+    FaceOverlayCacheEntry
+  >();
+  /** Which cached bake each character visual draws, for refcounting. */
+  private readonly faceOverlayVisualKeys = new WeakMap<Container, string>();
   private readonly cutinLayer = this.layers.cutins;
   private readonly cutinPanel: CharacterCutinPanel;
 
@@ -557,8 +673,8 @@ export class PixiStoryRenderer implements StoryRenderer {
     for (const state of this.characterSlots.values())
       this.disposeCharacterState(state);
     this.characterSlots.clear();
-    for (const texture of this.faceOverlayTextures.values())
-      texture.destroy(true);
+    for (const entry of this.faceOverlayTextures.values())
+      entry.texture.destroy(true);
     this.faceOverlayTextures.clear();
     for (const state of this.curtains.values()) this.disposeCurtainState(state);
     this.curtains.clear();
@@ -1583,6 +1699,7 @@ export class PixiStoryRenderer implements StoryRenderer {
       motionLayer,
       nativeKey: input.nativeKey,
       opacitySessionId: 0,
+      outgoingVisual: null,
       replaceFadeSessionId: 0,
       root,
       rotationDeg: 0,
@@ -1601,6 +1718,9 @@ export class PixiStoryRenderer implements StoryRenderer {
       transformSessionId: 0,
       visual,
       width: sizeX,
+      zoomSessionId: 0,
+      zoomShiftX: keepsOffset ? previous.zoomShiftX : 0,
+      zoomShiftY: keepsOffset ? previous.zoomShiftY : 0,
     };
     this.updateCharacterState(state);
 
@@ -1674,18 +1794,17 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     if (input.focusMode) this.applyCharacterSlotFocus(input.focusSlots ?? []);
 
-    const fromTransform = this.characterSlotFromTransform(state, input);
-    const toTransform = this.characterSlotToTransform(
-      state,
-      input,
-      fromTransform,
-    );
     const durationMs = Math.max(0, Math.round(input.durationMs ?? 0));
+    const move = characterSlotMove(state, input);
+    const zoom = characterSlotZoom(state, input);
 
-    state.actionX = fromTransform.x;
-    state.actionY = fromTransform.y;
-    state.scaleX = fromTransform.scaleX;
-    state.scaleY = fromTransform.scaleY;
+    // SlotMoveChar writes `localPosition = posFrom` when the tween is
+    // created, so the start of a move lands on the spot even when the tween
+    // itself has a duration.
+    if (move) {
+      state.actionX = move.from.x;
+      state.actionY = move.from.y;
+    }
     this.updateCharacterState(state);
 
     // `_GenSlotActionTw`: NeedSkipAnimation(duration) makes the shake branch
@@ -1740,45 +1859,78 @@ export class PixiStoryRenderer implements StoryRenderer {
     }
 
     this.applyCharacterSlotOpacity(state, input, durationMs);
-    if (input.action === "shake") return;
 
-    const transformUnchanged =
-      fromTransform.x === toTransform.x &&
-      fromTransform.y === toTransform.y &&
-      fromTransform.scaleX === toTransform.scaleX &&
-      fromTransform.scaleY === toTransform.scaleY;
-    if (transformUnchanged) return;
+    // The move (`_offset.localPosition`) and the zoom (the fore Image's
+    // pivot/localScale) are independent tweens natively: an image swap
+    // resets the zoom but leaves a running move alone, and a command whose
+    // from == to starts nothing, so an in-flight tween of either kind
+    // survives an unrelated command.
+    const pending: Promise<void>[] = [];
 
-    const sessionId = ++state.transformSessionId;
-    const transformDurationMs = input.action === "setpos" ? 0 : durationMs;
-    const run = this.tween(
-      transformDurationMs,
-      (progress) => {
-        if (!this.isActiveCharacterState(state, sessionId)) return;
-        state.actionX =
-          fromTransform.x + (toTransform.x - fromTransform.x) * progress;
-        state.actionY =
-          fromTransform.y + (toTransform.y - fromTransform.y) * progress;
-        state.scaleX =
-          fromTransform.scaleX +
-          (toTransform.scaleX - fromTransform.scaleX) * progress;
-        state.scaleY =
-          fromTransform.scaleY +
-          (toTransform.scaleY - fromTransform.scaleY) * progress;
-        this.updateCharacterState(state);
-      },
-      () => {
-        if (!this.isActiveCharacterState(state, sessionId)) return;
-        state.actionX = toTransform.x;
-        state.actionY = toTransform.y;
-        state.scaleX = toTransform.scaleX;
-        state.scaleY = toTransform.scaleY;
-        this.updateCharacterState(state);
-      },
-    );
+    if (move && (move.from.x !== move.to.x || move.from.y !== move.to.y)) {
+      const sessionId = ++state.transformSessionId;
+      const moveDurationMs = input.action === "setpos" ? 0 : durationMs;
+      const { from, to } = move;
+      const run = this.tween(
+        moveDurationMs,
+        (progress) => {
+          if (!this.isActiveCharacterState(state, sessionId)) return;
+          state.actionX = from.x + (to.x - from.x) * progress;
+          state.actionY = from.y + (to.y - from.y) * progress;
+          this.updateCharacterState(state);
+        },
+        () => {
+          if (!this.isActiveCharacterState(state, sessionId)) return;
+          state.actionX = to.x;
+          state.actionY = to.y;
+          this.updateCharacterState(state);
+        },
+      );
+      if (moveDurationMs > 0) pending.push(run);
+      else void run;
+    }
 
-    if (!input.block || transformDurationMs <= 0) void run;
-    else await run;
+    if (
+      zoom &&
+      (zoom.from.scaleX !== zoom.to.scaleX ||
+        zoom.from.scaleY !== zoom.to.scaleY ||
+        zoom.from.shiftX !== zoom.to.shiftX ||
+        zoom.from.shiftY !== zoom.to.shiftY)
+    ) {
+      const sessionId = ++state.zoomSessionId;
+      const { from, to } = zoom;
+      const run = this.tween(
+        durationMs,
+        (progress) => {
+          if (
+            !this.isActiveCharacterState(state) ||
+            state.zoomSessionId !== sessionId
+          )
+            return;
+          state.scaleX = from.scaleX + (to.scaleX - from.scaleX) * progress;
+          state.scaleY = from.scaleY + (to.scaleY - from.scaleY) * progress;
+          state.zoomShiftX = from.shiftX + (to.shiftX - from.shiftX) * progress;
+          state.zoomShiftY = from.shiftY + (to.shiftY - from.shiftY) * progress;
+          this.updateCharacterState(state);
+        },
+        () => {
+          if (
+            !this.isActiveCharacterState(state) ||
+            state.zoomSessionId !== sessionId
+          )
+            return;
+          state.scaleX = to.scaleX;
+          state.scaleY = to.scaleY;
+          state.zoomShiftX = to.shiftX;
+          state.zoomShiftY = to.shiftY;
+          this.updateCharacterState(state);
+        },
+      );
+      if (durationMs > 0) pending.push(run);
+      else void run;
+    }
+
+    if (input.block && pending.length > 0) await Promise.all(pending);
   }
 
   /**
@@ -3035,6 +3187,10 @@ export class PixiStoryRenderer implements StoryRenderer {
       sprite.anchor.set(0, 0);
       content.addChild(sprite);
       contentSprites.push(sprite);
+      this.retainFaceOverlay(
+        visual,
+        faceOverlayCacheKey(group.base, item.face),
+      );
       sourceWidth = baseTexture.width;
       sourceHeight = baseTexture.height;
     } else {
@@ -3114,6 +3270,7 @@ export class PixiStoryRenderer implements StoryRenderer {
         motionLayer,
         nativeKey: input.nativeKey,
         opacitySessionId: 0,
+        outgoingVisual: null,
         replaceFadeSessionId: 0,
         root,
         rotationDeg: 0,
@@ -3132,6 +3289,9 @@ export class PixiStoryRenderer implements StoryRenderer {
         transformSessionId: 0,
         visual: built.visual,
         width: sizeX,
+        zoomSessionId: 0,
+        zoomShiftX: 0,
+        zoomShiftY: 0,
       };
       this.updateCharacterState(state);
       this.updateCharacterOpacity(state);
@@ -3141,6 +3301,37 @@ export class PixiStoryRenderer implements StoryRenderer {
     }
 
     const previousVisual = current.visual;
+    // Native keeps one back Image; a swap mid-crossfade replaces it outright.
+    if (current.outgoingVisual && current.outgoingVisual !== previousVisual)
+      this.discardCharacterVisual(current.outgoingVisual);
+    current.outgoingVisual = null;
+
+    // `AVGCharacterSpriteHub._SetImage` (0x183ec8f50) and its HubGroup twin
+    // (0x183ec8020) both open with `GUIUtils.AssignLocalSettings(
+    // m_image.rectTransform, hub.rectTransform)` (0x181f02c70), which copies
+    // the hub prefab's sizeDelta/pivot/localScale/localRotation/localPosition
+    // onto the fore Image on every successful load -- exactly the pivot and
+    // localScale CharZoom's setter animates. A named swap therefore resets
+    // the zoom while the `_offset` move survives (resetOffsetPos=false). The
+    // outgoing Image keeps its own transform as it fades, so the previous
+    // visual carries the old zoom on itself (scaled back through the base
+    // ratio because the motion layer now holds the incoming art's base).
+    if (previousVisual !== built.visual) {
+      previousVisual.scale.set(
+        (current.scaleX * current.baseScaleX) / Math.max(1e-6, baseScaleX),
+        (current.scaleY * current.baseScaleY) / Math.max(1e-6, baseScaleY),
+      );
+      previousVisual.position.set(
+        current.zoomShiftX / Math.max(1e-6, baseScaleX),
+        -current.zoomShiftY / Math.max(1e-6, baseScaleY),
+      );
+    }
+    current.zoomSessionId += 1;
+    current.scaleX = 1;
+    current.scaleY = 1;
+    current.zoomShiftX = 0;
+    current.zoomShiftY = 0;
+
     current.baseScaleX = baseScaleX;
     current.baseScaleY = baseScaleY;
     current.baseX = baseX;
@@ -3179,6 +3370,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     if (previousVisual && previousVisual !== built.visual && fadeMs > 0) {
       const sessionId = ++current.replaceFadeSessionId;
       const previousAlpha = previousVisual.alpha;
+      current.outgoingVisual = previousVisual;
       void this.tween(
         fadeMs,
         (progress) => {
@@ -3195,25 +3387,29 @@ export class PixiStoryRenderer implements StoryRenderer {
             current.replaceFadeSessionId !== sessionId
           )
             return;
-          previousVisual.removeFromParent();
+          if (current.outgoingVisual === previousVisual)
+            current.outgoingVisual = null;
+          this.discardCharacterVisual(previousVisual);
         },
       );
-    } else {
-      previousVisual?.removeFromParent();
+    } else if (previousVisual && previousVisual !== built.visual) {
+      this.discardCharacterVisual(previousVisual);
     }
 
     return current;
   }
 
   /**
-   * Web approximation of the greenscreen black band: native feeds
-   * bstart/bend through `CharacterParam` into
-   * `AVGCharacterSlot._LoadImage` (0x183eb4f60) -> `AVGCharacterSpriteHub::
-   * SetImage`, which passes the values to the material verbatim -- unlike
-   * `SlotChangeMask` (the dead `charslotmask` channel), which tweens
-   * `_BlackStart/_BlackEnd` as 1-x. So no inversion belongs here; the exact
-   * band geometry lives in the greenscreen shader, which the DLL cannot
-   * show, and this static top-down gradient is the approximation.
+   * Web approximation of the greenscreen black band. Native feeds bstart/bend
+   * through `CharacterParam` into `AVGCharacterSlot._LoadImage` (0x183eb4f60)
+   * -> `AVGCharacterSpriteHub._SetImage` -> `AlphaSplitImageHolder.SetSprite`
+   * (0x183ec5e60), which writes the material floats as
+   * `_BlackStart = 1 - bstart` and `_BlackEnd = 1 - bend` -- the same 1-x the
+   * dead `charslotmask` channel (`SlotChangeMask`) tweens, so both channels
+   * hand the shader identical values and one mapping serves both. The band
+   * geometry itself lives in the greenscreen shader, which the DLL cannot
+   * show; this static top-down gradient was matched against the client
+   * visually and is the approximation.
    */
   private applyCharacterBlackGradient(
     content: Container,
@@ -3265,7 +3461,8 @@ export class PixiStoryRenderer implements StoryRenderer {
    * before the vertex colour multiplies the result. Keeping two stacked Pixi
    * sprites instead would fade each layer with its own copy of the alpha
    * (`1-(1-p)^2` over the face) and double-apply `_BlackStart` shading, so the
-   * composite is baked once per (base, face) pair and cached.
+   * composite is baked once per (base, face) pair and cached (bounded by
+   * `FACE_OVERLAY_CACHE_LIMIT`, refcounted by the visuals drawing it).
    *
    * The face texture is stretched to `faceRect` as-is (no aspect-ratio
    * preservation): the CDN face PNG matches what native maps through the
@@ -3278,9 +3475,14 @@ export class PixiStoryRenderer implements StoryRenderer {
     faceTexture: Texture,
     faceRect: { x: number; y: number; w: number; h: number },
   ): Texture | null {
-    const cacheKey = `${baseKey}|${faceKey}`;
+    const cacheKey = faceOverlayCacheKey(baseKey, faceKey);
     const cached = this.faceOverlayTextures.get(cacheKey);
-    if (cached) return cached;
+    if (cached) {
+      // Refresh recency: the Map's insertion order is the eviction order.
+      this.faceOverlayTextures.delete(cacheKey);
+      this.faceOverlayTextures.set(cacheKey, cached);
+      return cached.texture;
+    }
 
     const baseResource = baseTexture.source?.resource as
       CanvasImageSource | undefined;
@@ -3324,8 +3526,46 @@ export class PixiStoryRenderer implements StoryRenderer {
     const texture = new Texture({
       source: new CanvasSource({ resource: canvas }),
     });
-    this.faceOverlayTextures.set(cacheKey, texture);
+    this.faceOverlayTextures.set(cacheKey, { refs: 0, texture });
+    this.trimFaceOverlayCache();
     return texture;
+  }
+
+  /** Pins a cached bake for as long as `visual` is on stage. */
+  private retainFaceOverlay(visual: Container, cacheKey: string): void {
+    const entry = this.faceOverlayTextures.get(cacheKey);
+    if (!entry) return;
+    entry.refs += 1;
+    this.faceOverlayVisualKeys.set(visual, cacheKey);
+  }
+
+  private releaseCharacterVisual(visual: Container): void {
+    const cacheKey = this.faceOverlayVisualKeys.get(visual);
+    if (cacheKey === undefined) return;
+    this.faceOverlayVisualKeys.delete(visual);
+    const entry = this.faceOverlayTextures.get(cacheKey);
+    if (entry) entry.refs = Math.max(0, entry.refs - 1);
+    this.trimFaceOverlayCache();
+  }
+
+  /** Takes a character visual off stage and drops its hold on its bake. */
+  private discardCharacterVisual(visual: Container): void {
+    visual.removeFromParent();
+    this.releaseCharacterVisual(visual);
+  }
+
+  /**
+   * Evicts the least recently baked entries nobody draws any more until the
+   * cache is back under `FACE_OVERLAY_CACHE_LIMIT`. Entries still on stage
+   * are skipped, so the cap is soft.
+   */
+  private trimFaceOverlayCache(): void {
+    for (const [key, entry] of this.faceOverlayTextures) {
+      if (this.faceOverlayTextures.size <= FACE_OVERLAY_CACHE_LIMIT) return;
+      if (entry.refs > 0) continue;
+      this.faceOverlayTextures.delete(key);
+      entry.texture.destroy(true);
+    }
   }
 
   private bakeDarkenedCharacterTexture(
@@ -3379,88 +3619,6 @@ export class PixiStoryRenderer implements StoryRenderer {
     ctx.fillRect(0, 0, canvas.width, canvas.height);
 
     return new Texture({ source: new CanvasSource({ resource: canvas }) });
-  }
-
-  private characterSlotFromTransform(
-    state: CharacterRenderState,
-    input: CharacterSlotInput,
-  ): { scaleX: number; scaleY: number; x: number; y: number } {
-    // Native never resets a slot's transform between charslot commands:
-    // `_UpdateSeqWithParam` @ 0x183e53940 calls
-    // `SlotSetCharWithParam(slot, options, resetOffsetPos: false)` (literal 0
-    // at the call site), so `_SlotSetCharInternal`'s
-    // `if (resetOffsetPos && !IsNullOrEmpty(charName)) _offset.pos = zero`
-    // never fires on the charslot path and the offset keeps its
-    // localPosition; zoom scale lives on the fore image, which survives
-    // swaps. A command without pos/zoom input therefore starts from whatever
-    // transform the slot currently holds; only an explicit `posfrom` is
-    // absolute (SlotMoveChar sets localPosition = posFrom first), and only on
-    // the branches that actually reach SlotMoveChar (see
-    // `characterSlotUsesAbsoluteMove`).
-    if (input.positionFrom && characterSlotUsesAbsoluteMove(input)) {
-      return {
-        scaleX: state.scaleX,
-        scaleY: state.scaleY,
-        x: input.positionFrom.x,
-        y: input.positionFrom.y,
-      };
-    }
-
-    return {
-      scaleX: state.scaleX,
-      scaleY: state.scaleY,
-      x: state.actionX,
-      y: state.actionY,
-    };
-  }
-
-  private characterSlotToTransform(
-    state: CharacterRenderState,
-    input: CharacterSlotInput,
-    from: { scaleX: number; scaleY: number; x: number; y: number },
-  ): { scaleX: number; scaleY: number; x: number; y: number } {
-    let toX = from.x;
-    let toY = from.y;
-    // `_UpdateSeqWithParam` picks `_GenSlotActionTw` XOR `_GenCharslotMove`,
-    // so posfrom/posto only reach SlotMoveChar on the branches listed in
-    // `characterSlotUsesAbsoluteMove`; zoom/shake ignore them outright. The
-    // plain move is additionally gated on posFrom != (1,1), which is why a
-    // bare `posto` is a no-op. `action="jump"` is the one relative form:
-    // CharJump (0x183eb2690) lands at `localPosition + posTo`.
-    if (input.positionTo) {
-      if (characterSlotUsesAbsoluteMove(input) && input.positionFrom) {
-        toX = input.positionTo.x;
-        toY = input.positionTo.y;
-      } else if (characterSlotUsesRelativeMove(input)) {
-        toX += input.positionTo.x;
-        toY += input.positionTo.y;
-      }
-    }
-
-    let toScaleX = from.scaleX;
-    let toScaleY = from.scaleY;
-    if (input.action === "zoom") {
-      // CharZoom validates the pivot first: x/y outside [0,1] => return null,
-      // skipping the whole zoom (scale change included). An absent poszoom
-      // defaults to (1,1), which is inside the valid range; the Web port
-      // keeps treating an absent pivot as "no extra shift".
-      const zoom = input.posZoom;
-      const pivotValid =
-        !zoom || (zoom.x >= 0 && zoom.x <= 1 && zoom.y >= 0 && zoom.y <= 1);
-      if (pivotValid) {
-        // `CharZoom(zoomPos.x, zoomPos.y, options.scale, duration)` always
-        // tweens the fore image to `options.scale`, whose GetOrDefault falls
-        // back to 1.0 (0x183e4dcea) -- a zoom without `scale` resets it.
-        toScaleX = isFiniteNumber(input.scaleX) ? input.scaleX : 1;
-        toScaleY = isFiniteNumber(input.scaleY) ? input.scaleY : 1;
-        if (zoom) {
-          toX += (0.5 - zoom.x) * toScaleX * state.width;
-          toY += (zoom.y - 0.5) * toScaleY * state.height;
-        }
-      }
-    }
-
-    return { scaleX: toScaleX, scaleY: toScaleY, x: toX, y: toY };
   }
 
   private applyCharacterSlotFocus(focusSlots: string[]): void {
@@ -3616,9 +3774,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   private updateCharacterState(state: CharacterRenderState): void {
-    state.motionLayer.x = state.actionX + state.shakeOffsetX;
+    state.motionLayer.x = state.actionX + state.zoomShiftX + state.shakeOffsetX;
     state.motionLayer.y =
-      state.shakeOffsetY - state.actionY - state.jumpOffsetY;
+      state.shakeOffsetY - state.actionY - state.zoomShiftY - state.jumpOffsetY;
     state.motionLayer.scale.set(
       state.baseScaleX * state.scaleX,
       state.baseScaleY * state.scaleY,
@@ -3637,10 +3795,16 @@ export class PixiStoryRenderer implements StoryRenderer {
     state.opacitySessionId += 1;
     state.replaceFadeSessionId += 1;
     state.transformSessionId += 1;
+    state.zoomSessionId += 1;
     state.jumpSessionId += 1;
     this.stopRotateAction(state);
     this.stopShakeAction(state);
     state.root.removeFromParent();
+    // The current visual and any still-fading previous one both hold a
+    // face-overlay bake.
+    for (const child of state.rotationLayer.children)
+      this.releaseCharacterVisual(child as Container);
+    state.outgoingVisual = null;
   }
 
   private normalizeCharacterSlot(slot?: string): string {

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -168,10 +168,10 @@ function characterSlotMove(
 /**
  * The zoom half of a `charslot`: CharZoom (0x183eb2b50) tweens the fore
  * Image's `rectTransform.pivot` to `zoomPos` and its `localScale` to `scale`
- * (setter `<CharZoom>b__1` 0x183ed95a0), both absolute -- re-issuing the same
- * zoom lands on the same transform instead of stacking. The pivot move is
- * approximated as a translation of the scaled sprite. Returns null when the
- * command is not a zoom or CharZoom would reject the pivot.
+ * (setter `<CharZoom>b__1` 0x183ed95a0 lerp-drives both from one 0→1 float,
+ * Ease.Linear), both absolute -- re-issuing the same zoom lands on the same
+ * transform instead of stacking. Returns null when the command is not a zoom
+ * or CharZoom would reject the pivot.
  */
 function characterSlotZoom(
   state: CharacterRenderState,
@@ -181,7 +181,9 @@ function characterSlotZoom(
   // CharZoom validates the pivot first: x/y outside [0,1] => return null,
   // skipping the whole zoom (scale change included). An absent poszoom
   // defaults to (1,1), which is inside the valid range; the Web port keeps
-  // treating an absent pivot as "no extra shift".
+  // treating an absent pivot as (0.5,0.5) ("no pivot move"). Every zoom in
+  // the 2.7.61 corpus writes poszoom, so the native (1,1) default is
+  // unobservable there.
   const zoom = input.posZoom;
   const pivotValid =
     !zoom || (zoom.x >= 0 && zoom.x <= 1 && zoom.y >= 0 && zoom.y <= 1);
@@ -192,6 +194,20 @@ function characterSlotZoom(
   // -- a zoom without `scale` resets it.
   const toScaleX = isFiniteNumber(input.scaleX) ? input.scaleX : 1;
   const toScaleY = isFiniteNumber(input.scaleY) ? input.scaleY : 1;
+  // anchoredPosition is not tweened, and every character prefab ships pivot
+  // (0.5,0.5) / localScale 1 / sizeDelta = character.json size (verified on
+  // avg_npc_2227_1, avg_4225_tanya_1, avg_npc_820_1), so the pivot point
+  // stays where the resting rect was centred: the rect grows `scale`x
+  // around the fixed point at zoomPos, and its centre lands at
+  // `T + scale * (0.5 - zoomPos) * size` (Unity axes). The motion layer
+  // instead scales around the rect's top-left corner, so the shift must
+  // both move the scaled centre there and cancel that corner-origin growth:
+  //   (0.5 - z) * scale * size - (scale - 1) * size / 2
+  // (shiftY is stored in Unity's y-up and negated on apply). Tweening the
+  // shift linearly makes the endpoints exact and leaves a small mid-tween
+  // gap versus native's lerp(scale)*lerp(0.5-pivot) product curve.
+  const pivotX = zoom?.x ?? 0.5;
+  const pivotY = zoom?.y ?? 0.5;
   return {
     from: {
       scaleX: state.scaleX,
@@ -202,8 +218,12 @@ function characterSlotZoom(
     to: {
       scaleX: toScaleX,
       scaleY: toScaleY,
-      shiftX: zoom ? (0.5 - zoom.x) * toScaleX * state.width : 0,
-      shiftY: zoom ? (zoom.y - 0.5) * toScaleY * state.height : 0,
+      shiftX:
+        (0.5 - pivotX) * toScaleX * state.width -
+        ((toScaleX - 1) * state.width) / 2,
+      shiftY:
+        (0.5 - pivotY) * toScaleY * state.height +
+        ((toScaleY - 1) * state.height) / 2,
     },
   };
 }

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -394,6 +394,17 @@ export class PixiStoryRenderer implements StoryRenderer {
   private readonly context: Context;
   private readonly charLayer = this.layers.characters;
   private readonly characterSlots = new Map<string, CharacterRenderState>();
+  /**
+   * 每槽缓存 `DOTween.Sequence` 的完成时刻（`performance.now()` 毫秒）。
+   * `_GetCachedSlotSeq`（0x183e4f830）在 Sequence 未被 `end` 挂的
+   * OnComplete 标记 played 前一直复用同一条，而 `_UpdateSeqWithTween`
+   * （0x183e53fc0）把每条 charslot tween `Insert` 到各自 `delay` 上——
+   * 并行、从不 Append——所以 Sequence 在"全部已插入 tween 的最大结束
+   * 时刻"完成。`isblock` 等的就是这一刻（OnComplete → FinishCommand，
+   * 0x183e4e501）：紧跟 `end=false` 入场之后的 shake 要等两者同时结束，
+   * 但各自仍从自己命令的发出时刻起播。
+   */
+  private readonly characterSlotSeqDeadlines = new Map<string, number>();
   private readonly faceOverlayTextures = new Map<
     string,
     FaceOverlayCacheEntry
@@ -673,6 +684,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     for (const state of this.characterSlots.values())
       this.disposeCharacterState(state);
     this.characterSlots.clear();
+    this.characterSlotSeqDeadlines.clear();
     for (const entry of this.faceOverlayTextures.values())
       entry.texture.destroy(true);
     this.faceOverlayTextures.clear();
@@ -1772,12 +1784,35 @@ export class PixiStoryRenderer implements StoryRenderer {
    * `defaultAutoPlay` is `AutoPlay.All` (cctor 0x18410b0e0). `end=false` only
    * skips the `OnComplete(_SetSeqPlayed)` + redundant `Play()` pair at
    * 0x183e4e501, which in turn is what gates `isblock` (0x183e4e56f) -- it
-   * never defers the animation, so nothing is queued here.
+   * never defers the animation, so nothing is queued here. `isblock` instead
+   * waits for the whole cached Sequence (see characterSlotSeqDeadlines), not
+   * for this command's own tweens.
    */
   private async setCharacterSlot(input: CharacterSlotInput): Promise<void> {
     const slot = this.normalizeCharacterSlot(input.slot);
     let state = this.characterSlots.get(slot);
     const hasCharacter = Boolean(input.characterKey && input.expression);
+
+    // The deadline is anchored at dispatch time; the block wait at the end
+    // starts once this command's tweens are running, so an async asset load
+    // shifts the wait and its end equally -- native inserts the crossfade
+    // tweens into the same sequence only after the load completes. Every
+    // action contributes `durationMs`: DOLocalJump's duration spans all
+    // `times` jumps (0x183eb2690), and `CharShake`/`CharZoom` are plain
+    // duration-length tweens.
+    const durationMs = Math.max(0, Math.round(input.durationMs ?? 0));
+    let blockWaitMs = 0;
+    if (input.slotSequence) {
+      const nowMs = performance.now();
+      const cachedDeadlineMs = this.characterSlotSeqDeadlines.get(slot) ?? 0;
+      const seqDeadlineMs = Math.max(
+        cachedDeadlineMs,
+        nowMs,
+        nowMs + durationMs,
+      );
+      this.characterSlotSeqDeadlines.set(slot, seqDeadlineMs);
+      if (input.block) blockWaitMs = seqDeadlineMs - nowMs;
+    }
 
     if (hasCharacter) {
       const built = await this.buildCharacterSlotState(input, slot, state);
@@ -1789,12 +1824,12 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     if (!state) {
       if (input.focusMode) this.applyCharacterSlotFocus(input.focusSlots ?? []);
+      if (blockWaitMs > 0) await this.tween(blockWaitMs, () => {});
       return;
     }
 
     if (input.focusMode) this.applyCharacterSlotFocus(input.focusSlots ?? []);
 
-    const durationMs = Math.max(0, Math.round(input.durationMs ?? 0));
     const move = characterSlotMove(state, input);
     const zoom = characterSlotZoom(state, input);
 
@@ -1865,13 +1900,11 @@ export class PixiStoryRenderer implements StoryRenderer {
     // resets the zoom but leaves a running move alone, and a command whose
     // from == to starts nothing, so an in-flight tween of either kind
     // survives an unrelated command.
-    const pending: Promise<void>[] = [];
-
     if (move && (move.from.x !== move.to.x || move.from.y !== move.to.y)) {
       const sessionId = ++state.transformSessionId;
       const moveDurationMs = input.action === "setpos" ? 0 : durationMs;
       const { from, to } = move;
-      const run = this.tween(
+      void this.tween(
         moveDurationMs,
         (progress) => {
           if (!this.isActiveCharacterState(state, sessionId)) return;
@@ -1886,8 +1919,6 @@ export class PixiStoryRenderer implements StoryRenderer {
           this.updateCharacterState(state);
         },
       );
-      if (moveDurationMs > 0) pending.push(run);
-      else void run;
     }
 
     if (
@@ -1899,7 +1930,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     ) {
       const sessionId = ++state.zoomSessionId;
       const { from, to } = zoom;
-      const run = this.tween(
+      void this.tween(
         durationMs,
         (progress) => {
           if (
@@ -1926,11 +1957,12 @@ export class PixiStoryRenderer implements StoryRenderer {
           this.updateCharacterState(state);
         },
       );
-      if (durationMs > 0) pending.push(run);
-      else void run;
     }
 
-    if (input.block && pending.length > 0) await Promise.all(pending);
+    // `isblock` waits for the slot's whole cached Sequence -- this command's
+    // shake/jump/rotate tweens included, plus whatever a still-running
+    // `end=false` enter on the same slot left in it -- not just move/zoom.
+    if (blockWaitMs > 0) await this.tween(blockWaitMs, () => {});
   }
 
   /**

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -145,8 +145,11 @@ function characterSlotMove(
     }
     case "jump": {
       if ((input.durationMs ?? 0) > 0) {
-        // CharJump (0x183eb2690): DOLocalJump to `localPosition + posTo`,
-        // and posTo defaults to (1,1) -- a bare jump drifts one unit.
+        // CharJump (0x183eb2690): DOLocalJump to `localPosition + posTo`.
+        // An omitted posto stays at the (1,1) default -- a bare jump drifts
+        // one unit -- while a posto that is present but not an "x,y" pair
+        // becomes Vector2.zero (0x183e4e2db-0x183e4e322); the runtime hands
+        // that case in as (0,0).
         return {
           from: { x: state.actionX, y: state.actionY },
           to: { x: state.actionX + posTo.x, y: state.actionY + posTo.y },
@@ -403,6 +406,17 @@ export class PixiStoryRenderer implements StoryRenderer {
    * 时刻"完成。`isblock` 等的就是这一刻（OnComplete → FinishCommand，
    * 0x183e4e501）：紧跟 `end=false` 入场之后的 shake 要等两者同时结束，
    * 但各自仍从自己命令的发出时刻起播。
+   *
+   * 复用只在同一帧内成立：`TweenManager.Update(Tween, …)`（0x1841495c0）
+   * 在 tween 首次更新时置 `creationLocked`，此后 `Insert`（0x18411da10）
+   * 只打 `LogAddToLockedSequence` 就返回；播完的 Sequence 又因
+   * `defaultAutoKill`（cctor 0x18410b0e0）失活，而 `end=false` 的从不被标
+   * played，`_GetCachedSlotSeq` 会继续交出这条死 Sequence，Insert 与
+   * OnComplete 都成 no-op。AVG 的 `_DoExecuteCommands`（0x183e2b9c0）把
+   * 连续非阻塞命令在同一次 MoveNext 里跑完，所以相邻命令共享 Sequence；
+   * 隔了对白或阻塞命令之后，native 只等旧 Sequence 的剩余时间。全语料
+   * `end=false` 后接同槽 isblock 的只有相邻两处（act23side_02_beg 425→426、
+   * 555→556），这里按 max(旧 deadline, 自身 duration) 近似，不建模上锁。
    */
   private readonly characterSlotSeqDeadlines = new Map<string, number>();
   private readonly faceOverlayTextures = new Map<
@@ -1793,14 +1807,25 @@ export class PixiStoryRenderer implements StoryRenderer {
     let state = this.characterSlots.get(slot);
     const hasCharacter = Boolean(input.characterKey && input.expression);
 
-    // The deadline is anchored at dispatch time; the block wait at the end
-    // starts once this command's tweens are running, so an async asset load
-    // shifts the wait and its end equally -- native inserts the crossfade
-    // tweens into the same sequence only after the load completes. Every
-    // action contributes `durationMs`: DOLocalJump's duration spans all
-    // `times` jumps (0x183eb2690), and `CharShake`/`CharZoom` are plain
-    // duration-length tweens.
     const durationMs = Math.max(0, Math.round(input.durationMs ?? 0));
+
+    if (hasCharacter) {
+      const built = await this.buildCharacterSlotState(input, slot, state);
+      // Only a linkMap miss or a texture load failure lands here; the runtime
+      // already turns an unresolvable `name` into a slot clear (native swaps
+      // the Images before `_LoadImage`, so the old art fades out as the back
+      // Image). Keep whatever the slot shows and still run the action/focus
+      // sections, as `_UpdateSeqWithParam` does after a failed load.
+      if (built) state = built;
+    }
+
+    // The deadline is anchored once the asset is in, i.e. when this command's
+    // tweens actually start (native only inserts the crossfade tweens after
+    // its synchronous load), so a slow load neither shortens the wait of a
+    // later same-slot `isblock` nor this one's. Every action contributes
+    // `durationMs`: DOLocalJump's duration spans all `times` jumps
+    // (0x183eb2690), and `CharShake`/`CharZoom` are plain duration-length
+    // tweens.
     let blockWaitMs = 0;
     if (input.slotSequence) {
       const nowMs = performance.now();
@@ -1812,14 +1837,6 @@ export class PixiStoryRenderer implements StoryRenderer {
       );
       this.characterSlotSeqDeadlines.set(slot, seqDeadlineMs);
       if (input.block) blockWaitMs = seqDeadlineMs - nowMs;
-    }
-
-    if (hasCharacter) {
-      const built = await this.buildCharacterSlotState(input, slot, state);
-      // A failed `_LoadImage` (missing asset) only nulls m_currentKey; the
-      // action/focus sections still run on the sprite the slot already
-      // shows, so keep the previous state instead of aborting.
-      if (built) state = built;
     }
 
     if (!state) {
@@ -3398,7 +3415,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     // contentAlpha (set to `afrom` right after by the caller) and only the
     // outgoing visual gets a dedicated fade here.
     const fadeMs = Math.max(0, Math.round(input.replaceFadeMs ?? 0));
-    built.visual.alpha = current.contentAlpha;
+    built.visual.alpha = clamp01(current.contentAlpha);
     if (previousVisual && previousVisual !== built.visual && fadeMs > 0) {
       const sessionId = ++current.replaceFadeSessionId;
       const previousAlpha = previousVisual.alpha;
@@ -3677,7 +3694,11 @@ export class PixiStoryRenderer implements StoryRenderer {
     const hasTo = isFiniteNumber(input.alphaTo);
     if (!hasFrom && !hasTo) return;
 
-    const fromAlpha = hasFrom ? input.alphaFrom! : state.contentAlpha;
+    // `contentAlpha` mirrors the fore Image's vertex alpha, which native lets
+    // overshoot below 0 (a nameless `afrom` fades toward ato = -1); it is only
+    // clamped at the write in updateCharacterOpacity, so a resumed fade starts
+    // from the visible value.
+    const fromAlpha = hasFrom ? input.alphaFrom! : clamp01(state.contentAlpha);
     const toAlpha = hasTo ? input.alphaTo! : fromAlpha;
     state.contentAlpha = fromAlpha;
     this.updateCharacterOpacity(state);
@@ -3820,7 +3841,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   private updateCharacterOpacity(state: CharacterRenderState): void {
     const channel = Math.round(0xff * clamp01(state.focusBrightness));
     state.visual.tint = (channel << 16) | (channel << 8) | channel;
-    state.visual.alpha = state.contentAlpha;
+    // Unity's Color -> Color32 conversion clamps the vertex alpha, so a tween
+    // toward a negative `ato` reads as fully transparent once it crosses 0.
+    state.visual.alpha = clamp01(state.contentAlpha);
   }
 
   private disposeCharacterState(state: CharacterRenderState): void {

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -203,6 +203,19 @@ function toBoolean(value: unknown, fallback = false): boolean {
   return fallback;
 }
 
+/**
+ * Native port: `Command.GetOrDefault<int>` runs the JSON-boxed parameter value
+ * through `System.Convert.ToInt32`. AVGParser wraps the parameter list in JSON,
+ * so `random=true` arrives as a real boolean and converts to 1 (false to 0) --
+ * it never means "enabled".
+ */
+function toNativeIntParam(value: unknown, fallback: number): number {
+  if (typeof value === "boolean") return value ? 1 : 0;
+  if (value === "true") return 1;
+  if (value === "false") return 0;
+  return Math.trunc(toNumber(value, fallback));
+}
+
 function toString(value: unknown, fallback = ""): string {
   if (typeof value === "string") return value;
   if (typeof value === "number" || typeof value === "boolean")
@@ -1856,10 +1869,17 @@ export class StoryRuntime {
         const rawSlot = toString(args.slot).trim();
         const slot = this.parseCharacterSlot(rawSlot);
         const nameRef = toString(args.name);
-        // Native port: Torappu.AVG.AVGCharacterslotPanel._ExecuteCharslot. Duration
-        // defaults to 0.0 and goes through CalculateFadetime; zero skips animation.
+        // Native port: Torappu.AVG.AVGCharacterslotPanel._ExecuteCharslot
+        // (2.7.61, VA 0x183e4d310). Duration defaults to 0.0 and goes through
+        // CalculateFadetime; zero skips animation.
         const durationMs = Math.round(this.calculateFadeMs(args.duration, 0));
         const block = toBoolean(args.isblock, false);
+        // Native reads `end` (default true) only to decide whether the
+        // assembled per-slot Sequence plays (`end=false` fills the cached
+        // sequence but never calls Play, leaving it for a later `end=true`
+        // command on the same slot to fire). It is not a
+        // transform-preservation switch.
+        const deferPlay = toString(args.end).trim().toLowerCase() === "false";
 
         // The clear branch keys off an empty `slot`, never an empty `name`, and it
         // only touches the three built-in slots (custom slots are left alone).
@@ -1885,10 +1905,48 @@ export class StoryRuntime {
           return "continue";
         }
 
-        const resolved = nameRef ? this.resolveCharacterName(nameRef) : null;
-        if (nameRef && !resolved) {
-          this.warn("missing_asset", `character: ${nameRef}`);
-          return "continue";
+        // `name` is never ToLower'd natively, and `_UpdateSeqWithParam`
+        // (0x183e53940) compares it to "char_empty" with an ordinal
+        // String.op_Equality: that value routes to
+        // AVGCharacterSlot.SlotCleanChar (fade the slot's sprite out) and the
+        // action/focus sections keep executing. The later `_LoadImage` on
+        // "char_empty" only fails and nulls m_currentKey.
+        const isEmptyChar = nameRef === "char_empty";
+
+        let resolved: { base: string; expression: string } | null = null;
+        if (nameRef && !isEmptyChar) {
+          resolved = this.resolveCharacterName(nameRef);
+          if (!resolved) {
+            // Native `_LoadImage` failure just logs "[AVG] Error to load
+            // character pic" and nulls m_currentKey; the action/focus sections
+            // of `_UpdateSeqWithParam` still run on whatever the slot shows.
+            // Keep going without the image swap instead of dropping the
+            // whole command.
+            this.warn("missing_asset", `character: ${nameRef}`);
+          }
+        }
+
+        if (isEmptyChar && !deferPlay) {
+          // SlotCleanChar lives inside the same Sequence, so `end=false`
+          // defers the clean together with the rest of the tweens.
+          const clearPromise = this.renderer.clearCharacters(slot, durationMs);
+          if (block) await clearPromise;
+          else void clearPromise;
+        }
+
+        // Native `_UpdateSeqWithParam`: with a `name`, a negative (or
+        // omitted, default -1) afrom or ato resets the pair to (0, 1) -- a
+        // plain named charslot always fades the new art in over `duration`.
+        // Only a nameless command treats -1 as "leave the alpha alone".
+        const rawAlphaFrom =
+          args.afrom === undefined ? -1 : toNumber(args.afrom, -1);
+        const rawAlphaTo = args.ato === undefined ? -1 : toNumber(args.ato, -1);
+        let alphaFrom =
+          rawAlphaFrom >= 0 ? clamp(rawAlphaFrom, 0, 1) : undefined;
+        let alphaTo = rawAlphaTo >= 0 ? clamp(rawAlphaTo, 0, 1) : undefined;
+        if (resolved && (rawAlphaFrom < 0 || rawAlphaTo < 0)) {
+          alphaFrom = 0;
+          alphaTo = 1;
         }
 
         await this.renderer.setCharacter({
@@ -1896,14 +1954,8 @@ export class StoryRuntime {
           ...(args.angle === undefined
             ? {}
             : { angle: toNumber(args.angle, 0) }),
-          alphaFrom:
-            args.afrom === undefined
-              ? undefined
-              : clamp(toNumber(args.afrom, 1), 0, 1),
-          alphaTo:
-            args.ato === undefined
-              ? undefined
-              : clamp(toNumber(args.ato, 1), 0, 1),
+          alphaFrom,
+          alphaTo,
           blackEnd:
             args.bend === undefined
               ? undefined
@@ -1917,12 +1969,13 @@ export class StoryRuntime {
           ...(args.circles === undefined
             ? {}
             : { circles: Math.trunc(toNumber(args.circles, 0)) }),
+          deferPlay,
           durationMs,
           expression: resolved?.expression,
           fadeIdentity: nameRef
             ? nativeCharacterFadeIdentity(nameRef)
             : undefined,
-          focusMode: this.resolveCharacterSlotFocusMode(args, Boolean(nameRef)),
+          focusMode: "subset",
           focusSlots: this.resolveCharacterSlotFocusSlots(args),
           ...(args.inverse === undefined
             ? {}
@@ -1932,14 +1985,12 @@ export class StoryRuntime {
           positionTo: this.parseCharacterSlotPoint(args.posto),
           posZoom: this.parseCharacterSlotPoint(args.poszoom),
           power: Math.max(0, toNumber(args.power, 0)),
-          preserveTransform:
-            toString(args.end).trim().toLowerCase() === "false",
-          randomness: clamp(toNumber(args.random, 90), 0, 100),
-          replaceFadeMs: Math.max(
-            0,
-            Math.round(toNumber(args.fadetime, 0) * 1000),
-          ),
-          resetTransform: toString(args.end).trim().toLowerCase() !== "false",
+          randomness: clamp(toNativeIntParam(args.random, 10), 0, 100),
+          // The crossfade length of an image swap is `duration` itself
+          // (`_SlotSetCharInternal` -> `_GenForeImageTween` /
+          // `_GenBackImageTween`). `fadetime` is not a charslot key at all
+          // (dead parameter in both 2.7.51 and 2.7.61 audits).
+          replaceFadeMs: durationMs,
           scaleX:
             args.xscale === undefined && args.scale === undefined
               ? undefined
@@ -3071,30 +3122,21 @@ export class StoryRuntime {
     };
   }
 
-  private resolveCharacterSlotFocusMode(
-    args: StoryCommandArgs,
-    hasName: boolean,
-  ): CharacterSlotInput["focusMode"] | undefined {
+  private resolveCharacterSlotFocusSlots(args: StoryCommandArgs): string[] {
+    // Native `_ExecuteCharslot` turns an omitted `focus` into ["all"], and
+    // `_ProcessFocusArray` (2.7.61, VA 0x183e50b30) recognizes only
+    // all / left|l / middle|m / right|r / custom|c. There is no "n"/"none"/"a"
+    // branch: an unrecognized value clears all four focus flags and lights
+    // nothing, i.e. every slot goes dim. Custom slots are not modeled, so
+    // "all" maps to the three built-ins.
     const focus = toString(args.focus).trim().toLowerCase();
-    if (!focus) return hasName ? "current_only" : undefined;
-    if (focus === "n" || focus === "none") return "none";
-    if (focus === "a" || focus === "all") return "subset";
-    if (this.resolveCharacterSlotFocusSlots(args)?.length) return "subset";
-    return hasName ? "current_only" : undefined;
-  }
-
-  private resolveCharacterSlotFocusSlots(
-    args: StoryCommandArgs,
-  ): string[] | undefined {
-    const focus = toString(args.focus).trim().toLowerCase();
-    if (!focus) return undefined;
-    if (focus === "a" || focus === "all") return ["l", "m", "r"];
+    if (!focus || focus === "all") return ["l", "m", "r"];
 
     const slots = focus
       .split(",")
       .map((value) => this.parseCharacterSlot(value))
       .filter((slot): slot is string => slot !== undefined);
-    return slots.length > 0 ? [...new Set(slots)] : undefined;
+    return [...new Set(slots)];
   }
 
   private parseCharacterActionSlot(

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -213,7 +213,16 @@ function toNativeIntParam(value: unknown, fallback: number): number {
   if (typeof value === "boolean") return value ? 1 : 0;
   if (value === "true") return 1;
   if (value === "false") return 0;
-  return Math.trunc(toNumber(value, fallback));
+  return roundHalfToEven(toNumber(value, fallback));
+}
+
+/** `System.Convert.ToInt32(double)` rounds half to even, not toward zero. */
+function roundHalfToEven(value: number): number {
+  const floor = Math.floor(value);
+  const fraction = value - floor;
+  if (fraction < 0.5) return floor;
+  if (fraction > 0.5) return floor + 1;
+  return floor % 2 === 0 ? floor : floor + 1;
 }
 
 function toString(value: unknown, fallback = ""): string {
@@ -1915,44 +1924,68 @@ export class StoryRuntime {
 
         // `name` is never ToLower'd natively, and `_UpdateSeqWithParam`
         // (0x183e53940) compares it to "char_empty" with an ordinal
-        // String.op_Equality: that value routes to
-        // AVGCharacterSlot.SlotCleanChar (fade the slot's sprite out) and the
-        // action/focus sections keep executing. The later `_LoadImage` on
-        // "char_empty" only fails and nulls m_currentKey.
+        // String.op_Equality. That value runs AVGCharacterSlot.SlotCleanChar
+        // (0x183eb4260) and then still falls through to SlotSetCharWithParam
+        // with the same name: two `_SwapImages` in a row put the old art back
+        // in front, and the second `_LoadImage` (0x183eb4f60) opens with
+        // `DOKill(m_image)` -- killing the fade the first swap started --
+        // before `set_sprite(null)` + `enabled = false`. The slot is emptied
+        // on the spot regardless of `duration`; action/focus keep executing.
         const isEmptyChar = nameRef === "char_empty";
 
         let resolved: { base: string; expression: string } | null = null;
-        if (nameRef && !isEmptyChar) {
+        let clearPromise: Promise<void> | null = null;
+        if (isEmptyChar) {
+          clearPromise = Promise.resolve(
+            this.renderer.clearCharacters(slot, 0),
+          );
+        } else if (nameRef) {
           resolved = this.resolveCharacterName(nameRef);
           if (!resolved) {
-            // Native `_LoadImage` failure just logs "[AVG] Error to load
-            // character pic" and nulls m_currentKey; the action/focus sections
-            // of `_UpdateSeqWithParam` still run on whatever the slot shows.
-            // Keep going without the image swap instead of dropping the
-            // whole command.
+            // `_SlotSetCharInternal` (0x183eb5830) swaps the Images *before*
+            // `_LoadImage`, so a failed load ("[AVG] Error to load character
+            // pic") leaves the old art as the back Image -- which
+            // `_GenBackImageTween(duration).Play()` fades out -- while the new
+            // fore Image is disabled. The slot ends up empty; the action and
+            // focus sections of `_UpdateSeqWithParam` still run.
             this.warn("missing_asset", `character: ${nameRef}`);
+            clearPromise = Promise.resolve(
+              this.renderer.clearCharacters(slot, durationMs),
+            );
           }
         }
-
-        if (isEmptyChar) {
-          const clearPromise = this.renderer.clearCharacters(slot, durationMs);
+        if (clearPromise) {
           if (block) await clearPromise;
           else void clearPromise;
         }
 
-        // Native `_UpdateSeqWithParam`: with a `name`, a negative (or
-        // omitted, default -1) afrom or ato resets the pair to (0, 1) -- a
-        // plain named charslot always fades the new art in over `duration`.
-        // Only a nameless command treats -1 as "leave the alpha alone".
+        // Native `_UpdateSeqWithParam` alpha handling:
+        // - with a `name`, a negative (or omitted, default -1) afrom or ato
+        //   resets the pair to (0, 1): a plain named charslot always fades
+        //   the new art in over `duration`;
+        // - without a `name`, only `GE(afrom, 0)` gates
+        //   `SlotChangeAlpha(afrom, ato, duration)` (0x183eb3d20), and ato is
+        //   passed through as-is. An omitted ato (-1) therefore tweens the
+        //   vertex colour toward alpha -1, which the canvas clamps to 0 -- a
+        //   fade-out (29 corpus lines write `afrom=1` with no ato as an exit,
+        //   e.g. story_whitw2_1_1.txt:475). duration 0 => SetAlpha(fore, ato)
+        //   with the same clamp. Approximated as a fade to 0 over `duration`.
         const rawAlphaFrom =
           args.afrom === undefined ? -1 : toNumber(args.afrom, -1);
         const rawAlphaTo = args.ato === undefined ? -1 : toNumber(args.ato, -1);
-        let alphaFrom =
-          rawAlphaFrom >= 0 ? clamp(rawAlphaFrom, 0, 1) : undefined;
-        let alphaTo = rawAlphaTo >= 0 ? clamp(rawAlphaTo, 0, 1) : undefined;
-        if (resolved && (rawAlphaFrom < 0 || rawAlphaTo < 0)) {
-          alphaFrom = 0;
-          alphaTo = 1;
+        let alphaFrom: number | undefined;
+        let alphaTo: number | undefined;
+        if (resolved) {
+          if (rawAlphaFrom < 0 || rawAlphaTo < 0) {
+            alphaFrom = 0;
+            alphaTo = 1;
+          } else {
+            alphaFrom = clamp(rawAlphaFrom, 0, 1);
+            alphaTo = clamp(rawAlphaTo, 0, 1);
+          }
+        } else if (!nameRef && rawAlphaFrom >= 0) {
+          alphaFrom = clamp(rawAlphaFrom, 0, 1);
+          alphaTo = rawAlphaTo < 0 ? 0 : clamp(rawAlphaTo, 0, 1);
         }
 
         await this.renderer.setCharacter({

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1873,13 +1873,18 @@ export class StoryRuntime {
         // (2.7.61, VA 0x183e4d310). Duration defaults to 0.0 and goes through
         // CalculateFadetime; zero skips animation.
         const durationMs = Math.round(this.calculateFadeMs(args.duration, 0));
-        const block = toBoolean(args.isblock, false);
-        // Native reads `end` (default true) only to decide whether the
-        // assembled per-slot Sequence plays (`end=false` fills the cached
-        // sequence but never calls Play, leaving it for a later `end=true`
-        // command on the same slot to fire). It is not a
-        // transform-preservation switch.
-        const deferPlay = toString(args.end).trim().toLowerCase() === "false";
+        // `end` (default true) is neither a transform-preservation switch nor
+        // a defer switch. `_GetCachedSlotSeq` (0x183e4f830) hands back a fresh
+        // `DOTween.Sequence()` whenever the previous one already played, and
+        // `DOTween.Sequence()` (0x184109110) starts it playing because
+        // `defaultAutoPlay` is `AutoPlay.All` (cctor 0x18410b0e0) -- the tweens
+        // run either way. All `end` gates is the
+        // `OnComplete(_SetSeqPlayed)` + `Play()` pair at 0x183e4e501, and the
+        // `isblock` check nested inside it at 0x183e4e56f: on the slot path
+        // `isblock` only ever blocks when `end` is true.
+        const isEnd = toString(args.end).trim().toLowerCase() !== "false";
+        const rawBlock = toBoolean(args.isblock, false);
+        const block = rawBlock && isEnd;
 
         // The clear branch keys off an empty `slot`, never an empty `name`, and it
         // only touches the three built-in slots (custom slots are left alone).
@@ -1888,7 +1893,10 @@ export class StoryRuntime {
             undefined,
             durationMs,
           );
-          if (block) await clearPromise;
+          // This branch returns before the sequence is ever built, so it hands
+          // `isBlock` straight to `_CleanSlotsWithTween` (0x183e4e5c3) without
+          // the `end` gate the slot path has.
+          if (rawBlock) await clearPromise;
           else void clearPromise;
           return "continue";
         }
@@ -1926,9 +1934,7 @@ export class StoryRuntime {
           }
         }
 
-        if (isEmptyChar && !deferPlay) {
-          // SlotCleanChar lives inside the same Sequence, so `end=false`
-          // defers the clean together with the rest of the tweens.
+        if (isEmptyChar) {
           const clearPromise = this.renderer.clearCharacters(slot, durationMs);
           if (block) await clearPromise;
           else void clearPromise;
@@ -1969,7 +1975,6 @@ export class StoryRuntime {
           ...(args.circles === undefined
             ? {}
             : { circles: Math.trunc(toNumber(args.circles, 0)) }),
-          deferPlay,
           durationMs,
           expression: resolved?.expression,
           fadeIdentity: nameRef
@@ -3132,9 +3137,21 @@ export class StoryRuntime {
     const focus = toString(args.focus).trim().toLowerCase();
     if (!focus || focus === "all") return ["l", "m", "r"];
 
+    // The focus tokens are their own vocabulary, not the `slot` vocabulary:
+    // `_ProcessFocusArray` maps "custom"/"c" to `m_focusCustom`, so "c" must
+    // not fall through to the middle slot the way `parseCharacterSlot` maps
+    // it. Custom slots are unmodeled, so those tokens light nothing.
+    const focusSlotTokens: Record<string, string> = {
+      l: "l",
+      left: "l",
+      m: "m",
+      middle: "m",
+      r: "r",
+      right: "r",
+    };
     const slots = focus
       .split(",")
-      .map((value) => this.parseCharacterSlot(value))
+      .map((value) => focusSlotTokens[value.trim()])
       .filter((slot): slot is string => slot !== undefined);
     return [...new Set(slots)];
   }

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -2038,6 +2038,7 @@ export class StoryRuntime {
               ? undefined
               : Math.max(0, toNumber(args.yscale, toNumber(args.scale, 1))),
           slot,
+          slotSequence: true,
           stop: toBoolean(args.stop, false),
           times: Math.trunc(toNumber(args.times, 1)),
         });

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1928,9 +1928,13 @@ export class StoryRuntime {
         // (0x183eb4260) and then still falls through to SlotSetCharWithParam
         // with the same name: two `_SwapImages` in a row put the old art back
         // in front, and the second `_LoadImage` (0x183eb4f60) opens with
-        // `DOKill(m_image)` -- killing the fade the first swap started --
-        // before `set_sprite(null)` + `enabled = false`. The slot is emptied
-        // on the spot regardless of `duration`; action/focus keep executing.
+        // `DOKill(m_image)`, killing the fade the first swap started. Whether
+        // "char_empty" then resolves to a blank sprite hub (the
+        // `m_currentKey.ToLower() != "char_empty"` guard in
+        // `_SlotSetCharInternal` suggests it does) or fails into
+        // `set_sprite(null)` + `enabled = false`, the old art is gone at once:
+        // the slot is emptied regardless of `duration`; action/focus keep
+        // executing.
         const isEmptyChar = nameRef === "char_empty";
 
         let resolved: { base: string; expression: string } | null = null;
@@ -1966,10 +1970,13 @@ export class StoryRuntime {
         // - without a `name`, only `GE(afrom, 0)` gates
         //   `SlotChangeAlpha(afrom, ato, duration)` (0x183eb3d20), and ato is
         //   passed through as-is. An omitted ato (-1) therefore tweens the
-        //   vertex colour toward alpha -1, which the canvas clamps to 0 -- a
-        //   fade-out (29 corpus lines write `afrom=1` with no ato as an exit,
-        //   e.g. story_whitw2_1_1.txt:475). duration 0 => SetAlpha(fore, ato)
-        //   with the same clamp. Approximated as a fade to 0 over `duration`.
+        //   vertex colour linearly toward alpha -1, which Unity's Color32
+        //   conversion clamps to 0 -- a fade-out that is fully transparent by
+        //   `duration / 2` (29 corpus lines write `afrom=1` with no ato as an
+        //   exit, e.g. story_whitw2_1_1.txt:475). duration 0 =>
+        //   SetAlpha(fore, ato) with the same clamp. The negative target is
+        //   handed through so the renderer reproduces that timing; it clamps
+        //   at the write.
         const rawAlphaFrom =
           args.afrom === undefined ? -1 : toNumber(args.afrom, -1);
         const rawAlphaTo = args.ato === undefined ? -1 : toNumber(args.ato, -1);
@@ -1985,7 +1992,7 @@ export class StoryRuntime {
           }
         } else if (!nameRef && rawAlphaFrom >= 0) {
           alphaFrom = clamp(rawAlphaFrom, 0, 1);
-          alphaTo = rawAlphaTo < 0 ? 0 : clamp(rawAlphaTo, 0, 1);
+          alphaTo = Math.min(1, rawAlphaTo);
         }
 
         await this.renderer.setCharacter({
@@ -2020,7 +2027,14 @@ export class StoryRuntime {
             : { inverse: toBoolean(args.inverse, false) }),
           nativeKey: nameRef || undefined,
           positionFrom: this.parseCharacterSlotPoint(args.posfrom),
-          positionTo: this.parseCharacterSlotPoint(args.posto),
+          // `_ExecuteCharslot` treats a posto that is present but not an
+          // "x,y" pair differently from posfrom/poszoom: those log a parse
+          // error and keep the (1,1) default, posto falls back to
+          // Vector2.zero (0x183e4e2db-0x183e4e322). Scalar `posto=0` lines
+          // in the corpus therefore mean (0,0) natively.
+          positionTo:
+            this.parseCharacterSlotPoint(args.posto) ??
+            (toString(args.posto).trim() ? { x: 0, y: 0 } : undefined),
           posZoom: this.parseCharacterSlotPoint(args.poszoom),
           power: Math.max(0, toNumber(args.power, 0)),
           randomness: clamp(toNativeIntParam(args.random, 10), 0, 100),

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -167,12 +167,6 @@ export interface CharacterSlotInput {
   block?: boolean;
   characterKey?: string;
   circles?: number;
-  /**
-   * `charslot` 的 `end=false`:native 把整条 Sequence 组装进每槽缓存但不
-   * Play,留给同槽后续 end=true 的命令触发。图片置换本身不延迟
-   * (`_SlotSetCharInternal` 照跑,新图停在 afrom),全部 tween 延迟。
-   */
-  deferPlay?: boolean;
   dimmed?: boolean;
   durationMs?: number;
   enterFrom?: "down" | "left" | "right" | "up";

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -199,6 +199,15 @@ export interface CharacterSlotInput {
   scaleX?: number;
   scaleY?: number;
   slot: string;
+  /**
+   * charslot 专用：该命令的 tween 会进 `AVGCharacterslotPanel` 的每槽缓存
+   * Sequence（`_UpdateSeqWithTween` 是 Insert 并行，`_GetCachedSlotSeq`
+   * 0x183e4f830 在 Sequence 未播完前复用它），`isblock` 等整条 Sequence
+   * 完成（OnComplete → FinishCommand），详见 renderer 的
+   * `characterSlotSeqDeadlines`。`character` 命令走 `CharacterPanel`，
+   * tween 不入该 Sequence，不得置位。
+   */
+  slotSequence?: boolean;
   stop?: boolean;
   times?: number;
   transType?: number;

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -161,6 +161,12 @@ export interface CharacterSlotInput {
     "jump" | "move" | "rotate" | "setpos" | "shake" | "shakemove" | "zoom";
   angle?: number;
   alphaFrom?: number;
+  /**
+   * May be negative on the charslot path: native passes a nameless command's
+   * `ato` (default -1) straight into `SlotChangeAlpha`, and the renderer
+   * clamps only at the write, so the fade reaches full transparency early
+   * exactly as the vertex-colour tween does.
+   */
   alphaTo?: number;
   blackEnd?: number;
   blackStart?: number;
@@ -202,8 +208,9 @@ export interface CharacterSlotInput {
   /**
    * charslot 专用：该命令的 tween 会进 `AVGCharacterslotPanel` 的每槽缓存
    * Sequence（`_UpdateSeqWithTween` 是 Insert 并行，`_GetCachedSlotSeq`
-   * 0x183e4f830 在 Sequence 未播完前复用它），`isblock` 等整条 Sequence
-   * 完成（OnComplete → FinishCommand），详见 renderer 的
+   * 0x183e4f830 在 Sequence 未被标 played 前复用它；DOTween 的
+   * `creationLocked` 让这种复用只对同一帧内的相邻命令成立），`isblock`
+   * 等整条 Sequence 完成（OnComplete → FinishCommand），详见 renderer 的
    * `characterSlotSeqDeadlines`。`character` 命令走 `CharacterPanel`，
    * tween 不入该 Sequence，不得置位。
    */

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -167,6 +167,12 @@ export interface CharacterSlotInput {
   block?: boolean;
   characterKey?: string;
   circles?: number;
+  /**
+   * `charslot` 的 `end=false`:native 把整条 Sequence 组装进每槽缓存但不
+   * Play,留给同槽后续 end=true 的命令触发。图片置换本身不延迟
+   * (`_SlotSetCharInternal` 照跑,新图停在 afrom),全部 tween 延迟。
+   */
+  deferPlay?: boolean;
   dimmed?: boolean;
   durationMs?: number;
   enterFrom?: "down" | "left" | "right" | "up";
@@ -174,7 +180,11 @@ export interface CharacterSlotInput {
   expression?: string;
   fadeIdentity?: string;
   focus?: number;
-  focusMode?: "current_only" | "none" | "subset";
+  /**
+   * charslot 的 focus 是全量重刷:`_ProcessFocusArray` 清零后按列表点亮,
+   * 不认识的取值(含 "n"/"none"/"a")= 全部槽 unfocus。focusSlots 为点亮集。
+   */
+  focusMode?: "subset";
   focusSlots?: string[];
   inverse?: boolean;
   /**
@@ -189,10 +199,9 @@ export interface CharacterSlotInput {
   positionTo?: { x: number; y: number };
   posZoom?: { x: number; y: number };
   power?: number;
-  preserveTransform?: boolean;
   randomness?: number;
+  /** 换图 crossfade 时长(native = `duration`,非 `fadetime`) */
   replaceFadeMs?: number;
-  resetTransform?: boolean;
   scaleX?: number;
   scaleY?: number;
   slot: string;

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -604,6 +604,50 @@ describe("PixiStoryRenderer", () => {
     expect(renderer.tween).not.toHaveBeenCalled();
   });
 
+  it("waits out the cached slot sequence for an isblock shake after an end=false enter", async () => {
+    const renderer = createLiveCharacterRenderer();
+
+    // level_act23side_02_beg.txt:425 -- an `end=false` enter leaves a 3s
+    // tween in the slot's cached Sequence (`_GetCachedSlotSeq` reuses it
+    // until its OnComplete marks it played) without blocking the queue.
+    await renderer.setCharacter({
+      alphaFrom: 0,
+      alphaTo: 1,
+      block: false,
+      characterKey: "avg_test",
+      durationMs: 3000,
+      expression: "1$1",
+      fadeIdentity: "avg_test",
+      positionFrom: { x: 0, y: -500 },
+      positionTo: { x: 0, y: 0 },
+      slot: "l",
+      slotSequence: true,
+    });
+
+    // level_act23side_02_beg.txt:426 -- a 1s shake with isblock=true is
+    // INSERTed into the same Sequence (parallel, never Append): it starts at
+    // once, but the block waits for the whole sequence -- the 3s enter, not
+    // the 1s shake (native text onset measured at +2.2s for 2s+2s).
+    renderer.tween.mockClear();
+    await renderer.setCharacter({
+      action: "shake",
+      block: true,
+      durationMs: 1000,
+      power: 50,
+      randomness: 90,
+      slot: "l",
+      slotSequence: true,
+      times: 100,
+    });
+
+    // Shake runs on a timeout, opacity/move/zoom contribute nothing here, so
+    // the single tween call is the isblock wait itself.
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+    const waitMs = renderer.tween.mock.calls.at(-1)?.[0] as number;
+    expect(waitMs).toBeGreaterThanOrEqual(2900);
+    expect(waitMs).toBeLessThanOrEqual(3000);
+  });
+
   it("ignores a bare posto without posfrom or action=jump", async () => {
     const renderer = createCharacterRenderer();
 

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -238,37 +238,45 @@ describe("PixiStoryRenderer", () => {
     }
   });
 
-  it("bakes the black gradient over the body as well as the face", async () => {
+  it("composites the face onto the body before the black gradient bake", async () => {
     const baked = new Texture();
     const renderer = createFaceOverlayRenderer(baked);
+    const composited = new Texture();
+    const compositeSpy = vi
+      .spyOn(renderer, "bakeFaceOverlayTexture")
+      .mockReturnValue(composited);
 
     const built = await renderer.buildCharacterVisual("avg_test", "1$1", 0, 1);
 
     // Native composites the face into the same material as the body
     // (`AlphaSplitImageHolder.SetSprite` binds it as `_HGDynamicTex`) and only
-    // then applies `_BlackStart`/`_BlackEnd`, so the darkening covers the
-    // whole character. Baking the face alone would leave the body at its
-    // original colour with a darkened patch over the face.
-    const [sprites] = renderer.bakeDarkenedCharacterTexture.mock.calls[0];
-    const bodyTexture = await renderer.textureForCharacterKey("body-1");
-    const faceTexture = await renderer.textureForCharacterKey("face-1");
-    expect(sprites.map((sprite: Sprite) => sprite.texture)).toEqual([
-      bodyTexture,
-      faceTexture,
-    ]);
-    // Draw order matters: the body goes down first, the face patch on top.
-    expect(sprites.map((sprite: Sprite) => [sprite.x, sprite.y])).toEqual([
-      [0, 0],
-      [10, 20],
-    ]);
+    // then applies fade alpha and `_BlackStart`/`_BlackEnd`. The web port must
+    // bake the same way: two stacked sprites would each carry a copy of the
+    // fade alpha, making the face region's effective opacity 1-(1-p)^2 -- the
+    // face would fade in ahead of the body.
+    expect(compositeSpy).toHaveBeenCalledWith(
+      "body-1",
+      "face-1",
+      await renderer.textureForCharacterKey("body-1"),
+      await renderer.textureForCharacterKey("face-1"),
+      { h: 40, w: 50, x: 10, y: 20 },
+    );
 
     const content = built.visual.children[0] as Container;
     expect(content.children.length).toBe(1);
+
+    // The black gradient then bakes over the single composited sprite, so the
+    // darkening covers the whole character.
+    const [sprites] = renderer.bakeDarkenedCharacterTexture.mock.calls[0];
+    expect(sprites.length).toBe(1);
+    expect((sprites[0] as Sprite).texture).toBe(composited);
     expect((content.children[0] as Sprite).texture).toBe(baked);
   });
 
-  it("keeps every content sprite when one of them cannot be baked", async () => {
+  it("keeps the composited sprite when the black bake fails", async () => {
     const renderer = createFaceOverlayRenderer(new Texture());
+    const composited = new Texture();
+    renderer.bakeFaceOverlayTexture = vi.fn(() => composited);
     renderer.bakeDarkenedCharacterTexture = vi.fn(() => null);
 
     const built = await renderer.buildCharacterVisual("avg_test", "1$1", 0, 1);
@@ -276,7 +284,8 @@ describe("PixiStoryRenderer", () => {
     // The originals are only dropped in favour of a baked texture; when the
     // bake fails the character must stay drawable, just undarkened.
     const content = built.visual.children[0] as Container;
-    expect(content.children.length).toBe(2);
+    expect(content.children.length).toBe(1);
+    expect((content.children[0] as Sprite).texture).toBe(composited);
   });
 
   it("dims unfocused characters with tint without making them transparent", () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -777,19 +777,17 @@ describe("PixiStoryRenderer", () => {
     expect(renderer.tween).not.toHaveBeenCalled();
   });
 
-  it("defers end=false charslot tweens until the next command on the slot", async () => {
+  it("plays an end=false entrance immediately instead of deferring it", async () => {
     const renderer = createCharacterRenderer();
-    const shakeSpy = vi
-      .spyOn(renderer, "startShakeAction")
-      .mockImplementation(() => {});
 
-    // act23side_02_beg.txt:425-426 pattern: an entrance is assembled with
-    // end=false, then a shake command on the same slot plays it.
+    // act23side_02_beg.txt:425 pattern. `end=false` only skips the
+    // OnComplete(_SetSeqPlayed) + Play() pair; _GetCachedSlotSeq already
+    // handed back an auto-playing DOTween.Sequence, so the entrance runs now.
+    // The runtime therefore hands the renderer no defer flag at all.
     await renderer.setCharacter({
       alphaFrom: 0,
       alphaTo: 1,
       characterKey: "avg_test",
-      deferPlay: true,
       durationMs: 2000,
       expression: "1$1",
       focusMode: "subset",
@@ -799,33 +797,68 @@ describe("PixiStoryRenderer", () => {
       replaceFadeMs: 2000,
       slot: "l",
     });
+
     const state = renderer.characterSlots.get("l");
     expect(state).toBeTruthy();
-    // The image swap itself is not deferred (SetAlpha(fore, afrom)), but the
-    // move/alpha tweens are: nothing moved yet.
-    expect(state.contentAlpha).toBe(0);
-    expect(state.actionY).toBe(0);
-    expect(renderer.tween).not.toHaveBeenCalled();
-
-    await renderer.setCharacter({
-      action: "shake",
-      durationMs: 2000,
-      focusMode: "subset",
-      focusSlots: ["l", "m", "r"],
-      power: 50,
-      randomness: 90,
-      slot: "l",
-      times: 100,
-    });
-
-    // The deferred entrance now runs (from posfrom / afrom) together with
-    // the triggering shake.
+    // The stubbed tween never advances, so the slot sits at posfrom/afrom
+    // with the move and the fade-in both already started.
     expect(state.actionY).toBe(-500);
     expect(state.contentAlpha).toBe(0);
     expect(renderer.tween).toHaveBeenCalled();
-    expect(shakeSpy).toHaveBeenCalled();
-    // Nothing is left queued for the slot.
-    expect(renderer.deferredCharacterSlots.get("l")).toBeUndefined();
+  });
+
+  it("ignores posfrom/posto for zoom and resets the scale without an explicit scale", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+    const state = renderer.characterSlots.get("m");
+    // Stand in for a completed earlier zoom: the slot is scaled up and the
+    // offset is at rest (native keeps both across commands).
+    state.scaleX = 1.5;
+    state.scaleY = 1.5;
+    state.actionX = 0;
+    renderer.tween.mockClear();
+
+    // act42side_08_end.txt:109 pattern: `action="zoom"` with a pivot but no
+    // `scale`. CharZoom always tweens to `options.scale`, whose default is
+    // 1.0, so this has to start a tween back down to 1 rather than treat the
+    // current 1.5 as the target (which would leave from == to and no tween).
+    await renderer.setCharacter({
+      action: "zoom",
+      characterKey: "avg_test",
+      durationMs: 400,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      posZoom: { x: 0.5, y: 0.5 },
+      slot: "m",
+    });
+    expect(renderer.tween).toHaveBeenCalled();
+
+    // The zoom branch never reaches SlotMoveChar, so posfrom is inert: it must
+    // not snap the slot to -300 the way the plain-move branch would.
+    state.scaleX = 1;
+    state.scaleY = 1;
+    await renderer.setCharacter({
+      action: "zoom",
+      characterKey: "avg_test",
+      durationMs: 400,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      positionFrom: { x: -300, y: 0 },
+      positionTo: { x: 400, y: 0 },
+      slot: "m",
+    });
+
+    expect(state.actionX).toBe(0);
   });
 
   it("swaps the image instantly for an explicit enter without transtype", async () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1022,7 +1022,10 @@ describe("PixiStoryRenderer", () => {
 
     // story_tanya_1_1.txt:344-355 pattern: the same zoom re-issued. CharZoom
     // lerps `rectTransform.pivot` to the given pivot, an absolute target, so
-    // the shift settles at one value instead of stacking per command.
+    // the shift settles at one value instead of stacking per command. The
+    // stored (y-up) shift is the native centre move `scale * (0.5 - pivot) *
+    // size` plus the `(scale - 1) * size / 2` term that cancels the motion
+    // layer's corner-origin growth: (0.5-0.6)*1.8*200 + 0.8*200/2 = 44.
     const zoom = {
       action: "zoom" as const,
       durationMs: 0,
@@ -1035,7 +1038,7 @@ describe("PixiStoryRenderer", () => {
     };
     await renderer.setCharacter(zoom);
     const shiftY = state.zoomShiftY;
-    expect(shiftY).toBeCloseTo((0.6 - 0.5) * 1.8 * 200);
+    expect(shiftY).toBeCloseTo((0.5 - 0.6) * 1.8 * 200 + ((1.8 - 1) * 200) / 2);
     await renderer.setCharacter(zoom);
     await renderer.setCharacter(zoom);
     expect(state.zoomShiftY).toBeCloseTo(shiftY);

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -561,6 +561,273 @@ describe("PixiStoryRenderer", () => {
     expect(current.root.alpha).toBe(0);
   });
 
+  it("keeps the slot transform across charslot commands without pos input", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      positionFrom: { x: -300, y: 0 },
+      positionTo: { x: 0, y: 0 },
+      slot: "m",
+    });
+    const state = renderer.characterSlots.get("m");
+    // The stubbed tween never advances, so the slot sits at `posfrom`.
+    expect(state.actionX).toBe(-300);
+
+    // Native never resets `_offset.localPosition` between charslot commands
+    // (SlotSetCharWithParam uses resetOffsetPos=false), so a bare command
+    // must not snap the character back to the default transform.
+    renderer.tween.mockClear();
+    await renderer.setCharacter({
+      durationMs: 300,
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+
+    expect(state.actionX).toBe(-300);
+    // from == to: no transform tween is even started, which also keeps any
+    // still-running tween from a previously deferred command alive.
+    expect(renderer.tween).not.toHaveBeenCalled();
+  });
+
+  it("ignores a bare posto without posfrom or action=jump", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+    const state = renderer.characterSlots.get("m");
+    state.actionX = 120;
+    renderer.tween.mockClear();
+
+    // level_main_14-02_end.txt:379 pattern (`posto=0`, no posfrom): the
+    // native posFrom sentinel (1,1) never reaches SlotMoveChar, so this is a
+    // no-op instead of a relative move.
+    await renderer.setCharacter({
+      durationMs: 1000,
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      positionTo: { x: 400, y: 0 },
+      slot: "m",
+    });
+
+    expect(state.actionX).toBe(120);
+    expect(renderer.tween).not.toHaveBeenCalled();
+  });
+
+  it("skips the whole zoom when poszoom is outside [0,1]", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      action: "zoom",
+      characterKey: "avg_test",
+      durationMs: 400,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      posZoom: { x: 1.5, y: 0.5 },
+      scaleX: 2,
+      scaleY: 2,
+      slot: "m",
+    });
+    const state = renderer.characterSlots.get("m");
+
+    // CharZoom validates the pivot first: out-of-range means return null --
+    // the scale change is skipped too.
+    expect(state.scaleX).toBe(1);
+    expect(state.scaleY).toBe(1);
+    expect(renderer.tween).not.toHaveBeenCalled();
+  });
+
+  it("dims every slot for unrecognized focus values and relights them for all", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      // level_main_12-05_end.txt:349 pattern: focus="none" is not a native
+      // token, so _ProcessFocusArray clears every flag and lights nothing.
+      focusSlots: [],
+      slot: "l",
+    });
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: [],
+      slot: "r",
+    });
+
+    expect(renderer.characterSlots.get("l")!.focusBrightness).toBe(0.5);
+    expect(renderer.characterSlots.get("r")!.focusBrightness).toBe(0.5);
+
+    // An omitted focus resolves to ["all"]: the next command relights
+    // everything.
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "r",
+    });
+
+    expect(renderer.characterSlots.get("l")!.focusBrightness).toBe(1);
+    expect(renderer.characterSlots.get("r")!.focusBrightness).toBe(1);
+  });
+
+  it("cross-fades a swap over duration with the default (0,1) fade-in", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      fadeIdentity: "avg_test",
+      slot: "m",
+    });
+    const previous = renderer.characterSlots.get("m");
+
+    // Story_bubble-style plain swap: no afrom/ato, duration>0. Native resets
+    // the pair to (0,1) and the crossfade length equals `duration`.
+    await renderer.setCharacter({
+      alphaFrom: 0,
+      alphaTo: 1,
+      characterKey: "avg_test",
+      durationMs: 400,
+      expression: "2$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      replaceFadeMs: 400,
+      slot: "m",
+    });
+
+    const current = renderer.characterSlots.get("m");
+    // The incoming sprite sits at afrom until the (stubbed) tween advances,
+    // and the outgoing sprite gets its own fade-out tween.
+    expect(current.contentAlpha).toBe(0);
+    expect(current.visual.alpha).toBe(0);
+    expect(previous.visual.parent).not.toBeNull();
+  });
+
+  it("skips shake entirely when duration is zero", async () => {
+    const renderer = createCharacterRenderer();
+    const shakeSpy = vi
+      .spyOn(renderer, "startShakeAction")
+      .mockImplementation(() => {});
+
+    await renderer.setCharacter({
+      action: "shake",
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      // act22side_02_end.txt:191 pattern: no duration at all.
+      power: 8,
+      randomness: 1,
+      slot: "m",
+      times: 100,
+    });
+
+    // NeedSkipAnimation(duration): the shake branch returns null.
+    expect(shakeSpy).not.toHaveBeenCalled();
+  });
+
+  it("rotates from the standalone angle parameter regardless of action", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      angle: 30,
+      characterKey: "avg_test",
+      durationMs: 400,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+
+    // 2.7.61 drives rotation from the tail `angle` segment of
+    // _UpdateSeqWithParam; `action="rotate"` itself is an unknown action.
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+
+    renderer.tween.mockClear();
+    await renderer.setCharacter({
+      action: "rotate",
+      characterKey: "avg_test",
+      durationMs: 400,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+    expect(renderer.tween).not.toHaveBeenCalled();
+  });
+
+  it("defers end=false charslot tweens until the next command on the slot", async () => {
+    const renderer = createCharacterRenderer();
+    const shakeSpy = vi
+      .spyOn(renderer, "startShakeAction")
+      .mockImplementation(() => {});
+
+    // act23side_02_beg.txt:425-426 pattern: an entrance is assembled with
+    // end=false, then a shake command on the same slot plays it.
+    await renderer.setCharacter({
+      alphaFrom: 0,
+      alphaTo: 1,
+      characterKey: "avg_test",
+      deferPlay: true,
+      durationMs: 2000,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      positionFrom: { x: 0, y: -500 },
+      positionTo: { x: 0, y: 0 },
+      replaceFadeMs: 2000,
+      slot: "l",
+    });
+    const state = renderer.characterSlots.get("l");
+    expect(state).toBeTruthy();
+    // The image swap itself is not deferred (SetAlpha(fore, afrom)), but the
+    // move/alpha tweens are: nothing moved yet.
+    expect(state.contentAlpha).toBe(0);
+    expect(state.actionY).toBe(0);
+    expect(renderer.tween).not.toHaveBeenCalled();
+
+    await renderer.setCharacter({
+      action: "shake",
+      durationMs: 2000,
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      power: 50,
+      randomness: 90,
+      slot: "l",
+      times: 100,
+    });
+
+    // The deferred entrance now runs (from posfrom / afrom) together with
+    // the triggering shake.
+    expect(state.actionY).toBe(-500);
+    expect(state.contentAlpha).toBe(0);
+    expect(renderer.tween).toHaveBeenCalled();
+    expect(shakeSpy).toHaveBeenCalled();
+    // Nothing is left queued for the slot.
+    expect(renderer.deferredCharacterSlots.get("l")).toBeUndefined();
+  });
+
   it("swaps the image instantly for an explicit enter without transtype", async () => {
     const renderer = createCharacterRenderer();
 

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -816,7 +816,7 @@ describe("PixiStoryRenderer", () => {
     expect(renderer.tween).toHaveBeenCalled();
   });
 
-  it("ignores posfrom/posto for zoom and resets the scale without an explicit scale", async () => {
+  it("resets the zoom on a named swap, even one whose zoom carries no scale", async () => {
     const renderer = createCharacterRenderer();
 
     await renderer.setCharacter({
@@ -828,46 +828,215 @@ describe("PixiStoryRenderer", () => {
       slot: "m",
     });
     const state = renderer.characterSlots.get("m");
-    // Stand in for a completed earlier zoom: the slot is scaled up and the
-    // offset is at rest (native keeps both across commands).
+    // Stand in for a completed earlier zoom (scale + pivot shift) and a
+    // completed move.
     state.scaleX = 1.5;
     state.scaleY = 1.5;
-    state.actionX = 0;
+    state.zoomShiftX = 25;
+    state.zoomShiftY = -10;
+    state.actionX = -300;
+    const previousVisual = state.visual;
     renderer.tween.mockClear();
 
-    // act42side_08_end.txt:109 pattern: `action="zoom"` with a pivot but no
-    // `scale`. CharZoom always tweens to `options.scale`, whose default is
-    // 1.0, so this has to start a tween back down to 1 rather than treat the
-    // current 1.5 as the target (which would leave from == to and no tween).
+    // act42side_08_end.txt:109 pattern: `name` + `action="zoom"` with a pivot
+    // but no `scale`. `_SetImage` -> GUIUtils.AssignLocalSettings copies the
+    // hub prefab's pivot/localScale onto the fore Image on every load, so the
+    // swap itself resets the zoom; CharZoom then tweens 1 -> 1 (its default
+    // scale), i.e. nothing. The `_offset` move is untouched.
     await renderer.setCharacter({
       action: "zoom",
       characterKey: "avg_test",
       durationMs: 400,
-      expression: "1$1",
+      expression: "2$1",
       focusMode: "subset",
       focusSlots: ["l", "m", "r"],
       posZoom: { x: 0.5, y: 0.5 },
       slot: "m",
     });
-    expect(renderer.tween).toHaveBeenCalled();
+    expect(state.scaleX).toBe(1);
+    expect(state.scaleY).toBe(1);
+    expect(state.zoomShiftX).toBe(0);
+    expect(state.zoomShiftY).toBe(0);
+    expect(state.actionX).toBe(-300);
+    expect(renderer.tween).not.toHaveBeenCalled();
+    // The outgoing Image keeps its own transform while it fades, so the
+    // previous visual carries the old zoom on itself.
+    expect(previousVisual.scale.x).toBeCloseTo(1.5);
+    expect(previousVisual.scale.y).toBeCloseTo(1.5);
+    expect(previousVisual.x).toBeCloseTo(25);
+    expect(previousVisual.y).toBeCloseTo(10);
 
     // The zoom branch never reaches SlotMoveChar, so posfrom is inert: it must
     // not snap the slot to -300 the way the plain-move branch would.
-    state.scaleX = 1;
-    state.scaleY = 1;
+    state.actionX = 0;
     await renderer.setCharacter({
       action: "zoom",
-      characterKey: "avg_test",
       durationMs: 400,
-      expression: "1$1",
       focusMode: "subset",
       focusSlots: ["l", "m", "r"],
       positionFrom: { x: -300, y: 0 },
       positionTo: { x: 400, y: 0 },
       slot: "m",
     });
-
     expect(state.actionX).toBe(0);
+  });
+
+  it("keeps a completed zoom across nameless commands and tweens it back to 1 without a scale", async () => {
+    const renderer = createCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+    const state = renderer.characterSlots.get("m");
+    state.scaleX = 1.5;
+    state.scaleY = 1.5;
+    renderer.tween.mockClear();
+
+    // No name, no load, no AssignLocalSettings: the fore Image still holds
+    // the old zoom, and `CharZoom(..., options.scale = 1.0, duration)` has
+    // to start a tween back down to 1 rather than treat 1.5 as the target.
+    await renderer.setCharacter({
+      action: "zoom",
+      durationMs: 400,
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      posZoom: { x: 0.5, y: 0.5 },
+      slot: "m",
+    });
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the zoom pivot shift absolutely so repeated zooms do not drift", async () => {
+    const renderer = createLiveCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+    const state = renderer.characterSlots.get("m");
+
+    // story_tanya_1_1.txt:344-355 pattern: the same zoom re-issued. CharZoom
+    // lerps `rectTransform.pivot` to the given pivot, an absolute target, so
+    // the shift settles at one value instead of stacking per command.
+    const zoom = {
+      action: "zoom" as const,
+      durationMs: 0,
+      focusMode: "subset" as const,
+      focusSlots: ["l", "m", "r"],
+      posZoom: { x: 0.5, y: 0.6 },
+      scaleX: 1.8,
+      scaleY: 1.8,
+      slot: "m",
+    };
+    await renderer.setCharacter(zoom);
+    const shiftY = state.zoomShiftY;
+    expect(shiftY).toBeCloseTo((0.6 - 0.5) * 1.8 * 200);
+    await renderer.setCharacter(zoom);
+    await renderer.setCharacter(zoom);
+    expect(state.zoomShiftY).toBeCloseTo(shiftY);
+    expect(state.scaleX).toBe(1.8);
+    // The shift rides the motion layer next to the `_offset` position.
+    expect(state.motionLayer.y).toBeCloseTo(-shiftY);
+  });
+
+  it("moves jump with duration 0 and shakemove to posto without a posfrom gate", async () => {
+    const renderer = createLiveCharacterRenderer();
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+    const state = renderer.characterSlots.get("m");
+
+    // `_GenSlotActionTw`: jump with NeedSkipAnimation(duration) falls back to
+    // `_GenCharslotMove` -> SlotMoveChar(posFrom, posTo, 0) -> localPosition
+    // = posTo, with no (1,1) sentinel gate on this branch.
+    await renderer.setCharacter({
+      action: "jump",
+      durationMs: 0,
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      positionTo: { x: 120, y: 30 },
+      slot: "m",
+    });
+    expect(state.actionX).toBe(120);
+    expect(state.actionY).toBe(30);
+
+    // shakemove: SlotMoveChar(posFrom, posTo, duration) verbatim. An absent
+    // posfrom is the (1,1) default, written as-is.
+    await renderer.setCharacter({
+      action: "shakemove",
+      durationMs: 300,
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      positionTo: { x: -40, y: 0 },
+      slot: "m",
+    });
+    expect(state.actionX).toBe(-40);
+    expect(state.actionY).toBe(0);
+
+    // A bare jump with a duration lands at localPosition + posTo, and posTo
+    // defaults to (1,1) too.
+    await renderer.setCharacter({
+      action: "jump",
+      durationMs: 300,
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+    expect(state.actionX).toBe(-39);
+    expect(state.actionY).toBe(1);
+  });
+
+  it("evicts unreferenced face-overlay bakes beyond the cache limit only", () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const entries: Array<{ key: string; texture: any }> = [];
+    for (let index = 0; index < 10; index += 1) {
+      const texture = { destroy: vi.fn() };
+      const key = `base|face-${index}`;
+      renderer.faceOverlayTextures.set(key, { refs: 0, texture });
+      entries.push({ key, texture });
+    }
+    // The two oldest bakes are still drawn by visuals on stage.
+    const pinnedA = new Container();
+    const pinnedB = new Container();
+    renderer.retainFaceOverlay(pinnedA, entries[0].key);
+    renderer.retainFaceOverlay(pinnedB, entries[1].key);
+
+    renderer.trimFaceOverlayCache();
+
+    // 10 entries, limit 8: the oldest *unreferenced* two (indices 2 and 3)
+    // go; the pinned ones stay even though they are older.
+    expect(renderer.faceOverlayTextures.has(entries[0].key)).toBe(true);
+    expect(renderer.faceOverlayTextures.has(entries[1].key)).toBe(true);
+    expect(renderer.faceOverlayTextures.has(entries[2].key)).toBe(false);
+    expect(renderer.faceOverlayTextures.has(entries[3].key)).toBe(false);
+    expect(entries[2].texture.destroy).toHaveBeenCalledWith(true);
+    expect(entries[4].texture.destroy).not.toHaveBeenCalled();
+    expect(renderer.faceOverlayTextures.size).toBe(8);
+
+    // Releasing a pinned visual makes its bake evictable again.
+    renderer.faceOverlayTextures.set("base|face-x", {
+      refs: 0,
+      texture: { destroy: vi.fn() },
+    });
+    renderer.discardCharacterVisual(pinnedA);
+    expect(renderer.faceOverlayTextures.has(entries[0].key)).toBe(false);
+    expect(entries[0].texture.destroy).toHaveBeenCalledWith(true);
+    expect(renderer.faceOverlayTextures.size).toBe(8);
   });
 
   it("swaps the image instantly for an explicit enter without transtype", async () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -776,6 +776,58 @@ describe("PixiStoryRenderer", () => {
     expect(previous.visual.parent).not.toBeNull();
   });
 
+  it("clamps a nameless fade toward ato=-1 at the write so it is transparent by half the duration", async () => {
+    const renderer = createCharacterRenderer();
+    renderer.app = { stage: new Container() };
+
+    await renderer.setCharacter({
+      characterKey: "avg_test",
+      durationMs: 0,
+      expression: "1$1",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+    renderer.tween.mockClear();
+
+    // story_whitw2_1_1.txt:475 pattern: `afrom=1` with no ato. Native
+    // SlotChangeAlpha runs DOColor toward alpha -1 and the vertex colour
+    // clamps, so the sprite is invisible from duration/2 on.
+    await renderer.setCharacter({
+      alphaFrom: 1,
+      alphaTo: -1,
+      durationMs: 400,
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
+      slot: "m",
+    });
+
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+    const [durationMs, step, done] = renderer.tween.mock.calls.at(-1) as [
+      number,
+      (progress: number) => void,
+      () => void,
+    ];
+    expect(durationMs).toBe(400);
+    const state = renderer.characterSlots.get("m");
+
+    step(0.25);
+    expect(state.contentAlpha).toBeCloseTo(0.5);
+    expect(state.visual.alpha).toBeCloseTo(0.5);
+
+    step(0.5);
+    expect(state.contentAlpha).toBeCloseTo(0);
+    expect(state.visual.alpha).toBe(0);
+
+    step(0.75);
+    expect(state.contentAlpha).toBeCloseTo(-0.5);
+    expect(state.visual.alpha).toBe(0);
+
+    done();
+    expect(state.contentAlpha).toBe(-1);
+    expect(state.visual.alpha).toBe(0);
+  });
+
   it("skips shake entirely when duration is zero", async () => {
     const renderer = createCharacterRenderer();
     const shakeSpy = vi

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1661,7 +1661,6 @@ describe("StoryRuntime", () => {
         characterKey: "avg_1012_skadisp_1",
         // charslot's `duration` defaults to 0.0, not to DEFAULT_FADE_TIME.
         durationMs: 0,
-        deferPlay: false,
         expression: "avg_1012_skadisp_2",
         fadeIdentity: "avg_1012_skadiSP_1",
         // Omitted focus => ["all"] natively: every built-in slot is lit.
@@ -1837,16 +1836,17 @@ describe("StoryRuntime", () => {
     });
   });
 
-  it("maps charslot random like native GetOrDefault<int> and end=false to deferPlay", async () => {
+  it("maps charslot random like native GetOrDefault<int> and end=false only to blocking", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(
       createContext([
         // level_main_12-05_end.txt:576 pattern: random=true is
         // Convert.ToInt32(true) = 1, not "enable randomness".
         '[charslot(slot="m",action="shake",random=true,power=5,times=60,duration=0.3)]',
-        // act23side_02_beg.txt:425 pattern: end=false assembles but never
-        // plays the sequence.
-        '[charslot(slot="l",name="avg_npc_1",posfrom="0,-500",posto="0,0",duration=2,end=false)]',
+        // act23side_02_beg.txt:552 pattern: `end=false` still animates -- the
+        // sequence auto-plays -- but the isblock check at 0x183e4e56f sits
+        // inside the `end` branch, so it does not block.
+        '[charslot(slot="l",name="avg_npc_1",posfrom="0,-500",posto="0,0",duration=2,isblock=true,end=false)]',
         '[name="A"]ok',
       ]),
       renderer,
@@ -1860,15 +1860,36 @@ describe("StoryRuntime", () => {
       slot: "m",
     });
     expect(renderer.characterCalls[1]).toMatchObject({
-      deferPlay: true,
       // afrom/ato omitted with a name resets to (0, 1): always fade in.
       alphaFrom: 0,
       alphaTo: 1,
+      block: false,
       positionFrom: { x: 0, y: -500 },
       positionTo: { x: 0, y: 0 },
       replaceFadeMs: 2000,
       slot: "l",
     });
+    // The very same command with end omitted does block.
+    expect(renderer.characterCalls[1]).not.toHaveProperty("deferPlay");
+  });
+
+  it("keeps isblock on the slotless clear branch even with end=false", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        // The clear branch returns before the sequence is built and hands
+        // isBlock straight to _CleanSlotsWithTween (0x183e4e5c3), so it is
+        // not gated on `end` the way the slot path is.
+        "[charslot(duration=0.5,isblock=true,end=false)]",
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.clearedSlots).toEqual([{ fadeMs: 500, slot: undefined }]);
   });
 
   it("clears all characters with charslot duration when slot is omitted", async () => {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1679,6 +1679,9 @@ describe("StoryRuntime", () => {
         scaleX: undefined,
         scaleY: undefined,
         slot: "m",
+        // charslot tweens join the per-slot cached Sequence; `character`
+        // commands (CharacterPanel) leave this unset.
+        slotSequence: true,
         stop: false,
         times: 1,
       },

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1653,27 +1653,30 @@ describe("StoryRuntime", () => {
     expect(renderer.characterCalls).toEqual([
       {
         action: undefined,
-        alphaFrom: undefined,
-        alphaTo: undefined,
+        alphaFrom: 0,
+        alphaTo: 1,
         blackEnd: undefined,
         blackStart: undefined,
         block: false,
         characterKey: "avg_1012_skadisp_1",
         // charslot's `duration` defaults to 0.0, not to DEFAULT_FADE_TIME.
         durationMs: 0,
+        deferPlay: false,
         expression: "avg_1012_skadisp_2",
         fadeIdentity: "avg_1012_skadiSP_1",
-        focusMode: "current_only",
-        focusSlots: undefined,
+        // Omitted focus => ["all"] natively: every built-in slot is lit.
+        focusMode: "subset",
+        focusSlots: ["l", "m", "r"],
         nativeKey: "avg_1012_skadiSP_1#2",
         positionFrom: undefined,
         positionTo: undefined,
         posZoom: undefined,
         power: 0,
-        preserveTransform: false,
-        randomness: 90,
+        // GetOrDefault<int>("random", 10) -- DOTween randomness degrees.
+        randomness: 10,
+        // The crossfade length is `duration` itself (here 0), never
+        // `fadetime`, which native charslot never reads.
         replaceFadeMs: 0,
-        resetTransform: true,
         scaleX: undefined,
         scaleY: undefined,
         slot: "m",
@@ -1742,7 +1745,8 @@ describe("StoryRuntime", () => {
     expect(renderer.characterCalls[0]).toMatchObject({
       block: true,
       durationMs: 400,
-      focusMode: "current_only",
+      focusMode: "subset",
+      focusSlots: ["l", "m", "r"],
       slot: "l",
     });
     expect(runtime.getState()).toBe("waiting_input");
@@ -1766,9 +1770,104 @@ describe("StoryRuntime", () => {
     expect(renderer.characterCalls).toHaveLength(2);
     expect(renderer.characterCalls[1]).toMatchObject({
       characterKey: undefined,
-      focusMode: "none",
+      // focus="none" is not a native token (`_ProcessFocusArray` only knows
+      // all/left/l/middle/m/right/r/custom/c): it clears every focus flag,
+      // leaving all slots unfocused.
+      focusMode: "subset",
+      focusSlots: [],
       positionTo: { x: 10, y: 20 },
       slot: "m",
+    });
+  });
+
+  it("clears the slot for name=char_empty and keeps the rest of the command", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        // level_main_12-12_end.txt:373 / story_bubble_1_1.txt:502 pattern:
+        // char_empty is SlotCleanChar, not a missing asset.
+        '[charslot(slot="m",name="avg_npc_1")]',
+        '[charslot(slot="l",name="char_empty",focus="all",duration=0.5)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    expect(warnings).toEqual([]);
+    expect(renderer.clearedSlots).toEqual([{ fadeMs: 500, slot: "l" }]);
+    // The command keeps executing after the clean: focus=all is still applied.
+    expect(renderer.characterCalls[1]).toMatchObject({
+      characterKey: undefined,
+      focusSlots: ["l", "m", "r"],
+      slot: "l",
+    });
+  });
+
+  it("keeps running charslot actions when the character asset is missing", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[charslot(slot="m",name="avg_npc_1",duration=0.4)]',
+        '[charslot(slot="m",name="avg_missing_1",action="shake",power=5,duration=0.3)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    // Native `_LoadImage` failure only nulls m_currentKey; the action/focus
+    // sections still run, so the command is not dropped.
+    expect(warnings).toEqual([
+      expect.objectContaining({ type: "missing_asset" }),
+    ]);
+    expect(renderer.characterCalls[1]).toMatchObject({
+      action: "shake",
+      characterKey: undefined,
+      power: 5,
+      slot: "m",
+    });
+  });
+
+  it("maps charslot random like native GetOrDefault<int> and end=false to deferPlay", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        // level_main_12-05_end.txt:576 pattern: random=true is
+        // Convert.ToInt32(true) = 1, not "enable randomness".
+        '[charslot(slot="m",action="shake",random=true,power=5,times=60,duration=0.3)]',
+        // act23side_02_beg.txt:425 pattern: end=false assembles but never
+        // plays the sequence.
+        '[charslot(slot="l",name="avg_npc_1",posfrom="0,-500",posto="0,0",duration=2,end=false)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.characterCalls[0]).toMatchObject({
+      randomness: 1,
+      slot: "m",
+    });
+    expect(renderer.characterCalls[1]).toMatchObject({
+      deferPlay: true,
+      // afrom/ato omitted with a name resets to (0, 1): always fade in.
+      alphaFrom: 0,
+      alphaTo: 1,
+      positionFrom: { x: 0, y: -500 },
+      positionTo: { x: 0, y: 0 },
+      replaceFadeMs: 2000,
+      slot: "l",
     });
   });
 

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1798,7 +1798,11 @@ describe("StoryRuntime", () => {
     await runtime.start();
 
     expect(warnings).toEqual([]);
-    expect(renderer.clearedSlots).toEqual([{ fadeMs: 500, slot: "l" }]);
+    // SlotCleanChar starts a `duration` fade, but _UpdateSeqWithParam then
+    // falls through to SlotSetCharWithParam with the same name: the second
+    // _LoadImage DOKill()s that fade and disables the Image, so the slot is
+    // emptied instantly whatever `duration` says.
+    expect(renderer.clearedSlots).toEqual([{ fadeMs: 0, slot: "l" }]);
     // The command keeps executing after the clean: focus=all is still applied.
     expect(renderer.characterCalls[1]).toMatchObject({
       characterKey: undefined,
@@ -1823,17 +1827,49 @@ describe("StoryRuntime", () => {
 
     await runtime.start();
 
-    // Native `_LoadImage` failure only nulls m_currentKey; the action/focus
-    // sections still run, so the command is not dropped.
+    // `_SlotSetCharInternal` swaps before `_LoadImage`: on failure the old
+    // art is already the back Image and fades out over `duration` while the
+    // new fore Image is disabled, so the slot empties -- but the action/focus
+    // sections still run and the command is not dropped.
     expect(warnings).toEqual([
       expect.objectContaining({ type: "missing_asset" }),
     ]);
+    expect(renderer.clearedSlots).toEqual([{ fadeMs: 300, slot: "m" }]);
     expect(renderer.characterCalls[1]).toMatchObject({
       action: "shake",
       characterKey: undefined,
       power: 5,
       slot: "m",
     });
+  });
+
+  it("fades out a nameless charslot that sets afrom without ato", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[charslot(slot="m",name="avg_npc_1")]',
+        // story_whitw2_1_1.txt:475 pattern (`afrom=1, posto=0`, no ato): the
+        // nameless branch only gates on afrom >= 0 and passes ato through, so
+        // SlotChangeAlpha tweens toward alpha -1 -- clamped to 0, a fade-out.
+        '[charslot(slot="m",afrom=1,posto=0,duration=0.3)]',
+        // afrom omitted: `GE(alphaFrom, 0)` fails and nothing touches the
+        // alpha, even with an ato.
+        '[charslot(slot="m",ato=0.5,duration=0.3)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.characterCalls[1]).toMatchObject({
+      alphaFrom: 1,
+      alphaTo: 0,
+      slot: "m",
+    });
+    expect(renderer.characterCalls[2].alphaFrom).toBeUndefined();
+    expect(renderer.characterCalls[2].alphaTo).toBeUndefined();
   });
 
   it("maps charslot random like native GetOrDefault<int> and end=false only to blocking", async () => {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1853,7 +1853,10 @@ describe("StoryRuntime", () => {
         '[charslot(slot="m",name="avg_npc_1")]',
         // story_whitw2_1_1.txt:475 pattern (`afrom=1, posto=0`, no ato): the
         // nameless branch only gates on afrom >= 0 and passes ato through, so
-        // SlotChangeAlpha tweens toward alpha -1 -- clamped to 0, a fade-out.
+        // SlotChangeAlpha tweens toward alpha -1 (clamped at the vertex-colour
+        // write, fully transparent by duration/2). The -1 target is handed to
+        // the renderer as-is, and the scalar posto is (0,0) like native's
+        // Vector2.zero fallback.
         '[charslot(slot="m",afrom=1,posto=0,duration=0.3)]',
         // afrom omitted: `GE(alphaFrom, 0)` fails and nothing touches the
         // alpha, even with an ato.
@@ -1868,7 +1871,8 @@ describe("StoryRuntime", () => {
 
     expect(renderer.characterCalls[1]).toMatchObject({
       alphaFrom: 1,
-      alphaTo: 0,
+      alphaTo: -1,
+      positionTo: { x: 0, y: 0 },
       slot: "m",
     });
     expect(renderer.characterCalls[2].alphaFrom).toBeUndefined();


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `charslot` 命令移植中的行为差异(差异清单 P0×1、P1×4、P2×8 中建议修复的全部条目)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的 IDA 反编译复核(下文 VA 均为该 build),关键结论已直接给出,不依赖外部文档。

## 背景:native 的 charslot 机制(2.7.61 逆向结论)

- `Torappu.AVG.AVGCharacterslotPanel._ExecuteCharslot`(VA `0x183e4d310`):参数默认 `afrom`/`ato` = **-1.0**、`end` = true、`random` = **int 10**、`fadetime` 从不被读取(死参数);`duration`/`focusduration` 经 `CalculateFadetime`(= animateRatio × x)缩放。
- `_UpdateSeqWithParam`(VA `0x183e53940`):
  - `focus` 缺省 ⇒ `["all"]`;`_ProcessFocusArray`(VA `0x183e50b30`)先清零 4 个 focus 标志再按 token 点亮,只认识 `all` / `left|l` / `middle|m` / `right|r` / `custom|c` —— **没有 "n"/"none"/"a" 分支**,不认识的取值 = 全部槽 unfocus(暗);且每条带 slot 的 charslot 都全量重刷 focus 状态。
  - `name == "char_empty"`(ordinal 精确比较)⇒ `AVGCharacterSlot.SlotCleanChar(duration)` 清空该槽立绘,**后续 action/focus 段照常执行**(`_LoadImage` 对 char_empty 失败仅置 `m_currentKey = null` 并打日志)。
  - `name` 非空且 `afrom`/`ato` 任一 < 0(含双双缺省)⇒ 重置为 `(0, 1)` ⇒ **缺省即淡入**;仅 name 为空时 -1 才表示"不做 alpha"。
  - 位移:`posfrom`/`posto` 为 `_offset` 局部绝对坐标,仅当 `posFrom != (1,1)` 哨兵时触发 move;`posto` 单独出现(无 `posfrom`)不触发。`action=jump` 的 `posto` 是相对增量(CharJump = 当前位置 + posTo)。
  - 旋转由尾部独立参数段 `angle`(NaN 哨兵跳过)驱动,与 `action=` 取值无关;2.7.61 的 `_GenSlotActionTw`(VA `0x183e4f3b0`)只分发 jump/zoom/shake/shakemove。
- `_SlotSetCharInternal`(VA `0x183eb5830`,`resetOffsetPos=false`):**不重置位移**(跨命令保持);`_offset.localScale` 重置 (1,1,1) 但 zoom 的 scale 在 `_foreImage` 上、跨换图保留;换图 crossfade 时长 = **`duration`**(`_GenForeImageTween`/`_GenBackImageTween`),新图 `SetAlpha(fore, afrom)` 立即执行、旧图淡出立即 Play —— 这两个动作**不在 Sequence 里**,`end=false` 也会发生。
- `end=false`:Sequence 组装进 `_GetCachedSlotSeq` 的每槽缓存但不 Play;同槽后续 `end=true` 的命令会在同一 Sequence 上追加并 Play,**把先前欠下的 tween 一起触发**。
- `CharZoom`(VA `0x183eb2b50`)首行校验 pivot x/y ∉ [0,1] ⇒ 整个 zoom(含 scale)no-op;`poszoom` 缺省 (1,1) 合法。
- `_GenSlotActionTw` 的 shake 分支在 `NeedSkipAnimation(duration)`(即 duration==0)时 return null ⇒ **无抖动**。
- `random` 经 `AVGParser` 的 JSON 装箱 + `Convert.ToInt32`:`random=true` = **1**(false = 0),默认 10(DOTween randomness 角度)。
- bstart/bend 经 `CharacterParam` → `_LoadImage`(VA `0x183eb4f60`)→ `AVGCharacterSpriteHub::SetImage` **原样**传给材质;`SlotChangeMask`(死注册 `charslotmask` 通道)才做 `_BlackStart/_BlackEnd = 1-x` 反转,两条通道不同,前端不需反转(本轮已按反编译核对)。

## 修复内容

按 review 差异清单(编号与严重度沿用):

### P0-1 `name="char_empty"` 行为相反

- **native**:SlotCleanChar 清空该槽立绘,后续 action/focus 段照常执行。
- **前端**:`resolveCharacterSelection` 失败 → `warn("missing_asset")` 后整条 return,不清槽、不执行 action/focus。
- **改法**:runtime 在解析 name 前按 ordinal 精确比较 `"char_empty"`,命中则 `clearCharacters(slot, durationMs)`(block 时 await)后继续走 setCharacter(action/focus 照常,characterKey 为空)。

### P1-2 focus 缺省语义

- **native**:缺省 ⇒ `["all"]`,且每条带 slot 的命令都全量重置 focus(不带 focus 的命令把所有槽恢复亮)。
- **前端**:缺省时 `hasName ? "current_only" : undefined` —— 有 name 只亮当前槽,无 name 完全不动。
- **改法**:runtime 恒传 `focusMode: "subset"`;`resolveCharacterSlotFocusSlots` 对缺省/`"all"` 返回 `["l","m","r"]`(custom 槽未建模)。renderer 删除 `current_only` 分支。

### P1-3 `focus="n"/"none"` 全暗

- **native**:不识别的取值 = 清零后不点亮 ⇒ 全部槽 unfocus。
- **前端**:`"none"` 只把当前操作槽置暗。
- **改法**:不再特判 `"n"/"none"` —— 任何不识别取值解析出空槽列表,`subset` 空集 = 全部槽 0.5 亮度(顺带对齐 P3-21 的 `focus="a"`,同一规则覆盖)。

### P1-4 换图 crossfade 绑死参数 `fadetime` 且缺省不淡入

- **native**:crossfade 时长 = `duration`;name 非空且 afrom/ato 任一 < 0 ⇒ 重置 `(0,1)` 淡入。
- **前端**:`replaceFadeMs` 取自 `fadetime`(native 死参数)且缺省 0 ⇒ 瞬时替换;缺省 afrom/ato 无 alpha 动画。
- **改法**:runtime 传 `replaceFadeMs = durationMs`,不再读 `fadetime`;named 且 afrom/ato 任一缺省/负值 ⇒ `alphaFrom=0, alphaTo=1`。renderer 重构 crossfade:新图 alpha 完全由 afrom→ato(contentAlpha) tween 驱动,旧图单独淡出,消除旧实现的双重渐隐。

### P1-5 每条命令重置 transform

- **native**:位移仅由 posfrom/posto/jump/x/y 改变,换图不重置位移(`resetOffsetPos=false`),zoom scale 在 foreImage 上保留。
- **前端**:`end != "false"`(缺省)时 from 固定 `(0,0,scale 1)` ⇒ 不带 pos 的命令把已有位移/缩放瞬移回默认。
- **改法**:`characterSlotFromTransform` 恒以当前 state 为基准(仅显式 `posfrom` 为绝对坐标);from == to 时不启动 transform tween(也不 bump session,保护在途的延迟 tween)。
- **与 #396 的分歧(rebase 时已复核)**:#396 提交信息断言"charslot 带 name 时无条件清零位移、`end=false` 是唯一保留手段",与本条相反。按 build 2761 复核 `_UpdateSeqWithParam`(VA `0x183e53940`),其对 `SlotSetCharWithParam` 的调用第 3 参为**字面量 0**(`resetOffsetPos=false`);`SlotSetCharWithParam` 仅透传,且全库只有 `_UpdateSeqWithParam` 与 charactercutin 的 `SetCutinElement` 两个代码调用方 —— charslot 路径从不重置 `_offset.localPosition`,以本条为准。#396 对 `character` 命令路径(`Set` @ `0x183eb38a0` 的 `m_currentKey` 等价守卫)的分析不受影响,其 legacy 路径修复与本 PR 不冲突。

### P2-6 `random` 默认值与 `random=true` 换算

- **改法**:新增 `toNativeIntParam`(bool/`"true"` → 1、`"false"` → 0),默认 10(原 90);保留 0-100 clamp(语料无越界值)。

### P2-7 zoom pivot 校验

- **改法**:`characterSlotToTransform` 中 `action="zoom"` 且 `poszoom` 任一分量 ∉ [0,1] ⇒ 跳过整个 zoom(scale 与位移都不改);`poszoom` 缺省视为合法(近似为无额外位移,与原实现一致)。

### P2-8 `angle` 独立于 `action` 生效

- **改法**:renderer 旋转分支改为 `input.angle !== undefined` 即生效(原来要求 `action==="rotate"`);`action="rotate"` 无 angle 时无操作,对齐 native"未知 action ⇒ LogError + null"。`action=move` 保留兼容。语料 0 命中,前瞻对齐。

### P2-9 posto-only(无 action、无 posfrom)增量移动

- **改法**:`positionTo` 仅在 `positionFrom` 存在(绝对移动)或 `action === "jump"`(相对增量)时生效,否则忽略 ⇒ 与 native "posFrom 哨兵 (1,1) 不触发 move" 对齐。

### P2-10 shake 不受 duration 门槛限制

- **改法**:shake/shakemove 仅在 `durationMs > 0` 时启动 `startShakeAction`(shakemove 的位移部分不受影响,对应 native duration==0 时 shakemove 退化为纯 move)。

### P2-11 name 加载失败整条丢弃

- **改法**:runtime 解析失败只 `warn("missing_asset")` 不再 return,以无 characterKey 继续下发 action/focus;renderer 的 `buildCharacterSlotState` 失败时保留旧 state 继续(原来 `if (!built) return` 会连 focus 都跳过)。

### P2-12 bstart/bend 黑影方向(核对项)

- **结论**:本轮按 IDA 复核 `_LoadImage`(0x183eb4f60):`CharacterParam` 的 blackStart/blackEnd **原样**传给 `AVGCharacterSpriteHub::SetImage`,不做 `SlotChangeMask` 那种 1-x 反转 ⇒ 前端现有"不反转的静态渐变 overlay"映射正确,方向细节在 greenscreen shader 内(DLL 不可见),维持近似并在注释中记录依据。无行为改动。

### P2-13 `end=false` tween 照常播放

- **native**:Sequence 组装但不 Play,留给同槽后续 end=true 命令触发;图片置换本身不延迟。
- **前端**:原来 `preserveTransform=true` 保留当前值但 tween 照常播放。
- **改法**:input 字段 `preserveTransform`/`resetTransform` 语义废除,替换为 `deferPlay`(runtime 由 `end=="false"` 派生)。renderer 维护每槽 `deferredCharacterSlots` 队列:`deferPlay` 时只装瞬时状态(换图、`SetAlpha(fore, afrom)`、旧图淡出),tween 全部入队;同槽下一条 end=true 命令先把队列逐条"补播"再执行自身(近似 native 的同 Sequence 追加后 Play)。`clearCharacters` 清掉对应队列。

未实现(有意省略,维持 review 建议):P3 的 delay/focusduration/x/y/stop/xscale/yscale/glitch/matname/custom slot/`action=move|rotate|setpos` 移除/times 默认/afrom-ato 不 clamp/阻塞边界近似,以及 P2-12 的 shader 级方向(见上)。

## 验证用剧情文件

生产剧情语料位于本地 `torappu/storage/asset/gamedata/latest/story`(2.7.61 全量,161,391 条带参 + 27,786 条裸 `[charslot]`):

- **P0-1(char_empty)**:`obt/main/level_main_12-12_end.txt:373`(`name="char_empty"` + zoom 参数,清中槽)、`obt/memory/story_bubble_1_1.txt:502`(清左槽 + `focus="all"` 继续执行)。
- **P1-2(focus 缺省 = all)**:`activities/act23side/level_act23side_02_beg.txt:421`(无 focus 的入场,其余槽恢复亮;全语料 62,591 条同型)。
- **P1-3(focus=none 全暗)**:`obt/main/level_main_12-05_end.txt:349`、`obt/main/level_main_14-10_end.txt:17`。
- **P1-4(crossfade 用 duration + 缺省 (0,1))**:`obt/main/level_main_12-12_end.txt:377`(`name+duration=1` 无 afrom/ato,1s 淡入;全语料 10,638 条同型)。
- **P1-5(transform 保持)**:`activities/act23side/level_act23side_02_beg.txt:425-426`(425 位移入场后,426 的 shake/focus 命令不再把位移瞬移回默认)。
- **P2-6(random=true = 1)**:`obt/main/level_main_12-05_end.txt:576`、`obt/main/level_main_12-04_beg.txt:214`。
- **P2-7(zoom pivot 越界)**:语料 0 命中 —— 前瞻对齐,由单测锁定(`tests/renderer.spec.ts` > "skips the whole zoom when poszoom is outside [0,1]")。
- **P2-8(angle 独立生效)**:语料 0 命中 —— 前瞻对齐,单测锁定(同文件 > "rotates from the standalone angle parameter regardless of action")。
- **P2-9(posto-only 忽略)**:`activities/act53side/level_act53side_06_end.txt:424`(`posto="0,0"` 无 posfrom/action ⇒ no-op);其余 posto-only 样本多为标量(`obt/main/level_main_14-02_end.txt:379` 等),native 同为 no-op。
- **P2-10(shake 无 duration 不抖)**:`activities/act22side/level_act22side_02_end.txt:191`(`action="shake",random=true,power=8,times=100,isblock=true` 且无 duration ⇒ 原前端会持续抖动,native 完全不抖)。
- **P2-11(缺资源不丢命令)**:生产语料无未知角色引用,属容错路径 —— 单测锁定(`tests/runtime.spec.ts` > "keeps running charslot actions when the character asset is missing")。
- **P2-12(bstart/bend 方向)**:核对后无需改动(见修复内容;`obt/memory/story_blkngt_1_1.txt:810` 等含 bstart/bend 的 glitch 场景行为不变)。
- **P2-13(end=false 延迟触发)**:`obt/memory/story_blkngt_1_1.txt:810-811`(换图 deferred,由 811 的 zoom 触发淡入)、`activities/act23side/level_act23side_02_beg.txt:425-426`(入场 deferred,由 426 的 shake 触发)、`obt/main/level_main_12-12_end.txt:345-346`(淡出 deferred,由 346 的 zoom 触发)。

## 测试

已 rebase main(`3f8a6169`),与 #342(enter/transtype)、#396(`nativeKey`/同 key 保留位移)的冲突已解:两边测试均保留,`focusMode` 收窄为 `"subset"` 并保留 #342 的 `focus?: number`,#396 在 `characterSlotFromTransform` 留下的与 native 相悖的注释已按上述复核结论更正。

- `pnpm test`:24 个文件 **323** 用例全部通过(rebase 后 main 基线 312,新增/更新 charslot 用例 11 个)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint <改动文件>`:通过。
- `STORY_CORPUS_ROOT=... pnpm test:story-log`:全语料 Log All 回归 2 用例通过(charslot 不涉及文本可见性,`engine/log/*` 与 `tests/helpers/storyOracle.ts` 无引用,无需同步)。

