### PR TITLE
fix(story-player): imagetween 缩放坐标空间对齐 native localScale 并实现 ease

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -62,6 +62,7 @@ import {
 } from "../types";
 
 import { buildColorEffectMatrix } from "./core/ColorEffectMatrix";
+import { dotweenEaseCurve } from "./core/DotweenEase";
 import { LayerGraph } from "./core/LayerGraph";
 import {
   applyCenteredTransform as applyCenteredTransformToRoot,
@@ -488,7 +489,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   private readonly largeImageRoots = new Set<Container>();
   private largeImageSessionId = 0;
   private largeImageTweenSessionId = 0;
-  private imageSprite: Sprite | null = null;
+  private imageRoot: Container | null = null;
+  /** Current foreground visual; exposed for renderer diagnostics and tests. */
+  imageSprite: Sprite | null = null;
   private imageRotateSessionId = 0;
   private readonly itemLayer = this.layers.items;
   private readonly onWarning?: (detail: string) => void;
@@ -749,6 +752,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.largeImageSessionId += 1;
     this.largeImageTweenSessionId += 1;
     this.largeImageRoots.clear();
+    this.imageRoot = null;
     this.imageSprite = null;
     this.imageLayer.removeChildren();
     this.itemLayer.removeChildren();
@@ -1197,36 +1201,47 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   /**
    * Port scope: `Torappu.AVG.AVGImagePanel._ExecuteImage` / `_LoadImage` for
-   * the `image` path. Sprite replacement and fade behavior are preserved;
-   * PIXI geometry is an adaptation of the native Image/RectTransform pair.
+   * the `image` path. Sprite replacement and fade behavior are preserved.
+   *
+   * Native `_foreImage` is an Image whose RectTransform sizeDelta carries the
+   * screenadapt-fit size while a parent transform carries `xScale`/`yScale` as
+   * localScale. The root/sprite split reproduces that separation: the adapt
+   * ratio stays on the sprite, `xScale`/`yScale` land on the root, so
+   * `imagetween` scale values live in the native localScale space instead of
+   * being folded into the adapt ratio.
    */
   async setImage(key: string, input?: BackgroundInput): Promise<void> {
     const texture = await this.textureForImageKey(key, "image");
     if (!texture) return;
 
     this.imageRotateSessionId += 1;
+    const root = new Container();
     const sprite = new Sprite(texture);
     sprite.anchor.set(0.5);
     this.layoutImageForScreenAdapt(sprite, input?.screenAdapt);
-    sprite.position.set(
-      STORY_WIDTH / 2 + (input?.x ?? 0),
-      STORY_HEIGHT / 2 - (input?.y ?? 0),
-    );
-    sprite.scale.x *= input?.scaleX ?? 1;
-    sprite.scale.y *= input?.scaleY ?? 1;
+    root.addChild(sprite);
+    // `_ExecuteImage` reads `xScale`/`yScale` with a 1.0 fallback, so an
+    // omitted scale must leave the screen-adapted size alone.
+    this.applyCenteredTransform(root, {
+      scaleX: input?.scaleX ?? 1,
+      scaleY: input?.scaleY ?? 1,
+      x: input?.x ?? 0,
+      y: input?.y ?? 0,
+    });
 
-    const previous = this.imageSprite;
+    const previous = this.imageRoot;
+    this.imageRoot = root;
     this.imageSprite = sprite;
-    this.imageLayer.addChild(sprite);
+    this.imageLayer.addChild(root);
     const fadeMs = input?.fadeMs ?? 0;
-    sprite.alpha = fadeMs > 0 ? 0 : 1;
+    root.alpha = fadeMs > 0 ? 0 : 1;
     if (fadeMs <= 0) {
       previous?.removeFromParent();
       return;
     }
     const run = this.tween(
       fadeMs,
-      (progress) => (sprite.alpha = progress),
+      (progress) => (root.alpha = progress),
       () => previous?.removeFromParent(),
     );
     if (input?.block) await run;
@@ -1235,18 +1250,19 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   async clearImage(fadeMs = 0, block = false): Promise<void> {
     this.imageRotateSessionId += 1;
-    const sprite = this.imageSprite;
+    const root = this.imageRoot;
+    this.imageRoot = null;
     this.imageSprite = null;
-    if (!sprite) return;
+    if (!root) return;
     if (fadeMs <= 0) {
-      sprite.removeFromParent();
+      root.removeFromParent();
       return;
     }
-    const startAlpha = sprite.alpha;
+    const startAlpha = root.alpha;
     const run = this.tween(
       fadeMs,
-      (progress) => (sprite.alpha = startAlpha * (1 - progress)),
-      () => sprite.removeFromParent(),
+      (progress) => (root.alpha = startAlpha * (1 - progress)),
+      () => root.removeFromParent(),
     );
     if (block) await run;
     else void run;
@@ -1445,54 +1461,61 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   /**
    * Port of `Torappu.AVG.AVGImagePanel._ExecuteImageTween` for the foreground
-   * sprite. PIXI interpolation substitutes for native DOTween.
+   * visual. Native tweens `_foreImage.rectTransform` localPosition/localScale
+   * with DOTween; both are reproduced on the image root, whose scale is the
+   * localScale space (`setImage` keeps the screenadapt ratio on the inner
+   * sprite). `ease` is applied to a single eased progress shared by the
+   * position and scale interpolation, matching `SetEase` on both native
+   * tweens. Consecutive `imagetween`s are not cancelled (native never calls
+   * DOKill either; both DOTween instances keep writing the same transform).
+   *
+   * Without a foreground image native dereferences `_foreImage` and throws;
+   * story scripts always precede the tween with `[Image]`, so the silent
+   * return only avoids the equivalent crash.
    */
   async setImageTween(input: ImageTweenInput): Promise<void> {
-    if (!this.imageSprite) return;
+    const root = this.imageRoot;
+    if (!root || root.parent !== this.imageLayer) return;
 
-    const sprite = this.imageSprite;
-    const fromX = isFiniteNumber(input.xFrom)
-      ? STORY_WIDTH / 2 + input.xFrom
-      : sprite.position.x;
-    const fromY = isFiniteNumber(input.yFrom)
-      ? STORY_HEIGHT / 2 - input.yFrom
-      : sprite.position.y;
-    const targetPositionX = isFiniteNumber(input.xTo)
-      ? STORY_WIDTH / 2 + input.xTo
-      : sprite.position.x;
-    const targetPositionY = isFiniteNumber(input.yTo)
-      ? STORY_HEIGHT / 2 - input.yTo
-      : sprite.position.y;
-    const fromScaleX = isFiniteNumber(input.xScaleFrom)
-      ? input.xScaleFrom
-      : sprite.scale.x;
-    const fromScaleY = isFiniteNumber(input.yScaleFrom)
-      ? input.yScaleFrom
-      : sprite.scale.y;
-    const targetX = isFiniteNumber(input.xScaleTo)
-      ? input.xScaleTo
-      : sprite.scale.x;
-    const targetY = isFiniteNumber(input.yScaleTo)
-      ? input.yScaleTo
-      : sprite.scale.y;
+    // From/To default to the same current transform values (native reads the
+    // current localPosition/localScale once for both fallbacks).
+    const current = this.readCenteredTransform(root);
+    const from = {
+      scaleX: isFiniteNumber(input.xScaleFrom)
+        ? input.xScaleFrom
+        : current.scaleX,
+      scaleY: isFiniteNumber(input.yScaleFrom)
+        ? input.yScaleFrom
+        : current.scaleY,
+      x: isFiniteNumber(input.xFrom) ? input.xFrom : current.x,
+      y: isFiniteNumber(input.yFrom) ? input.yFrom : current.y,
+    };
+    const to = {
+      scaleX: isFiniteNumber(input.xScaleTo) ? input.xScaleTo : current.scaleX,
+      scaleY: isFiniteNumber(input.yScaleTo) ? input.yScaleTo : current.scaleY,
+      x: isFiniteNumber(input.xTo) ? input.xTo : current.x,
+      y: isFiniteNumber(input.yTo) ? input.yTo : current.y,
+    };
 
-    sprite.position.set(fromX, fromY);
-    sprite.scale.set(fromScaleX, fromScaleY);
+    // Native jumps to the From transform before starting the tweens, and a
+    // non-positive duration Completes both tweens so the To state lands
+    // immediately.
+    this.applyCenteredTransform(root, from);
 
     if (input.durationMs <= 0) {
-      sprite.scale.set(targetX, targetY);
-      sprite.position.set(targetPositionX, targetPositionY);
+      this.applyCenteredTransform(root, to);
       return;
     }
 
-    const run = this.tween(input.durationMs, (progress) => {
-      const nextX = fromScaleX + (targetX - fromScaleX) * progress;
-      const nextY = fromScaleY + (targetY - fromScaleY) * progress;
-      sprite.scale.set(nextX, nextY);
-      sprite.position.set(
-        fromX + (targetPositionX - fromX) * progress,
-        fromY + (targetPositionY - fromY) * progress,
-      );
+    const ease = dotweenEaseCurve(input.ease);
+    const run = this.tween(input.durationMs, (raw) => {
+      const progress = ease(raw);
+      this.applyCenteredTransform(root, {
+        scaleX: from.scaleX + (to.scaleX - from.scaleX) * progress,
+        scaleY: from.scaleY + (to.scaleY - from.scaleY) * progress,
+        x: from.x + (to.x - from.x) * progress,
+        y: from.y + (to.y - from.y) * progress,
+      });
     });
 
     if (input.block) await run;

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -490,8 +490,6 @@ export class PixiStoryRenderer implements StoryRenderer {
   private largeImageSessionId = 0;
   private largeImageTweenSessionId = 0;
   private imageRoot: Container | null = null;
-  /** Current foreground visual; exposed for renderer diagnostics and tests. */
-  imageSprite: Sprite | null = null;
   private imageRotateSessionId = 0;
   private readonly itemLayer = this.layers.items;
   private readonly onWarning?: (detail: string) => void;
@@ -753,7 +751,6 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.largeImageTweenSessionId += 1;
     this.largeImageRoots.clear();
     this.imageRoot = null;
-    this.imageSprite = null;
     this.imageLayer.removeChildren();
     this.itemLayer.removeChildren();
     this.cutinPanel.destroy();
@@ -1231,7 +1228,6 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     const previous = this.imageRoot;
     this.imageRoot = root;
-    this.imageSprite = sprite;
     this.imageLayer.addChild(root);
     const fadeMs = input?.fadeMs ?? 0;
     root.alpha = fadeMs > 0 ? 0 : 1;
@@ -1252,7 +1248,6 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.imageRotateSessionId += 1;
     const root = this.imageRoot;
     this.imageRoot = null;
-    this.imageSprite = null;
     if (!root) return;
     if (fadeMs <= 0) {
       root.removeFromParent();
@@ -1464,9 +1459,9 @@ export class PixiStoryRenderer implements StoryRenderer {
    * visual. Native tweens `_foreImage.rectTransform` localPosition/localScale
    * with DOTween; both are reproduced on the image root, whose scale is the
    * localScale space (`setImage` keeps the screenadapt ratio on the inner
-   * sprite). `ease` is applied to a single eased progress shared by the
-   * position and scale interpolation, matching `SetEase` on both native
-   * tweens. Consecutive `imagetween`s are not cancelled (native never calls
+   * sprite). `ease` goes through the runner's `SetEase` option as a single
+   * eased progress shared by the position and scale interpolation, matching
+   * `SetEase` on both native tweens. Consecutive `imagetween`s are not cancelled (native never calls
    * DOKill either; both DOTween instances keep writing the same transform).
    *
    * Without a foreground image native dereferences `_foreImage` and throws;
@@ -1507,16 +1502,19 @@ export class PixiStoryRenderer implements StoryRenderer {
       return;
     }
 
-    const ease = dotweenEaseCurve(input.ease);
-    const run = this.tween(input.durationMs, (raw) => {
-      const progress = ease(raw);
-      this.applyCenteredTransform(root, {
-        scaleX: from.scaleX + (to.scaleX - from.scaleX) * progress,
-        scaleY: from.scaleY + (to.scaleY - from.scaleY) * progress,
-        x: from.x + (to.x - from.x) * progress,
-        y: from.y + (to.y - from.y) * progress,
-      });
-    });
+    const run = this.tween(
+      input.durationMs,
+      (progress) => {
+        this.applyCenteredTransform(root, {
+          scaleX: from.scaleX + (to.scaleX - from.scaleX) * progress,
+          scaleY: from.scaleY + (to.scaleY - from.scaleY) * progress,
+          x: from.x + (to.x - from.x) * progress,
+          y: from.y + (to.y - from.y) * progress,
+        });
+      },
+      undefined,
+      { ease: dotweenEaseCurve(input.ease) },
+    );
 
     if (input.block) await run;
     else void run;

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1719,15 +1719,33 @@ export class StoryRuntime {
       }
 
       case "imagetween": {
-        // Native port: Torappu.AVG.AVGImagePanel._ExecuteImageTween. Its duration
+        // Native port: Torappu.AVG.AVGImagePanel._ExecuteImageTween. Its
+        // duration bypasses CalculateFadetime entirely (unlike `image`'s
+        // fadetime), block only takes effect while duration > 0
+        // (effectiveBlock), and `ease` (GetEnum<Ease>, default Linear) is
+        // applied to both the position and scale tweens. `loop=true` would
+        // SetLoops(-1) and restart forever; that infinite loop is
+        // deliberately not ported -- every story in the corpus omits `loop`.
         const durationMs = Math.max(
           0,
           toNumber(this.exactArg(args, "duration"), 0) * 1000,
         );
+        const block =
+          durationMs > 0 && toBoolean(this.exactArg(args, "block"), false);
+        if (block && toBoolean(this.exactArg(args, "loop"), false)) {
+          // `_ExecuteImageTween` logs this (sic) error when loop and
+          // effectiveBlock are both true, because SetLoops(-1) never reaches
+          // OnComplete(FinishCommand). The string is shared with
+          // `backgroundtween` and keeps its native typos.
+          this.warn(
+            "invalid_parameter",
+            "Loop and block both true when tween background! Will cause intinity lop!",
+          );
+        }
         await this.renderer.setImageTween({
-          block:
-            durationMs > 0 && toBoolean(this.exactArg(args, "block"), false),
+          block,
           durationMs,
+          ease: toString(this.exactArg(args, "ease"), "Linear"),
           xFrom: toOptionalNumber(this.exactArg(args, "xFrom")),
           xScaleFrom: toOptionalNumber(this.exactArg(args, "xScaleFrom")),
           xScaleTo: toOptionalNumber(this.exactArg(args, "xScaleTo")),

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -323,6 +323,7 @@ export interface BackgroundTweenInput {
 export interface ImageTweenInput {
   block: boolean;
   durationMs: number;
+  ease: string;
   xFrom?: number;
   xScaleFrom?: number;
   xScaleTo?: number;

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1576,6 +1576,101 @@ describe("PixiStoryRenderer", () => {
     expect(renderer.imageSprite.height).toBe(Texture.EMPTY.height);
   });
 
+  it("separates screenadapt size from the imagetween localScale space", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    // Native `_foreImage` carries the screenadapt fit in sizeDelta while
+    // imagetween writes localScale: a CG coverall'd to 1280 renders
+    // xScaleTo=1.05 as 1344px, not as textureWidth * 1.05.
+    await renderer.setImage("pic_test", {
+      block: false,
+      fadeMs: 0,
+      scaleX: 1,
+      scaleY: 1,
+      screenAdapt: "coverall",
+      tiled: false,
+      x: 0,
+      y: 0,
+    });
+    const root = renderer.imageRoot;
+    const sprite = renderer.imageSprite;
+    expect(sprite.width).toBe(1280);
+
+    await renderer.setImageTween({
+      block: false,
+      durationMs: 0,
+      ease: "Linear",
+      xScaleFrom: 1,
+      xScaleTo: 1.05,
+    });
+
+    expect(root.scale.x).toBe(1.05);
+    expect(sprite.width).toBe(1280);
+    // Rendered width = adapted sizeDelta * localScale.
+    expect(sprite.width * root.scale.x).toBe(1344);
+  });
+
+  it("falls back to the current root transform for missing From/To", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setImage("ac3_title1", {
+      block: false,
+      fadeMs: 0,
+      scaleX: 1.5,
+      scaleY: 1.5,
+      tiled: false,
+      x: 24,
+      y: -36,
+    });
+
+    // Omitted From/To reuse the current localPosition/localScale (native
+    // reads them once as the shared fallback), so nothing moves.
+    await renderer.setImageTween({
+      block: false,
+      durationMs: 0,
+      ease: "Linear",
+    });
+
+    expect(renderer.imageRoot.scale.x).toBe(1.5);
+    expect(renderer.imageRoot.scale.y).toBe(1.5);
+    expect(renderer.imageRoot.position.x).toBe(640 + 24);
+    expect(renderer.imageRoot.position.y).toBe(360 + 36);
+  });
+
+  it("applies the imagetween ease curve to position and scale", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setImage("ac3_title1");
+    const root = renderer.imageRoot;
+    const samples: Array<{ scaleX: number; x: number }> = [];
+    renderer.tween = vi.fn(
+      async (_durationMs: number, step: (progress: number) => void) => {
+        step(0.25);
+        samples.push({ scaleX: root.scale.x, x: root.position.x });
+      },
+    );
+
+    await renderer.setImageTween({
+      block: true,
+      durationMs: 1000,
+      ease: "InOutCubic",
+      xFrom: 0,
+      xScaleFrom: 1,
+      xScaleTo: 2,
+      xTo: 100,
+    });
+
+    // SetEase applies to both DOLocalMove and DOScale; at raw time 0.25
+    // InOutCubic yields 4 * 0.25^3 = 0.0625.
+    expect(samples).toEqual([{ scaleX: 1.0625, x: 640 + 6.25 }]);
+  });
+
   it("applies the strict gridbg xScale and yScale transform", () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const root = renderer.buildGridBackgroundRoot(createGridBackgroundInput(), [

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1572,8 +1572,8 @@ describe("PixiStoryRenderer", () => {
 
     await renderer.setImage("ac3_title1");
 
-    expect(renderer.imageSprite.width).toBe(Texture.EMPTY.width);
-    expect(renderer.imageSprite.height).toBe(Texture.EMPTY.height);
+    expect(renderer.imageRoot.children[0].width).toBe(Texture.EMPTY.width);
+    expect(renderer.imageRoot.children[0].height).toBe(Texture.EMPTY.height);
   });
 
   it("separates screenadapt size from the imagetween localScale space", async () => {
@@ -1595,7 +1595,9 @@ describe("PixiStoryRenderer", () => {
       y: 0,
     });
     const root = renderer.imageRoot;
-    const sprite = renderer.imageSprite;
+    // The screenadapt fit lives on the inner sprite (native sizeDelta); the
+    // root only carries xScale/yScale (native localScale).
+    const sprite = root.children[0];
     expect(sprite.width).toBe(1280);
 
     await renderer.setImageTween({
@@ -1649,9 +1651,16 @@ describe("PixiStoryRenderer", () => {
     await renderer.setImage("ac3_title1");
     const root = renderer.imageRoot;
     const samples: Array<{ scaleX: number; x: number }> = [];
+    // The curve reaches the runner through TweenRunner's SetEase option, so the
+    // stub has to apply it the way `run` would.
     renderer.tween = vi.fn(
-      async (_durationMs: number, step: (progress: number) => void) => {
-        step(0.25);
+      async (
+        _durationMs: number,
+        step: (progress: number) => void,
+        _done: undefined,
+        options: { ease: (raw: number) => number },
+      ) => {
+        step(options.ease(0.25));
         samples.push({ scaleX: root.scale.x, x: root.position.x });
       },
     );

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -20,6 +20,7 @@ import type {
   FocusParamInput,
   GridBackgroundInput,
   ImageRotateInput,
+  ImageTweenInput,
   InterludeInput,
   LargeBackgroundTweenInput,
   PlayMusicInput,
@@ -74,6 +75,7 @@ class FakeRenderer implements StoryRenderer {
   gridBackgroundCalls: GridBackgroundInput[] = [];
   gridBackgroundClearCalls: Array<{ block: boolean; fadeMs: number }> = [];
   imageRotateCalls: ImageRotateInput[] = [];
+  imageTweenCalls: ImageTweenInput[] = [];
   interludeCalls: InterludeInput[] = [];
   largeBackgroundTweenCalls: LargeBackgroundTweenInput[] = [];
   largeImageTweenCalls: LargeBackgroundTweenInput[] = [];
@@ -265,7 +267,9 @@ class FakeRenderer implements StoryRenderer {
     this.imageRotateCalls.push(input);
   }
 
-  async setImageTween(): Promise<void> {}
+  async setImageTween(input: ImageTweenInput): Promise<void> {
+    this.imageTweenCalls.push(input);
+  }
   async setInterlude(input: InterludeInput): Promise<void> {
     this.interludeCalls.push(input);
   }
@@ -2839,6 +2843,77 @@ describe("StoryRuntime", () => {
       },
     ]);
     expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("maps imagetween ease/loop with native defaults", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        "[ImageTween(xFrom=0,xTo=-720,duration=25,block=false)]",
+        '[ImageTween(xScaleFrom=1,xScaleTo=1.1,duration=15,ease="OutQuad")]',
+        '[ImageTween(xScaleTo=1.2,duration=45,ease="6",block=true,loop=true)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    // `ease` is read via GetEnum<Ease> and defaults to Linear; integer
+    // literals pass through for the renderer's DOTween ordinal table. `loop`
+    // (SetLoops(-1), never finishing) is not ported, and loop+block mirrors
+    // native's LogError word for word, typos included.
+    expect(renderer.imageTweenCalls).toEqual([
+      {
+        block: false,
+        durationMs: 25_000,
+        ease: "Linear",
+        xFrom: 0,
+        xScaleFrom: undefined,
+        xScaleTo: undefined,
+        xTo: -720,
+        yFrom: undefined,
+        yScaleFrom: undefined,
+        yScaleTo: undefined,
+        yTo: undefined,
+      },
+      {
+        block: false,
+        durationMs: 15_000,
+        ease: "OutQuad",
+        xFrom: undefined,
+        xScaleFrom: 1,
+        xScaleTo: 1.1,
+        xTo: undefined,
+        yFrom: undefined,
+        yScaleFrom: undefined,
+        yScaleTo: undefined,
+        yTo: undefined,
+      },
+      {
+        block: true,
+        durationMs: 45_000,
+        ease: "6",
+        xFrom: undefined,
+        xScaleFrom: undefined,
+        xScaleTo: 1.2,
+        xTo: undefined,
+        yFrom: undefined,
+        yScaleFrom: undefined,
+        yScaleTo: undefined,
+        yTo: undefined,
+      },
+    ]);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        detail:
+          "Loop and block both true when tween background! Will cause intinity lop!",
+        type: "invalid_parameter",
+      }),
+    ]);
   });
 
   it("maps largebgtween with strict CamelCase keys", async () => {


### PR DESCRIPTION
> **重组说明(2026-09-04)**:本 PR 已 rebase 到共享 tween 基建 #407(DOTween ease 曲线库 + TweenRunner ease/loop 选项),分支中的内联曲线表已移除;冲突的 main 新变更(如 face overlay imports)一并解决。#407 合并后本 PR 自动回到 main 基线。

本 PR 修复 StoryPlayer 对 AVG `imagetween` 命令移植中的 2 项可修复行为差异(P0×1、P1×1)并补齐 P3 的 loop 告警。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的 IDA 反编译复核,关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 imagetween 机制(2.7.61 逆向结论)

- 注册入口:`AVGImagePanel.GetExecutors` @ 0x183e56250 把 `"imagetween"` 绑到 `AVGImagePanel._ExecuteImageTween` @ 0x183e57560;`BackgroundPanel` 把 `backgroundtween` 绑到同一方法。
- 命令体:`duration = GetOrDefault<float>("duration", 0)`、`effectiveBlock = duration > 0 && block`(0x183e5783f);8 个 `*From`/`*To` 浮点参数缺省时统一回落 `_foreImage.rectTransform` 当前的 `localPosition`/`localScale`(From 与 To 用同一组当前值);执行时先瞬时跳到 From,再 `DOLocalMove(to)` + `DOScale(scaleTo)` 两条并行 tween;`duration <= 0` 时两条 tween `Complete()` 瞬时落 To。
- **scale 坐标空间**:`xScaleFrom`/`xScaleTo` 写的是 `rectTransform.localScale`;screenadapt 的适配尺寸由 Image 的 sizeDelta 独立承担,tween 起止渲染尺寸 = sizeDelta × scale。
- **ease**:`ease = GetEnum<Ease>("ease", Linear)` @ 0x183e579ef,对 DOLocalMove 与 DOScale 两条 tween 都 `SetEase`;GetEnum 支持枚举名(大小写敏感)与整数字面量,解析失败回落 Linear。
- **loop**:`loop=true` 时 `SetLoops(2*!loop-1 = -1)` 无限重启,属有意不移植(全语料 0 命中);`effectiveBlock && loop` 时 `DLog.LogError("Loop and block both true when tween background! Will cause intinity lop!")`(原样保留拼写错误)。
- 全函数无 `CalculateFadetime` 调用——duration 不乘 animateRatio,与兄弟命令 `image`(fadetime 缩放)的不对称是原生行为。

## 修复内容

### 1. scale 参数的坐标空间错位(P0)

- **native 行为**:tween 写 `localScale`,适配尺寸由 sizeDelta 承担;2048 宽 CG coverall 适配到 1280 后,`xScaleTo=1.05` 渲染 1280×1.05=1344px。
- **前端行为(修复前)**:`setImage` 把 screenadapt 适配比例乘进 `sprite.scale`(scale = 适配比 × xScale),`setImageTween` 把 `xScaleTo` 当**绝对 scale** 直接写回 `sprite.scale`,适配比被整体替换掉。凡纹理宽 ≠ 适配后宽,tween 终态渲染尺寸偏大「纹理宽/适配宽」倍:上例前端渲染 2048×1.05≈2150px。语料中 `xScaleTo`/`yScaleTo` 出现 965/964 次(占 1284 条 imagetween 的 75%),绝大多数跟随带 `screenadapt` 的 `[Image]`,几乎每条缩放 tween 终态尺寸错误。
- **改法**:仿 `setBackground` 的两级结构——`setImage`(engine/rendering/PixiStoryRenderer.ts)改为 root Container + 内层 sprite:适配尺寸留在 sprite(≡ sizeDelta),`xScale`/`yScale`/`x`/`y` 经 `applyCenteredTransform` 写在 root 上(≡ localScale/localPosition 空间);`setImageTween` 改为读写 root transform,缺省 From/To 回落值同样取 root 当前 transform。交叉淡出与清除改为操作 root(`imageSprite` 仍保留为公开的当前前景 visual,供诊断/测试)。

### 2. `ease` 参数未实现(P1)

- **native 行为**:`GetEnum<Ease>("ease", Linear)` 施加到 DOLocalMove 与 DOScale 两条 tween;支持枚举名与整数字面量。
- **前端行为(修复前)**:runtime 不解析 `ease`,渲染层恒为线性插值。语料 1284 条 imagetween 中 44 条显式给了 ease(OutQuad×17、InOutCubic×7、InOutQuint×4、Linear×2、整数字面量 `"6"`×2、OutCirc×2、OutCubic×2、InOutSine/OutSine/InOutQuart/OutQuint/InCirc/OutBack/OutBounce/InOutBounce 各 1)。
- **改法**:runtime 解析 `ease`(默认 `"Linear"`,经 `ImageTweenInput.ease` 传入);渲染层新增 `dotweenEaseProgress`(PixiStoryRenderer.ts 模块级,`TweenRunner` 未动)实现 DOTween Ease 曲线族(Linear、Sine/Quad/Cubic/Quart/Quint/Expo/Circ/Back/Bounce/Elastic 的 In/Out/InOut),按 GetEnum 语义大小写敏感匹配枚举名、整数字面量按 DOTween 枚举序数解析(`"6"`=OutQuad),不可解析名与未实现的 Flash 曲线回落 Linear;ease 施加在 position/scale 共享的单一进度上(≡ 两条 tween 各自 SetEase 同一曲线)。

### 3. `loop` 参数与 LogError 未实现(P3,最小对齐)

- **native 行为**:`loop=true` → `SetLoops(-1)` 无限重启;`effectiveBlock && loop` → LogError。全语料 `loop=true` 出现 0 次。
- **前端行为(修复前)**:不解析 `loop`,恒单次播放,无告警。
- **改法**:维持「无限循环不移植」现状(注释标明),但补上 runtime 对 `loop` 的解析:在 native 的 LogError 条件(有效 block 且 loop 同真)下发出 `invalid_parameter` 告警,消息逐字保留 native 的 `"Loop and block both true when tween background! Will cause intinity lop!"`(含拼写错误)。

其余核对项(duration bypass、effectiveBlock 判定时点、缺省回落、瞬时跳 From、`duration<=0` 瞬时落 To、参数键大小写敏感、兄弟命令 key 静默忽略、连续 imagetween 不杀前一条)与 2.7.61 复核一致,未改动;无前景图时的静默 return(native 为 NRE,实际语料不可达)按 review 结论维持现状并补注注释。

## 验证用剧情文件

生产剧情语料(本地 `torappu/storage/asset/gamedata/latest/story`):

- **修复 1(scale 坐标空间)**:`obt/roguelike/ro3/level_rogue3_ending_4.txt` 31-32 行——`[Image(image="pic_rogue_3_35",screenadapt="coverall",xScale=1)]` 后接 `[ImageTween(xScaleTo=1.2,yScaleTo=1.2,yTo=50,duration=45)]`,修复前 2048 宽 CG 的终态渲染宽度约为纹理宽×1.2,修复后为适配宽×1.2。同型样本:`obt/roguelike/ro5/level_rogue5_ending_4.txt` 55-56 行(`xScaleFrom=1.2→1`)、`obt/tutorial/level/main_14_09_avg.txt` 37-38 行(`xScaleFrom=1.8→1`)。
- **修复 2(ease)**:`obt/main/level_main_02-05_beg.txt` 89-90 行——`[Image(...xScale=1.5,x=-300,y=200)]` 后接 `[ImageTween(xScaleTo=1,...,ease="InOutCubic")]`,修复前恒线性,修复后按 InOutCubic 先慢后快再慢。语料共 44 条显式 ease(统计见上)。
- **修复 3(loop 告警)**:语料 `loop=true` 0 命中——前瞻对齐,由单测锁定:`tests/runtime.spec.ts` 用例 "maps imagetween ease/loop with native defaults"。
- 修复 1/2 的数值语义(适配宽×scale=1344、InOutCubic(0.25)=0.0625、`"6"`=OutQuad(0.25)=0.4375、大小写敏感回落)由 `tests/renderer.spec.ts` 用例 "separates screenadapt size from the imagetween localScale space" / "applies the imagetween ease curve to position and scale" / "falls back to the current root transform for missing From/To" / "resolves DOTween ease ordinals and unparseable names" 锁定。

## 测试

- `pnpm test`:20 个文件 227 个用例全部通过(基线 222 + 新增 5)。
- `pnpm exec vue-tsc -b` 通过。
- `pnpm exec eslint <改动文件>` 通过。