### PR TITLE
fix(story-player): characteraction 阻塞键/exit 方向表/shake 阻塞/zoom pivot 等原生语义对齐

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -139,6 +139,9 @@ interface CharacterRenderState {
   jumpSessionId: number;
   motionLayer: Container;
   opacitySessionId: number;
+  /** Zoom pivot in image pixels (Pixi y-down); undefined = image center. */
+  pivotX?: number;
+  pivotY?: number;
   replaceFadeSessionId: number;
   root: Container;
   rotationDeg: number;
@@ -1713,8 +1716,11 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   /**
    * Port scope: `Torappu.AVG.CharacterPanel._ExecuteCharacterAction` and its
-   * move/jump/shake/zoom/exit handlers. Browser tween sampling adapts DOTween,
-   * but keeps the per-action state and completion boundary.
+   * move/jump/shake/zoom/exit handlers (build 2761). Browser tween sampling
+   * adapts DOTween, but keeps the per-action state and the completion
+   * boundary: every branch funnels through `_AddFinishCommand`, so a blocking
+   * command awaits the full native tween duration (shake included, and jump's
+   * move+bounce sequence, not just the move segment).
    */
   async runCharacterAction(input: CharacterActionInput): Promise<void> {
     const state = this.characterSlots.get(
@@ -1737,18 +1743,33 @@ export class PixiStoryRenderer implements StoryRenderer {
         return;
       }
       case "jump": {
-        this.startJumpAction(state, input.power, input.times, input.durationMs);
-        await this.runMoveAction(
+        // Native runs one DOLocalJump tween of durationMs containing `times`
+        // jumps and blocks on that whole tween.
+        const moveRun = this.startMoveAction(
           state,
           input.xOffset,
           input.yOffset,
           input.durationMs,
-          input.block,
         );
+        const jumpRun = this.startJumpAction(
+          state,
+          input.power,
+          input.times,
+          input.durationMs,
+        );
+        if (input.block && input.durationMs > 0) {
+          await Promise.all([moveRun, jumpRun]);
+        }
         return;
       }
       case "shake": {
         this.startShakeAction(state, input);
+        // Native CharShake returns the DOShakePosition tween of durationMs
+        // and _AddFinishCommand blocks on it. `stop` is a web extension with
+        // no tween to wait for.
+        if (input.block && input.durationMs > 0 && !input.stop) {
+          await this.tween(input.durationMs, () => {});
+        }
         return;
       }
       case "zoom": {
@@ -1756,8 +1777,7 @@ export class PixiStoryRenderer implements StoryRenderer {
           state,
           input.scaleX,
           input.scaleY,
-          input.xOffset,
-          input.yOffset,
+          input.pivot,
           input.durationMs,
           input.block,
         );
@@ -1768,7 +1788,7 @@ export class PixiStoryRenderer implements StoryRenderer {
           state,
           input.durationMs,
           input.direction,
-          input.yOffset,
+          input.absolutePosition,
           input.block,
         );
       }
@@ -2792,6 +2812,10 @@ export class PixiStoryRenderer implements StoryRenderer {
     current.height = sizeY;
     current.root.x = baseX;
     current.root.y = baseY;
+    // A fresh visual is a fresh native _foreImage: its pivot resets to the
+    // center until a later zoom sets it again.
+    current.pivotX = undefined;
+    current.pivotY = undefined;
     current.sourceHeight = built.sourceHeight;
     current.sourceWidth = built.sourceWidth;
     current.visual = built.visual;
@@ -3054,10 +3078,31 @@ export class PixiStoryRenderer implements StoryRenderer {
     state.motionLayer.x = state.actionX + state.shakeOffsetX;
     state.motionLayer.y =
       state.shakeOffsetY - state.actionY - state.jumpOffsetY;
-    state.motionLayer.scale.set(
-      state.baseScaleX * state.scaleX,
-      state.baseScaleY * state.scaleY,
-    );
+    const scaleX = state.baseScaleX * state.scaleX;
+    const scaleY = state.baseScaleY * state.scaleY;
+    state.motionLayer.scale.set(scaleX, scaleY);
+    if (state.pivotX !== undefined && state.pivotY !== undefined) {
+      // Zoom pivot mode: pin the pivot point of the image at the story-space
+      // spot where the image center sits at rest (width/2, height/2 in root
+      // space). Dividing the rotationLayer position by the current scale
+      // cancels the parent scale, so scaling keeps the pivot fixed while the
+      // rest of the image grows around it — the observable of Unity's
+      // rectTransform.pivot + localScale pairing.
+      state.rotationLayer.pivot.set(state.pivotX, state.pivotY);
+      state.rotationLayer.position.set(
+        (state.width / 2 - state.motionLayer.x) / Math.max(scaleX, 1e-6),
+        (state.height / 2 - state.motionLayer.y) / Math.max(scaleY, 1e-6),
+      );
+    } else {
+      state.rotationLayer.pivot.set(
+        state.sourceWidth / 2,
+        state.sourceHeight / 2,
+      );
+      state.rotationLayer.position.set(
+        state.sourceWidth / 2,
+        state.sourceHeight / 2,
+      );
+    }
     state.rotationLayer.rotation = (state.rotationDeg * Math.PI) / 180;
     this.updateCharacterOpacity(state);
   }
@@ -3163,12 +3208,17 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.disposeCurtainState(state);
   }
 
-  private async runMoveAction(
+  /**
+   * Native port: AVGCharacterSlot.MoveChar (0x183EB2FD0). Relative
+   * displacement (cur + (x, y)); a zero fadeTime applies it instantly and
+   * returns a null tween, which is why `block` only waits when there is a
+   * tween to wait for.
+   */
+  private startMoveAction(
     state: CharacterRenderState,
     xOffset: number,
     yOffset: number,
     durationMs: number,
-    block: boolean,
   ): Promise<void> {
     const fromX = state.actionX;
     const fromY = state.actionY;
@@ -3176,7 +3226,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     const toY = fromY + yOffset;
     const sessionId = ++state.transformSessionId;
 
-    const run = this.tween(
+    return this.tween(
       durationMs,
       (progress) => {
         if (!this.isActiveCharacterState(state, sessionId)) return;
@@ -3191,43 +3241,57 @@ export class PixiStoryRenderer implements StoryRenderer {
         this.updateCharacterState(state);
       },
     );
-
-    if (block && durationMs > 0) await run;
   }
 
-  private async runScaleAction(
+  private async runMoveAction(
     state: CharacterRenderState,
-    scaleX: number | undefined,
-    scaleY: number | undefined,
     xOffset: number,
     yOffset: number,
     durationMs: number,
     block: boolean,
   ): Promise<void> {
-    const fromX = state.actionX;
-    const fromY = state.actionY;
+    const run = this.startMoveAction(state, xOffset, yOffset, durationMs);
+    if (block && durationMs > 0) await run;
+  }
+
+  /**
+   * Native port: AVGCharacterSlot.CharZoom (0x183EB2B50). xpos/ypos are the
+   * [0,1] pivot of the character image (runtime already rejected out-of-range
+   * values, which native turns into a whole-command no-op). Setting the pivot
+   * shifts the image so the new pivot lands where the center used to be
+   * (Unity pivot semantics), then localScale tweens linearly around that
+   * pivot. Without a pivot the historical top-left-anchored scaling applies.
+   */
+  private async runScaleAction(
+    state: CharacterRenderState,
+    scaleX: number | undefined,
+    scaleY: number | undefined,
+    pivot: { x: number; y: number } | undefined,
+    durationMs: number,
+    block: boolean,
+  ): Promise<void> {
     const fromScaleX = state.scaleX;
     const fromScaleY = state.scaleY;
-    const toX = fromX + xOffset;
-    const toY = fromY + yOffset;
     const toScaleX = isFiniteNumber(scaleX) ? scaleX : state.scaleX;
     const toScaleY = isFiniteNumber(scaleY) ? scaleY : state.scaleY;
+    if (pivot) {
+      // Unity pivots measure y from the bottom; Pixi anchors from the top.
+      state.pivotX = pivot.x * state.sourceWidth;
+      state.pivotY = (1 - pivot.y) * state.sourceHeight;
+    }
     const sessionId = ++state.transformSessionId;
+    this.updateCharacterState(state);
 
     const run = this.tween(
       durationMs,
       (progress) => {
         if (!this.isActiveCharacterState(state, sessionId)) return;
-        state.actionX = fromX + (toX - fromX) * progress;
-        state.actionY = fromY + (toY - fromY) * progress;
         state.scaleX = fromScaleX + (toScaleX - fromScaleX) * progress;
         state.scaleY = fromScaleY + (toScaleY - fromScaleY) * progress;
         this.updateCharacterState(state);
       },
       () => {
         if (!this.isActiveCharacterState(state, sessionId)) return;
-        state.actionX = toX;
-        state.actionY = toY;
         state.scaleX = toScaleX;
         state.scaleY = toScaleY;
         this.updateCharacterState(state);
@@ -3237,20 +3301,49 @@ export class PixiStoryRenderer implements StoryRenderer {
     if (block && durationMs > 0) await run;
   }
 
+  /**
+   * Native port: CharacterPanel._ExecuteCharacterExit (0x183E69C80) →
+   * _GenExitPosition (0x183E6B670) → AVGCharacterSlot.SetCharPos
+   * (0x183EB3290). The exit table below is verbatim native: displacements
+   * from each slot's rest anchor (l=440/m=640/r=840 in 1280x720 story space;
+   * actionX/actionY are exactly that displacement). Both coordinates are set
+   * absolutely, so a horizontal exit also snaps the vertical drift back to 0.
+   * An unknown direction resolves to (0,0) — the rest anchor.
+   */
   private async runExitAction(
     state: CharacterRenderState,
     durationMs: number,
     direction: CharacterActionInput["direction"],
-    yOffset: number,
+    absolutePosition: { x: number; y: number } | undefined,
     block: boolean,
   ): Promise<void> {
-    const toX =
-      direction === "left"
-        ? -(state.baseX + state.width + 64)
-        : STORY_WIDTH - state.baseX + 64;
+    const exitTable: Record<string, Record<string, [number, number]>> = {
+      l: { left: [-952, 0], right: [1352, 0] },
+      m: { left: [-1152, 0], right: [1152, 0] },
+      r: { left: [-1352, 0], right: [952, 0] },
+    };
+    const verticalTable: Record<string, [number, number]> = {
+      down: [0, -1072],
+      up: [0, 1072],
+    };
+
+    let toX: number;
+    let toY: number;
+    if (absolutePosition) {
+      // Both xpos & ypos present: absolute story-space target, same anchor
+      // convention as the `character` command (actionY is up-positive).
+      toX = absolutePosition.x - state.baseX;
+      toY = state.baseY - absolutePosition.y;
+    } else if (direction === "up" || direction === "down") {
+      [toX, toY] = verticalTable[direction];
+    } else if (direction === "left" || direction === "right") {
+      [toX, toY] = (exitTable[state.slot] ?? exitTable.m)[direction] ?? [0, 0];
+    } else {
+      [toX, toY] = [0, 0];
+    }
+
     const fromX = state.actionX;
     const fromY = state.actionY;
-    const toY = fromY + yOffset;
     const sessionId = ++state.transformSessionId;
 
     const run = this.tween(
@@ -3272,47 +3365,47 @@ export class PixiStoryRenderer implements StoryRenderer {
     if (block && durationMs > 0) await run;
   }
 
+  /**
+   * Native port: AVGCharacterSlot.CharJump (0x183EB2690) — a single
+   * DOLocalJump tween whose total duration is fadeTime with `times` jumps
+   * inside, not `times` separate tweens.
+   */
   private startJumpAction(
     state: CharacterRenderState,
     power: number,
     times: number,
     durationMs: number,
-  ): void {
+  ): Promise<void> {
     const sessionId = ++state.jumpSessionId;
     state.jumpOffsetY = 0;
     this.updateCharacterState(state);
 
-    if (power <= 0 || durationMs <= 0) return;
+    if (power <= 0 || durationMs <= 0) return Promise.resolve();
 
-    const iterations = Math.max(1, times);
-    void (async () => {
-      for (let index = 0; index < iterations; index += 1) {
+    const cycles = Math.max(1, times);
+    return this.tween(
+      durationMs,
+      (progress) => {
         if (
           !this.isActiveCharacterState(state) ||
           state.jumpSessionId !== sessionId
         )
           return;
-
-        await this.tween(durationMs, (progress) => {
-          if (
-            !this.isActiveCharacterState(state) ||
-            state.jumpSessionId !== sessionId
-          )
-            return;
-          const cycle = progress <= 0.5 ? progress / 0.5 : (1 - progress) / 0.5;
-          state.jumpOffsetY = Math.max(0, power * cycle);
-          this.updateCharacterState(state);
-        });
-      }
-
-      if (
-        !this.isActiveCharacterState(state) ||
-        state.jumpSessionId !== sessionId
-      )
-        return;
-      state.jumpOffsetY = 0;
-      this.updateCharacterState(state);
-    })();
+        const phase = (progress * cycles) % 1;
+        const cycle = phase <= 0.5 ? phase / 0.5 : (1 - phase) / 0.5;
+        state.jumpOffsetY = Math.max(0, power * cycle);
+        this.updateCharacterState(state);
+      },
+      () => {
+        if (
+          !this.isActiveCharacterState(state) ||
+          state.jumpSessionId !== sessionId
+        )
+          return;
+        state.jumpOffsetY = 0;
+        this.updateCharacterState(state);
+      },
+    );
   }
 
   private startShakeAction(
@@ -3437,13 +3530,19 @@ export class PixiStoryRenderer implements StoryRenderer {
     blocker.visible = blocker.alpha > 0;
   }
 
-  // CharacterAction still uses the legacy per-tick shake model; CameraShake uses ShakePath.
+  /**
+   * CharacterAction still uses this legacy per-tick shake model; CameraShake
+   * uses ShakePath. Web adaptation of DOShakePosition's randomness parameter
+   * (native key `random`, degrees, default 10): the degree value is
+   * reinterpreted as the per-tick chance of a nonzero jolt, so a shake with
+   * the native default still produces sparse jolts over `times` vibrations.
+   */
   private pickShakeOffset(strength: number, randomness: number): number {
     const roll = Math.floor(Math.random() * 99) + 1;
     const directions = [-1, -0.707, 0, 1, 0.707];
     const index =
       roll < randomness ? Math.floor(Math.random() * directions.length) : 0;
-    return directions[index] * strength;
+    return directions[index]! * strength;
   }
 
   private createOverlayTextStyle(fontSize: number, widthPx: number): TextStyle {

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1787,8 +1787,13 @@ export class StoryRuntime {
       }
 
       case "characteraction": {
-        // Native port: Torappu.AVG.CharacterPanel._ExecuteCharacterAction. It uses
-        // literal fadetime and accepts both legacy block spellings.
+        // Native port: Torappu.AVG.CharacterPanel._ExecuteCharacterAction
+        // (0x183E699F0, build 2761). All five branches scale fadetime through
+        // AVGUtils.CalculateFadetime (animateRatio × fadetime) and read the
+        // blocking flag from `isblock` only — `_AddFinishCommand`
+        // (0x183E698E0) never reads `block=` (only the cutin panel does), so
+        // the thousands of legacy `block=` spellings in the corpus stay
+        // non-blocking exactly like the native client.
         const type = this.parseCharacterActionType(args.type);
         if (!type) {
           this.warn(
@@ -1799,28 +1804,88 @@ export class StoryRuntime {
         }
         const slot = this.parseCharacterActionSlot(args.name, type);
 
-        const scaleFallback =
-          args.scale === undefined
-            ? undefined
-            : Math.max(0, toNumber(args.scale, 1));
+        // Per-branch GetOrDefault defaults: exit/zoom fade in for 1.0s while
+        // move/jump/shake default to 0.5s.
+        const fadetimeFallback = type === "exit" || type === "zoom" ? 1 : 0.5;
+        const durationMs = this.calculateFadeMs(
+          this.exactArg(args, "fadetime"),
+          fadetimeFallback,
+        );
+
+        // NeedSkipAnimation (0x183E69680): jump/shake collapse into a plain
+        // move when the scaled fadetime is zero (skip mode or fadetime=0);
+        // the move executor then applies xpos/ypos instantly.
+        const effectiveType: CharacterActionInput["type"] =
+          (type === "jump" || type === "shake") && durationMs <= 0
+            ? "move"
+            : type;
+
+        let pivot: { x: number; y: number } | undefined;
+        if (type === "zoom") {
+          // xpos/ypos are the [0,1] pivot of the character image (default
+          // 0.5/0.5). AVGCharacterSlot.CharZoom (0x183EB2B50) returns null
+          // for pivots outside [0,1], making the whole command a no-op.
+          const pivotX = toNumber(args.xpos, 0.5);
+          const pivotY = toNumber(args.ypos, 0.5);
+          if (pivotX < 0 || pivotX > 1 || pivotY < 0 || pivotY > 1) {
+            this.warn(
+              "parse",
+              `characteraction zoom pivot out of range: xpos=${toString(args.xpos)}, ypos=${toString(args.ypos)}`,
+            );
+            return "continue";
+          }
+          pivot = { x: pivotX, y: pivotY };
+        }
+
+        // Native exit reads xpos/ypos as an absolute target only when BOTH
+        // are present (TryGetParam<int>); otherwise _GenExitPosition ignores
+        // them. `direction` accepts left/right/up/down and defaults to "left"
+        // when the key is missing; an unrecognized value falls through as
+        // undefined (native exits to the (0,0) rest anchor).
+        const hasExitX = this.exactArg(args, "xpos") !== undefined;
+        const hasExitY = this.exactArg(args, "ypos") !== undefined;
+        const parsedDirection = this.parseCharacterActionDirection(
+          args.direction,
+        );
+        const direction =
+          type === "exit"
+            ? (parsedDirection ??
+              (this.exactArg(args, "direction") === undefined
+                ? "left"
+                : undefined))
+            : parsedDirection;
+
+        // `scale` resets to the native 1.0 default when omitted; xscale and
+        // yscale are web extensions (the native panel never reads them).
+        const scaleFallback = Math.max(0, toNumber(args.scale, 1));
         const xScale =
           args.xscale === undefined
             ? scaleFallback
-            : Math.max(0, toNumber(args.xscale, scaleFallback ?? 1));
+            : Math.max(0, toNumber(args.xscale, scaleFallback));
         const yScale =
           args.yscale === undefined
             ? scaleFallback
-            : Math.max(0, toNumber(args.yscale, scaleFallback ?? 1));
+            : Math.max(0, toNumber(args.yscale, scaleFallback));
 
         await this.renderer.runCharacterAction({
-          block: toBoolean(args.block, toBoolean(args.isblock, false)),
-          direction: this.parseCharacterActionDirection(args.direction),
-          durationMs: Math.max(
-            0,
-            Math.round(toNumber(args.fadetime, 0.5) * 1000),
-          ),
-          power: Math.max(0, toNumber(args.power, 0)),
-          randomness: clamp(toNumber(args.randomness, 90), 0, 100),
+          absolutePosition:
+            type === "exit" && hasExitX && hasExitY
+              ? {
+                  x: toNumber(args.xpos, 0),
+                  y: toNumber(args.ypos, 0),
+                }
+              : undefined,
+          block: toBoolean(args.isblock, false),
+          direction,
+          durationMs,
+          pivot,
+          // jump/shake GetOrDefault defaults: power 10, int times 3.
+          power: Math.max(0, toNumber(args.power, 10)),
+          // Native key is `random` (DOShakePosition randomness degrees,
+          // default 10); `randomness=` is not read by the native panel.
+          randomness: toNumber(args.random, 10),
+          // start/leftend/rightend and stop are web extensions kept for
+          // charslot-style scripts; the native panel never reads them.
           rotationFromDeg: toNumber(args.start, 0),
           rotationLeftDeg:
             args.leftend === undefined ? -15 : -toNumber(args.leftend, 15),
@@ -1830,10 +1895,10 @@ export class StoryRuntime {
           scaleY: yScale,
           slot,
           stop: toBoolean(args.stop, false),
-          times: Math.trunc(toNumber(args.times, 1)),
-          type,
-          xOffset: toNumber(args.xpos, 0),
-          yOffset: toNumber(args.ypos, 0),
+          times: Math.trunc(toNumber(args.times, 3)),
+          type: effectiveType,
+          xOffset: type === "zoom" ? 0 : toNumber(args.xpos, 0),
+          yOffset: type === "zoom" ? 0 : toNumber(args.ypos, 0),
         } satisfies CharacterActionInput);
         return "continue";
       }
@@ -2789,7 +2854,18 @@ export class StoryRuntime {
     value: unknown,
   ): CharacterActionInput["direction"] | undefined {
     const normalized = toString(value).trim().toLowerCase();
-    if (normalized === "left" || normalized === "right") return normalized;
+    // _GenExitPosition (0x183E6B670) recognizes exactly left/right/up/down;
+    // anything else resolves to the (0,0) rest anchor (renderer handles
+    // undefined that way). The "left" default for a missing key is applied by
+    // the exit branch, matching GetOrDefault("direction", "left").
+    if (
+      normalized === "down" ||
+      normalized === "left" ||
+      normalized === "right" ||
+      normalized === "up"
+    ) {
+      return normalized;
+    }
     return undefined;
   }
 

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -171,10 +171,32 @@ export interface CharacterSlotInput {
 }
 
 export interface CharacterActionInput {
+  /**
+   * Exit-only: present when the command carries BOTH xpos and ypos (native
+   * TryGetParam<int> pair) — absolute story-space coordinates, mirroring the
+   * `character` command's absolutePosition convention.
+   */
+  absolutePosition?: { x: number; y: number };
   block: boolean;
-  direction?: "left" | "right";
+  /**
+   * Native reads `direction` only in the exit branch with GetOrDefault
+   * "left"; `_GenExitPosition` also accepts up/down. Undefined here means the
+   * raw value was not one of the four native directions (native exits to the
+   * slot rest anchor (0,0)).
+   */
+  direction?: "down" | "left" | "right" | "up";
   durationMs: number;
+  /**
+   * Zoom-only: native reads xpos/ypos as the [0,1] RectTransform pivot of the
+   * character image (default 0.5/0.5, y measured from the bottom like Unity).
+   * Runtime rejects out-of-range pivots before dispatch (native no-ops).
+   */
+  pivot?: { x: number; y: number };
   power: number;
+  /**
+   * DOShakePosition randomness. Native key is `random` (int, degrees, default
+   * 10); the web renderer adapts it to a per-tick duty cycle.
+   */
   randomness: number;
   rotationFromDeg: number;
   rotationLeftDeg: number;

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -604,3 +604,270 @@ describe("PixiStoryRenderer", () => {
     expect(360 - root.position.y).toBe(0);
   });
 });
+
+function createActionInput(
+  overrides: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    block: false,
+    durationMs: 100,
+    power: 0,
+    randomness: 10,
+    rotationFromDeg: 0,
+    rotationLeftDeg: -15,
+    rotationRightDeg: 15,
+    scaleX: 1,
+    scaleY: 1,
+    slot: "m",
+    stop: false,
+    times: 3,
+    xOffset: 0,
+    yOffset: 0,
+    ...overrides,
+  };
+}
+
+async function createSlot(renderer: any, slot: string): Promise<any> {
+  // isActiveCharacterState gates every tween step on the live app.
+  renderer.app ??= {};
+  await renderer.setCharacter({
+    characterKey: "avg_test",
+    durationMs: 0,
+    expression: "1$1",
+    fadeIdentity: "avg_test",
+    slot,
+  });
+  return renderer.characterSlots.get(slot);
+}
+
+describe("PixiStoryRenderer characteraction", () => {
+  it("exits along the native direction table including up and down", async () => {
+    const renderer = createCharacterRenderer();
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        step: (progress: number) => void,
+        done?: () => void,
+      ) => {
+        step(1);
+        done?.();
+      },
+    );
+
+    const middle = await createSlot(renderer, "m");
+    await renderer.runCharacterAction(
+      createActionInput({ direction: "left", type: "exit" }),
+    );
+    expect(middle.actionX).toBe(-1152);
+    expect(middle.actionY).toBe(0);
+
+    await renderer.runCharacterAction(
+      createActionInput({ direction: "right", type: "exit" }),
+    );
+    expect(middle.actionX).toBe(1152);
+
+    // Vertical exits apply +/-1072 on the (up-positive) action axis and also
+    // snap the horizontal drift back to the rest anchor.
+    await renderer.runCharacterAction(
+      createActionInput({ direction: "up", type: "exit" }),
+    );
+    expect(middle.actionX).toBe(0);
+    expect(middle.actionY).toBe(1072);
+    await renderer.runCharacterAction(
+      createActionInput({ direction: "down", type: "exit" }),
+    );
+    expect(middle.actionY).toBe(-1072);
+
+    // Unknown directions exit to the (0,0) rest anchor, like _GenExitPosition.
+    await renderer.runCharacterAction(
+      createActionInput({ direction: undefined, type: "exit" }),
+    );
+    expect(middle.actionX).toBe(0);
+    expect(middle.actionY).toBe(0);
+
+    // Slot-specific table rows.
+    const left = await createSlot(renderer, "l");
+    await renderer.runCharacterAction(
+      createActionInput({ direction: "left", slot: "l", type: "exit" }),
+    );
+    expect(left.actionX).toBe(-952);
+    const right = await createSlot(renderer, "r");
+    await renderer.runCharacterAction(
+      createActionInput({ direction: "left", slot: "r", type: "exit" }),
+    );
+    expect(right.actionX).toBe(-1352);
+  });
+
+  it("uses exit xpos/ypos as absolute coordinates when both are present", async () => {
+    const renderer = createCharacterRenderer();
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        step: (progress: number) => void,
+        done?: () => void,
+      ) => {
+        step(1);
+        done?.();
+      },
+    );
+    const state = await createSlot(renderer, "m");
+
+    await renderer.runCharacterAction(
+      createActionInput({
+        absolutePosition: { x: 300, y: 200 },
+        direction: "left",
+        type: "exit",
+      }),
+    );
+
+    expect(state.actionX).toBe(300 - state.baseX);
+    expect(state.actionY).toBe(state.baseY - 200);
+  });
+
+  it("treats zoom xpos/ypos as the image pivot and scales around it", async () => {
+    const renderer = createCharacterRenderer();
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        step: (progress: number) => void,
+        done?: () => void,
+      ) => {
+        step(1);
+        done?.();
+      },
+    );
+    const state = await createSlot(renderer, "m");
+
+    // avg_test image is 100x200 px; unity pivot y is measured from the
+    // bottom, pixi anchors from the top.
+    await renderer.runCharacterAction(
+      createActionInput({
+        pivot: { x: 0.8, y: 0.2 },
+        scaleX: 2,
+        scaleY: 2,
+        type: "zoom",
+      }),
+    );
+
+    expect(state.pivotX).toBe(80);
+    expect(state.pivotY).toBe(160);
+    expect(state.scaleX).toBe(2);
+    expect(state.rotationLayer.pivot.x).toBe(80);
+    expect(state.rotationLayer.pivot.y).toBe(160);
+    // The pivot stays pinned at the rest-center spot: the layer position
+    // compensates the parent scale (100/2 image-space / 2 scale).
+    expect(state.rotationLayer.position.x).toBeCloseTo(25);
+    expect(state.rotationLayer.position.y).toBeCloseTo(50);
+
+    // A later zoom with the default 0.5/0.5 pivot (what the runtime always
+    // sends when xpos/ypos are absent) re-centers the anchor.
+    await renderer.runCharacterAction(
+      createActionInput({
+        pivot: { x: 0.5, y: 0.5 },
+        scaleX: 1,
+        scaleY: 1,
+        type: "zoom",
+      }),
+    );
+    expect(state.rotationLayer.pivot.x).toBe(50);
+    expect(state.rotationLayer.pivot.y).toBe(100);
+    expect(state.rotationLayer.position.x).toBe(50);
+    expect(state.rotationLayer.position.y).toBe(100);
+  });
+
+  it("awaits the full shake duration when blocking, even with zero power", async () => {
+    const renderer = createCharacterRenderer();
+    await createSlot(renderer, "m");
+    const gates: Array<() => void> = [];
+    renderer.tween = vi.fn(
+      (_durationMs: number, _step: (progress: number) => void) =>
+        new Promise<void>((resolve) => {
+          gates.push(resolve);
+        }),
+    );
+
+    let settled = false;
+    const run = renderer.runCharacterAction(
+      createActionInput({ block: true, durationMs: 400, type: "shake" }),
+    );
+    void run.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Native CharShake always returns a tween of fadeTime, so _AddFinishCommand
+    // blocks on it regardless of the (here zero) shake power.
+    expect(gates).toHaveLength(1);
+    expect(settled).toBe(false);
+
+    for (const gate of gates) gate();
+    await run;
+    expect(settled).toBe(true);
+  });
+
+  it("runs jump as one tween of the fade duration with the jumps inside", async () => {
+    const renderer = createCharacterRenderer();
+    await createSlot(renderer, "m");
+    const tweens: Array<{
+      durationMs: number;
+      step: (progress: number) => void;
+      done?: () => void;
+      resolve: () => void;
+    }> = [];
+    renderer.tween = vi.fn(
+      (
+        durationMs: number,
+        step: (progress: number) => void,
+        done?: () => void,
+      ) =>
+        new Promise<void>((resolve) => {
+          tweens.push({ durationMs, step, done, resolve });
+        }),
+    );
+
+    let settled = false;
+    const run = renderer.runCharacterAction(
+      createActionInput({
+        block: true,
+        durationMs: 400,
+        power: 20,
+        times: 4,
+        type: "jump",
+        xOffset: 100,
+      }),
+    );
+    void run.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Move + jump each take exactly one fadeTime tween; the jump no longer
+    // costs times × durationMs.
+    expect(tweens.map((tween) => tween.durationMs)).toEqual([400, 400]);
+    expect(settled).toBe(false);
+
+    const state = renderer.characterSlots.get("m");
+    const jumpTween = tweens[1]!;
+    jumpTween.step(0.125);
+    expect(state.jumpOffsetY).toBe(20);
+    jumpTween.step(0.25);
+    expect(state.jumpOffsetY).toBe(0);
+    jumpTween.step(0.375);
+    expect(state.jumpOffsetY).toBe(20);
+
+    // Finalize the tweens the way the real TweenRunner does: step(1) + done.
+    for (const tween of tweens) {
+      tween.step(1);
+      tween.done?.();
+      tween.resolve();
+    }
+    await run;
+    expect(settled).toBe(true);
+    expect(state.jumpOffsetY).toBe(0);
+    expect(state.actionX).toBe(100);
+  });
+});

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2088,7 +2088,7 @@ describe("StoryRuntime", () => {
     ]);
   });
 
-  it("maps characteraction move with legacy slot aliases and block args", async () => {
+  it("maps characteraction move with legacy slot aliases and isblock", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(
       createContext([
@@ -2101,27 +2101,139 @@ describe("StoryRuntime", () => {
 
     await runtime.start();
 
+    // Native defaults: power 10, times 3, random 10, scale 1.0.
     expect(renderer.actionCalls).toEqual([
       {
         block: true,
         direction: undefined,
         durationMs: 100,
-        power: 0,
-        randomness: 90,
+        power: 10,
+        randomness: 10,
         rotationFromDeg: 0,
         rotationLeftDeg: -15,
         rotationRightDeg: 15,
-        scaleX: undefined,
-        scaleY: undefined,
+        scaleX: 1,
+        scaleY: 1,
         slot: "l",
         stop: false,
-        times: 1,
+        times: 3,
         type: "move",
         xOffset: -200,
         yOffset: 60,
       },
     ]);
     expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("ignores legacy block= and only reads isblock like the native panel", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        // Corpus-dominant spelling: block= is dead weight natively (only the
+        // cutin panel reads it), so these must not stall the player.
+        '[characteraction(name="left",type="move",xpos=100,fadetime=0.2,block=true)]',
+        '[characteraction(name="left",type="move",xpos=-100,fadetime=0.2,block=true,isblock=true)]',
+        '[characteraction(name="left",type="move",xpos=0,fadetime=0.2,isblock=false,block=true)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.actionCalls.map((action) => action.block)).toEqual([
+      false,
+      true,
+      false,
+    ]);
+    // None of the non-blocking moves may stall the runtime.
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("scales characteraction fadetime by animateRatio per native branch defaults", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[characteraction(name="l",type="move",fadetime=0.5)]',
+        '[characteraction(name="l",type="exit",fadetime=0.5)]',
+        '[characteraction(name="l",type="zoom",fadetime=0.5)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { animateRatio: 0.5 },
+    );
+
+    await runtime.start();
+
+    // move defaults to 0.5s, exit/zoom to 1.0s, all halved by animateRatio.
+    expect(renderer.actionCalls.map((action) => action.durationMs)).toEqual([
+      250, 250, 250,
+    ]);
+    // Missing fadetime keeps the per-branch defaults (500 move / 1000 exit).
+    const fallbackRenderer = new FakeRenderer();
+    await new StoryRuntime(
+      createContext([
+        '[characteraction(name="l",type="jump",fadetime=0)]',
+        '[characteraction(name="l",type="exit")]',
+        '[name="A"]ok',
+      ]),
+      fallbackRenderer,
+      new FakeAudio(),
+    ).start();
+    expect(
+      fallbackRenderer.actionCalls.map((action) => action.durationMs),
+    ).toEqual([0, 1000]);
+  });
+
+  it("degenerates jump and shake to an instant move when the scaled fadetime is zero", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[characteraction(name="l",type="jump",xpos=30,ypos=40,power=20,fadetime=0.5)]',
+        '[characteraction(name="l",type="shake",power=20,fadetime=0.5)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      // Quick-play speed: animateRatio 0 → NeedSkipAnimation collapses
+      // jump/shake into _ExecuteCharacterMove with the same xpos/ypos.
+      { animateRatio: 0 },
+    );
+
+    await runtime.start();
+
+    expect(renderer.actionCalls.map((action) => action.type)).toEqual([
+      "move",
+      "move",
+    ]);
+    expect(renderer.actionCalls.map((action) => action.xOffset)).toEqual([
+      30, 0,
+    ]);
+    expect(renderer.actionCalls.map((action) => action.durationMs)).toEqual([
+      0, 0,
+    ]);
+  });
+
+  it("reads the shake randomness from the native random key", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[characteraction(name="l",type="shake",power=5,times=10,fadetime=0.2,random=42)]',
+        '[characteraction(name="l",type="shake",power=5,times=10,fadetime=0.2,randomness=42)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // `randomness=` is not a native key; the second call falls back to 10.
+    expect(renderer.actionCalls.map((action) => action.randomness)).toEqual([
+      42, 10,
+    ]);
   });
 
   it("uses the five strict characteraction branches and native slot fallbacks", async () => {
@@ -2141,11 +2253,14 @@ describe("StoryRuntime", () => {
 
     expect(renderer.actionCalls).toEqual([
       {
-        block: true,
+        // block= is ignored (native reads isblock only); zoom's missing
+        // fadetime defaults to 1.0s and xpos/ypos become the 0.5/0.5 pivot.
+        block: false,
         direction: undefined,
-        durationMs: 500,
-        power: 0,
-        randomness: 90,
+        durationMs: 1000,
+        pivot: { x: 0.5, y: 0.5 },
+        power: 10,
+        randomness: 10,
         rotationFromDeg: 0,
         rotationLeftDeg: -15,
         rotationRightDeg: 15,
@@ -2153,7 +2268,7 @@ describe("StoryRuntime", () => {
         scaleY: 0.8,
         slot: "l",
         stop: false,
-        times: 1,
+        times: 3,
         type: "zoom",
         xOffset: 0,
         yOffset: 0,
@@ -2161,23 +2276,96 @@ describe("StoryRuntime", () => {
       {
         block: false,
         direction: "left",
-        durationMs: 500,
-        power: 0,
-        randomness: 90,
+        durationMs: 1000,
+        power: 10,
+        randomness: 10,
         rotationFromDeg: 0,
         rotationLeftDeg: -15,
         rotationRightDeg: 15,
-        scaleX: undefined,
-        scaleY: undefined,
+        scaleX: 1,
+        scaleY: 1,
         slot: "m",
         stop: false,
-        times: 1,
+        times: 3,
         type: "exit",
         xOffset: 0,
         yOffset: 0,
       },
     ]);
     expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("defaults the exit direction to left and accepts native up/down", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[characteraction(name="m",type="exit")]',
+        '[characteraction(name="m",type="exit",direction="up")]',
+        '[characteraction(name="m",type="exit",direction="down")]',
+        '[characteraction(name="m",type="exit",direction="sideways")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.actionCalls.map((action) => action.direction)).toEqual([
+      "left",
+      "up",
+      "down",
+      // Non-native directions stay undefined; the renderer maps that to the
+      // native (0,0) rest-anchor exit.
+      undefined,
+    ]);
+  });
+
+  it("treats zoom xpos/ypos as a [0,1] pivot and no-ops out-of-range values", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[characteraction(name="m",type="zoom",xpos=0.8,ypos=0.2,scale=1.5,fadetime=0.1)]',
+        // Corpus spelling (xpos=-1 / ypos=-1): CharZoom rejects the pivot and
+        // the whole command — including the scale change — is a no-op.
+        '[characteraction(name="m",type="zoom",xpos=-1,ypos=-1,scale=0.8,fadetime=0.1,block=true)]',
+        '[characteraction(name="m",type="zoom",xpos=1.5,scale=0.8)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    expect(renderer.actionCalls).toHaveLength(1);
+    expect(renderer.actionCalls[0]?.pivot).toEqual({ x: 0.8, y: 0.2 });
+    expect(warnings.filter((warning) => warning.type === "parse")).toHaveLength(
+      2,
+    );
+    // The no-op zoom with block=true must not stall the runtime.
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("uses exit xpos/ypos as absolute coordinates only when both are present", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[characteraction(name="m",type="exit",xpos=300,ypos=200,fadetime=0.1)]',
+        '[characteraction(name="m",type="exit",ypos=200,fadetime=0.1)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(
+      renderer.actionCalls.map((action) => action.absolutePosition),
+    ).toEqual([{ x: 300, y: 200 }, undefined]);
   });
 
   it("maps imagerotate strict parameters", async () => {


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `characteraction` 命令移植中的全部 P1/P2 行为差异与可顺手对齐的 P3 默认值(共 10 项)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的逆向分析,关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 characteraction 机制(2.7.61 逆向结论)

命令由 `Torappu.AVG.CharacterPanel` 处理(与 `character` 命令共用面板),分发入口 `_ExecuteCharacterAction`(VA `0x183E699F0`),按 `type` 明文比较分 `move/jump/exit/zoom/shake` 五支,未知 type 记 LogError 且不阻塞。关键语义:

- **阻塞**(`_AddFinishCommand`,VA `0x183E698E0`):只读 `isblock` 参数;`block=` 键被整个 CharacterPanel 忽略(全库仅 cutin panel 读 `block`)。tween 非空且 isblock 时 `OnComplete(FinishCommand)` 阻塞,tween 为空(零时长)不阻塞。
- **时长缩放**:五个分支全部经 `AVGUtils.CalculateFadetime`(VA `0x183E69360`,`animateRatio × fadetime`)。快进(animateRatio→0)时 `NeedSkipAnimation`(VA `0x183E69680`)为真,jump/shake 整体退化重新走 `_ExecuteCharacterMove`(瞬时应用 xpos/ypos)。
- **exit**(`0x183E69C80`):`direction` 缺省 `"left"`;`_GenExitPosition`(VA `0x183E6B670`)按槽位给定位移:left 槽 left/right → `(-952,0)/(1352,0)`,right 槽 → `(-1352,0)/(952,0)`,middle → `(-1152,0)/(1152,0)`,up/down → `(0,±1072)`,非法 direction → `(0,0)`;经 `AVGCharacterSlot.SetCharPos`(`0x183EB3290`)绝对定位(水平退出同时把纵向漂移归零)。`xpos/ypos` 经 `TryGetParam<int>` **双双存在**才作绝对坐标。fadetime 缺省 **1.0**。
- **zoom**(`0x183E6AC90` → `AVGCharacterSlot.CharZoom`,`0x183EB2B50`):`xpos/ypos` 是 `[0,1]` 区间的 **pivot**(缺省 0.5/0.5,作用于 `_foreImage.rectTransform`),越界 → 返回 null,**整条命令 no-op**(scale 也不生效);scale 缺省 1.0,fadetime 缺省 1.0;无 NeedSkipAnimation。
- **shake**(`0x183E6A870` → `CharShake`,`0x183EB29F0`):`DOShakePosition(fadeTime, power, times, random, ...)`,随机度键名是 **`random`**(int,缺省 10),power 缺省 10、times 缺省 3、fadetime 缺省 0.5;与其它分支一样经 `_AddFinishCommand` 可阻塞。
- **jump**(`0x183E6A050` → `CharJump`,`0x183EB2690`):`DOLocalJump(cur+(x,y), power, times, fadeTime)` 是**单 tween,总时长 = fadeTime**(times 次跳动内含其中),阻塞等完整 tween。

## 修复内容

### 1. 阻塞键别名(P1)

- **native**:只读 `isblock`;`block=` 恒忽略(2.7.61 语料 characteraction 行内 `block=` 4183 次 vs `isblock=` 187 次)。
- **前端原状**:`toBoolean(block, toBoolean(isblock, false))`,`block=` 优先生效,数千条命令产生原生没有的停顿。
- **修复**:只读 `isblock`;`block=` 不再参与。同步改写原来声称"native 接受两种拼写"的错误 provenance 注释。

### 2. exit 缺省方向相反(P1)

- **native**:`direction` 缺省 `"left"` → 向左屏外。
- **前端原状**:缺省(及 up/down/非法值)一律向右出屏。
- **修复**:缺省改向左;新增 up/down(`(0,±1072)` 原生值);非法值按原生 `(0,0)` 回到槽位静止锚点;出屏目标从"按宽度估算"改为 `_GenExitPosition` 原生位移表逐值照抄(l/m/r 槽位区分),水平退出同时把 actionY 归零(原生 SetCharPos 语义)。

### 3. shake 永不阻塞(P1)

- **native**:shake 与其它分支一样经 `_AddFinishCommand`,`isblock=true` 时阻塞到抖动结束(时长 = 缩放后 fadeTime)。
- **前端原状**:`case "shake"` 直接 return,`block` 被丢弃。
- **修复**:block 时 await 一段等效时长(power=0 也阻塞,对齐"tween 恒存在"的原生行为;web 扩展 `stop=true` 除外)。

### 4. zoom 的 xpos/ypos 语义(P1)

- **native**:`[0,1]` pivot,越界 → 整条命令 no-op。
- **前端原状**:当位移增量,越界值(语料中的 `xpos=-1`)仍生效 scale + 偏移。
- **修复**:runtime 侧校验 pivot ∈ [0,1](越界 warn + 整条跳过,含 scale);renderer 侧把 pivot 换算到 Pixi 锚点(Unity pivot y 自底向上,Pixi 自顶向下,做 y 翻转),缩放围绕 pivot 进行(rotationLayer 位置按当前缩放补偿,pivot 点钉在图像静止中心位置)。无 pivot 时保持原有居中锚定行为,不影响 `charslot` 的 scale 路径。

### 5. fadetime 不经 animateRatio(P2)

- **native**:5 分支全过 `CalculateFadetime`;快进时 jump/shake 退化为 move,move/exit/zoom 走瞬时分支。
- **前端原状**:字面值;任何速度下时长不变、不退化。
- **修复**:改用与 `character` 命令相同的 `calculateFadeMs`;缩放后时长为 0 时 jump/shake 在 runtime 侧改派发为 move(对齐 NeedSkipAnimation → `_ExecuteCharacterMove`)。

### 6. exit/zoom 的 fadetime 默认(P2):按 type 取默认(`exit/zoom → 1.0`,move/jump/shake → 0.5),原状统一 0.5。

### 7. power 默认值(P2):jump/shake 默认从 0 改为原生 10(原状未写 power 的 jump 完全不弹跳;语料 761 条 jump 中 94 条未写 power)。

### 8. jump 总时长与阻塞边界(P2):每跳时长从 `durationMs` 改为 `durationMs/times`(单 tween 内含 times 次跳动,总时长 = durationMs,对齐 DOLocalJump);阻塞从"只等 move 段"改为 `Promise.all([move, jump])` 覆盖全程。

### 9. shake 随机度参数键(P2):从 `randomness`(默认 90,clamp 0-100)改为原生 `random` 键(int,默认 10);pickShakeOffset 的"度数→逐 tick 触发概率"映射在注释中声明为 web 适配。

### 10. exit 显式坐标(P2)+ times 默认(P3):exit 的 `xpos/ypos` 双双存在时作**绝对**故事坐标(与 `character` 命令的 absolutePosition 约定一致),仅单个存在时忽略(原状把单独 ypos 当相对增量、丢弃 xpos);`times` 默认从 1 改为原生 3(语料 70 条 jump 未写 times;`time=` 拼写错误键也落到默认 3)。另:zoom 缺省 `scale` 从"保持当前"改为原生缺省 1.0,`stop/start/leftend/rightend/xscale/yscale` 在注释中标注为 charslot 风格 web 扩展(native 面板不读)。

**不改动**(review 确认一致或建议维持):5 分支 type 分发与未知 type 非阻塞、逐分支 slot 真值表(含 exit 兜底 middle)、move/jump 相对位移、`fadetime=0` 时不阻塞、exit 不清槽、zoom scale 目标值语义、`name/type` 的大小写归一(P3,语料全小写)、ease 线性(P3 视觉细节,涉及共享 TweenRunner,不在本命令范围内动)。

## 验证用剧情文件

生产剧情语料(2.7.61)本地路径 `torappu/storage/asset/gamedata/latest/story`:

- **修复 1(block= 不再阻塞)**:`obt/main/level_main_09-03_beg.txt` 144/158/183 行(`type="move"` + `block=true` 无 `isblock`)——播放时这些位移不再把播放器卡住(与官服一致)。
- **修复 2(exit 缺省向左)**:`activities/act15d0/level_act15d0_07_beg.txt` 90 行 `[characteraction(name="left", type="exit",fadetime=0.5, block=true)]`——无 direction,角色应向左出屏(旧版向右),且 block= 不生效。
- **修复 4(zoom pivot/no-op)**:`activities/act17side/level_act17side_01_beg.txt` 414/417/429 行与 `activities/act17side/level_act17side_st03.txt` 361/363/368/371 行(`xpos=-1`)——整条 zoom 不再执行(旧版会把 scale 一并应用);`activities/act12side/level_act12side_08_end.txt` 264 行(`xpos=0.5,ypos=0.3,scale=1.5`)、`activities/act22side/level_act22side_08_end.txt` 192 行(`xpos=0.8,ypos=0.8`)、`activities/act20side/level_act20side_03_end.txt` 180 行——缩放围绕指定 pivot 进行。
- **修复 7(power 默认 10)**:`obt/main/level_main_09-16_end.txt` 168/174/175 行(未写 power 的 jump,旧版不弹跳)。
- **修复 10(times 默认 3)**:`obt/memory/story_asbest_1_1.txt` 381 行(未写 times,原生弹 3 次);`obt/memory/story_billro_1_1.txt` 36 行(`time=1` 拼写错误键,同样落默认 3)。
- **修复 5(jump 零时长退化)**:`obt/memory/story_bstalk_1_1.txt` 263 行与 `activities/act20side/level_act20side_02_end.txt` 154 行(`fadetime=0`,后者带 `isblock=true` 但零时长不阻塞,瞬时位移)。
- **修复 3(shake 阻塞)、9(random 键)、exit up/down、exit 显式坐标**:语料 0 命中(shake 无 `isblock=true`、无 `random=`、exit 无 up/down、无 xpos/ypos),前瞻对齐,由单测锁定:`tests/runtime.spec.ts`(「awaits the full shake duration…」位于 `tests/renderer.spec.ts`、「reads the shake randomness from the native random key」、「defaults the exit direction to left and accepts native up/down」、「uses exit xpos/ypos as absolute coordinates when both are present」)与 `tests/renderer.spec.ts`(「exits along the native direction table including up and down」)。

## 测试

- `pnpm test`:20 个文件 234 个用例全部通过(基线 222,新增/改写 characteraction 相关 12 个)。
- `pnpm exec vue-tsc -b` 通过;`pnpm exec eslint`(改动文件)通过。
- `STORY_CORPUS_ROOT=… pnpm test:story-log` 全语料 Log All 回归通过(2 用例,约 71s)。
