### PR TITLE
fix(story-player): interlude switch 仅内容层、三段 tween 并行与模板时序对齐 native

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/panels/InterludePanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/InterludePanel.ts
@@ -18,10 +18,20 @@ type Tween = (
 
 interface ChannelState {
   elements: Map<string, Container>;
+  label: Text | null;
   mask: Graphics;
   root: Container;
+  /** Current template scale ratio (tracked through ts tweens for clear). */
+  ratio: { x: number; y: number };
+  /** Guards element tweens; bumped by every command on the channel. */
   sessionId: number;
   size: { x: number; y: number };
+  /**
+   * Guards the template show/scale tween separately: native element commands
+   * DOKill only the element tweens, never the template DOScale, so element
+   * sessions must not cancel it (only clear/recreate does).
+   */
+  templateSessionId: number;
 }
 
 function lerp(from: number, to: number, progress: number): number {
@@ -29,9 +39,31 @@ function lerp(from: number, to: number, progress: number): number {
 }
 
 /**
- * Port scope: `Torappu.AVG.AVGCharacterCutinPanel._ExecuteInterlude`, including
- * channel replacement, template masking, and block timing. Containers/masks
- * are a Web/PIXI adaptation of the native character-cutin prefab hierarchy.
+ * Port scope: `Torappu.AVG.AVGCharacterCutinPanel._ExecuteInterlude` /
+ * `CutinController` / `CutinChannel` / `CutinTemplate` (2.7.61, build 2761):
+ *
+ * - Channel begin (`OnCutinBegin` → `CutinTemplate.ShowCutinMask`) applies
+ *   size/offset once and owns the show timing: the sequence has a 1s
+ *   `AppendInterval` floor, Fade/Both styles join a hardcoded 3s mask fade,
+ *   and Scale style runs an independent tsFrom→tsTo DOScale that does not
+ *   gate completion.
+ * - Channel update (`OnCutinUpdate` → `CutinTemplate.UpdateCutinMask`) only
+ *   refreshes the deco (charName/switch); it never re-applies size/offset.
+ *   `switch` feeds the deco `TwoStateToggle` (`CutinTemplateDecoView.Render`)
+ *   alone, so only the content layers toggle and only when the key is present.
+ * - Elements (`CutinChannel._ProcessElement` → `CutinElement.SetCutinElement`)
+ *   run alpha/pos/scale tweens in parallel, each with its own duration
+ *   (alpha via aDuration on the Set append, pos via duration, scale via
+ *   sDuration); the command completes when all of them finish.
+ * - Clear (`CutinTemplate.HideCutinMask`) scales the mask from its current
+ *   ratio to `tsto` over tsduration (style 0 path: DOScale to tsTo only,
+ *   tsFrom is not reused).
+ *
+ * Web adaptations (intentional simplifications): the native mask-template
+ * prefab (stencil pass, `maskid`, deco TwoStateToggle wiring, `direction`
+ * animator entry) is approximated by a rectangular Graphics mask plus a text
+ * label; `dialogCharPos`/`dialogCharScale` (2.7.61 `CutinTemplateDialogView`)
+ * are forwarded on the input but have no Web template to consume them yet.
  */
 export class InterludePanel {
   private readonly channels = new Map<number, ChannelState>();
@@ -53,13 +85,30 @@ export class InterludePanel {
       return;
     }
 
-    const state = this.channels.get(input.channel) ?? this.createChannel(input);
+    const existing = this.channels.get(input.channel);
+    const state = existing ?? this.createChannel(input);
+    const created = existing === undefined;
     const sessionId = ++state.sessionId;
-    this.updateTemplate(state, input);
+    this.refreshDeco(state, input);
 
-    if (input.type === 0) return;
+    // Native OnCutinUpdate: type 0/unknown never reaches _ProcessElement; with
+    // a plain template the completion callback is not fired either, so a
+    // blocking type-0 update would hang natively. We intentionally complete
+    // immediately instead.
+    if (input.type === 0) {
+      if (created && input.block)
+        await this.tween(this.showMs(input.style), () => {});
+      return;
+    }
 
     const slot = input.slot || "m";
+    // Native _GetImgElementByParam fails the lookup when a char/uichar slot
+    // name is missing (LogError + immediate callback); bg (type 2) never uses
+    // a slot. Keep the historical "m" fallback but surface the mismatch.
+    if ((input.type === 1 || input.type === 3) && !input.slot)
+      this.onWarning?.(
+        `interlude element slot is missing (type ${input.type}), falling back to "m"`,
+      );
     let element = state.elements.get(slot);
     if (input.name) {
       const texture = await this.loadTexture(input);
@@ -81,37 +130,60 @@ export class InterludePanel {
       return;
     }
 
-    element.visible = input.switchOn;
+    const el = element;
+    if (input.switchSet) el.visible = input.switchOn;
     if (input.positionFrom && input.positionTo)
-      element.position.set(input.positionFrom.x, -input.positionFrom.y);
-    if (input.scaleFrom)
-      element.scale.set(input.scaleFrom.x, input.scaleFrom.y);
+      el.position.set(input.positionFrom.x, -input.positionFrom.y);
+    if (input.scaleFrom) el.scale.set(input.scaleFrom.x, input.scaleFrom.y);
 
-    const duration = Math.max(
-      input.durationMs,
-      input.scaleDurationMs,
-      input.alphaDurationMs,
-    );
-    const startAlpha = input.alphaFrom >= 0 ? input.alphaFrom : element.alpha;
-    const endAlpha = input.alphaTo >= 0 ? input.alphaTo : 1;
-    const run = this.tween(duration, (progress) => {
-      if (state.sessionId !== sessionId) return;
-      if (input.positionFrom && input.positionTo) {
-        element!.position.set(
-          lerp(input.positionFrom.x, input.positionTo.x, progress),
-          -lerp(input.positionFrom.y, input.positionTo.y, progress),
-        );
-      }
-      if (input.scaleFrom && input.scaleTo) {
-        element!.scale.set(
-          lerp(input.scaleFrom.x, input.scaleTo.x, progress),
-          lerp(input.scaleFrom.y, input.scaleTo.y, progress),
-        );
-      }
-      element!.alpha = lerp(startAlpha, endAlpha, progress);
-    });
-    if (input.block) await run;
-    else void run;
+    // Native _ProcessElement: the SetCutinElement alpha tween (name present)
+    // and the pos/scale tweens each keep their own duration and run in
+    // parallel; the sequence completes when every tween finished.
+    const runs: Array<Promise<void>> = [];
+    if (input.positionFrom && input.positionTo) {
+      const from = input.positionFrom;
+      const to = input.positionTo;
+      runs.push(
+        this.tween(input.durationMs, (progress) => {
+          if (state.sessionId !== sessionId) return;
+          el.position.set(
+            lerp(from.x, to.x, progress),
+            -lerp(from.y, to.y, progress),
+          );
+        }),
+      );
+    }
+    if (input.scaleFrom && input.scaleTo) {
+      const from = input.scaleFrom;
+      const to = input.scaleTo;
+      runs.push(
+        this.tween(input.scaleDurationMs, (progress) => {
+          if (state.sessionId !== sessionId) return;
+          el.scale.set(
+            lerp(from.x, to.x, progress),
+            lerp(from.y, to.y, progress),
+          );
+        }),
+      );
+    }
+    if (input.name) {
+      const startAlpha = Math.max(input.alphaFrom, 0);
+      const endAlpha = input.alphaTo >= 0 ? input.alphaTo : 1;
+      runs.push(
+        this.tween(input.alphaDurationMs, (progress) => {
+          if (state.sessionId !== sessionId) return;
+          el.alpha = lerp(startAlpha, endAlpha, progress);
+        }),
+      );
+    }
+    if (input.block) {
+      const show = created
+        ? this.tween(this.showMs(input.style), () => {})
+        : null;
+      await Promise.all(show ? [show, ...runs] : runs);
+    } else {
+      for (const run of runs) void run;
+    }
   }
 
   async clearAll(): Promise<void> {
@@ -124,6 +196,17 @@ export class InterludePanel {
     void this.clearAll();
   }
 
+  /**
+   * Native CutinTemplate.ShowCutinMask completion floor: the show sequence
+   * always starts with AppendInterval(1.0); Fade/Both styles join a hardcoded
+   * 3s DOFade; ANIMATOR hands completion to the template animation (not
+   * ported, completes immediately).
+   */
+  private showMs(style: number): number {
+    if (style === 3) return 0;
+    return style === 1 || style === 2 ? 3000 : 1000;
+  }
+
   private createChannel(input: InterludeInput): ChannelState {
     const root = new Container();
     const mask = new Graphics();
@@ -134,50 +217,88 @@ export class InterludePanel {
     root.addChild(mask);
     root.mask = mask;
     this.layer.addChild(root);
-    const state = {
+
+    const state: ChannelState = {
       elements: new Map(),
+      label: null,
       mask,
       root,
+      ratio: { x: 1, y: 1 },
       sessionId: 0,
       size: { ...input.size },
+      templateSessionId: 0,
     };
+
+    // Native ShowCutinMask style Scale(0): when tsTo has any component > 0 the
+    // template starts at localScale=tsFrom and DOScales to tsTo over
+    // tsduration. Other styles keep scale 1 (their ts keys are ignored).
+    const scaleEntry =
+      input.style === 0 &&
+      (input.templateSizeTo.x > 0 || input.templateSizeTo.y > 0);
+    if (scaleEntry) {
+      const from = input.templateSizeFrom;
+      const to = input.templateSizeTo;
+      state.ratio = { x: from.x, y: from.y };
+      if (input.templateSizeDurationMs > 0) {
+        const templateSessionId = ++state.templateSessionId;
+        void this.tween(input.templateSizeDurationMs, (progress) => {
+          if (state.templateSessionId !== templateSessionId) return;
+          state.ratio = {
+            x: lerp(from.x, to.x, progress),
+            y: lerp(from.y, to.y, progress),
+          };
+          this.drawMask(
+            state.mask,
+            state.size.x * state.ratio.x,
+            state.size.y * state.ratio.y,
+          );
+        });
+      } else {
+        state.ratio = { x: to.x, y: to.y };
+      }
+    }
+    this.drawMask(
+      state.mask,
+      state.size.x * state.ratio.x,
+      state.size.y * state.ratio.y,
+    );
+
+    if (input.charName) {
+      const label = this.makeLabel(input.charName);
+      state.label = label;
+      state.root.addChild(label);
+    }
+
     this.channels.set(input.channel, state);
     return state;
   }
 
-  private updateTemplate(state: ChannelState, input: InterludeInput): void {
-    if (input.size.x > 0) state.size.x = input.size.x;
-    if (input.size.y > 0) state.size.y = input.size.y;
-    state.root.position.set(
-      STORY_WIDTH / 2 + input.offset.x,
-      STORY_HEIGHT / 2 - input.offset.y,
-    );
-    state.root.visible = input.switchOn;
-    this.drawMask(state.mask, state.size.x, state.size.y);
-
-    const oldLabel = state.root.getChildByLabel("interlude-char");
-    oldLabel?.destroy();
-    if (input.charName) {
-      const label = new Text({
-        style: new TextStyle({ fill: 0xff_ff_ff, fontSize: 24 }),
-        text: input.charName,
-      });
-      label.label = "interlude-char";
-      label.anchor.set(0.5);
-      state.root.addChild(label);
+  /**
+   * Native CutinTemplate.UpdateCutinMask: only the deco is refreshed (name
+   * text and the TwoStateToggle); size/offset are never re-applied and the
+   * mask itself never toggles. The Web stand-in for the deco TwoStateToggle is
+   * toggling the content layers (elements + name label) visibility.
+   */
+  private refreshDeco(state: ChannelState, input: InterludeInput): void {
+    if (input.switchSet) {
+      for (const element of state.elements.values())
+        element.visible = input.switchOn;
+      if (state.label) state.label.visible = input.switchOn;
     }
 
-    if (input.templateSizeDurationMs > 0) {
-      const from = input.templateSizeFrom;
-      const to = input.templateSizeTo;
-      void this.tween(input.templateSizeDurationMs, (progress) => {
-        this.drawMask(
-          state.mask,
-          state.size.x * lerp(from.x, to.x, progress),
-          state.size.y * lerp(from.y, to.y, progress),
-        );
-      });
+    if (!input.charName) {
+      // CutinTemplateDecoView.Render sets the text every update; an empty
+      // name keeps the (now empty) deco alive.
+      if (state.label) state.label.text = "";
+      return;
     }
+    if (state.label) {
+      state.label.text = input.charName;
+      return;
+    }
+    const label = this.makeLabel(input.charName);
+    state.label = label;
+    state.root.addChild(label);
   }
 
   private async clear(input: InterludeInput): Promise<void> {
@@ -187,24 +308,34 @@ export class InterludePanel {
         : [...this.channels.entries()].filter(
             ([channel]) => channel === input.channel,
           );
-    const duration = input.templateSizeDurationMs;
+    // Native _ProcessChannelClean clear-all invokes the completion callback
+    // once per recycled channel (and never when there are none); we aggregate
+    // into a single completion on purpose.
+    if (input.channel < 0 && input.block && states.length > 1)
+      this.onWarning?.(
+        `interlude clear-all aggregates ${states.length} channel completions into one (native fires per channel)`,
+      );
     const tasks = states.map(async ([channel, state]) => {
       const sessionId = ++state.sessionId;
+      state.templateSessionId += 1;
+      // Native HideCutinMask style 0: DOScale from the current scale to tsTo
+      // over tsduration (tsFrom is not reused); other styles only fade the
+      // mask image, which the rectangular Graphics mask cannot express.
+      const from = { ...state.ratio };
+      const to = input.templateSizeTo;
       const run = this.tween(
-        duration,
+        input.templateSizeDurationMs,
         (progress) => {
           if (state.sessionId !== sessionId) return;
-          const x = lerp(
-            input.templateSizeFrom.x,
-            input.templateSizeTo.x,
-            progress,
+          state.ratio = {
+            x: lerp(from.x, to.x, progress),
+            y: lerp(from.y, to.y, progress),
+          };
+          this.drawMask(
+            state.mask,
+            state.size.x * state.ratio.x,
+            state.size.y * state.ratio.y,
           );
-          const y = lerp(
-            input.templateSizeFrom.y,
-            input.templateSizeTo.y,
-            progress,
-          );
-          this.drawMask(state.mask, state.size.x * x, state.size.y * y);
         },
         () => {
           state.root.destroy({ children: true });
@@ -215,6 +346,16 @@ export class InterludePanel {
       else void run;
     });
     if (input.block) await Promise.all(tasks);
+  }
+
+  private makeLabel(charName: string): Text {
+    const label = new Text({
+      style: new TextStyle({ fill: 0xff_ff_ff, fontSize: 24 }),
+      text: charName,
+    });
+    label.label = "interlude-char";
+    label.anchor.set(0.5);
+    return label;
   }
 
   private drawMask(mask: Graphics, width: number, height: number): void {

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1896,6 +1896,9 @@ export class StoryRuntime {
       case "interlude": {
         // Native port: Torappu.AVG.AVGCharacterCutinPanel._ExecuteInterlude and
         // _GenCutinParamWithCommand. Validation uses default 0, while CutinParam
+        // [uses -1]. 2.7.61 adds `icharpos`/`icharscale`: non-empty vectors go
+        // through _EnsureDialogExtra into CutinParam.extra.dialog.charPos/
+        // charScale (consumed by the new CutinTemplateDialogView template).
         const checkedChannel = Math.trunc(
           toNumber(this.exactArg(args, "channel"), 0),
         );
@@ -1941,6 +1944,8 @@ export class StoryRuntime {
           channel,
           charName: toString(this.exactArg(args, "char")),
           clear: toBoolean(this.exactArg(args, "clear"), false),
+          dialogCharPos: parseVector2(this.exactArg(args, "icharpos")),
+          dialogCharScale: parseVector2(this.exactArg(args, "icharscale")),
           direction: toString(this.exactArg(args, "direction")),
           durationMs: duration("duration"),
           maskId: toString(this.exactArg(args, "maskid")),
@@ -1954,6 +1959,10 @@ export class StoryRuntime {
           size: parseVector2(this.exactArg(args, "size")) ?? { x: 0, y: 0 },
           slot: toString(this.exactArg(args, "slot")),
           style: Math.trunc(toNumber(this.exactArg(args, "style"), 0)),
+          // Native `switch` only feeds the template deco TwoStateToggle; a
+          // command without the key must not change any visibility, so the
+          // panel also needs to know whether the key was present at all.
+          switchSet: this.exactArg(args, "switch") !== undefined,
           switchOn: toBoolean(this.exactArg(args, "switch"), false),
           templateSizeDurationMs: duration("tsduration"),
           templateSizeFrom: parseVector2(this.exactArg(args, "tsfrom")) ?? {

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -475,6 +475,16 @@ export interface InterludeInput {
   channel: number;
   charName: string;
   clear: boolean;
+  /**
+   * 2.7.61 `icharpos`/`icharscale`: written to CutinParam.extra.dialog.charPos/
+   * charScale by `AVGCharacterCutinPanel._GenCutinParamWithCommand` (via
+   * `_EnsureDialogExtra`) and consumed by the new `CutinTemplateDialogView`
+   * template. The Web panel has no dialog template yet, so these are parsed
+   * and forwarded only (forward-looking alignment; 2.7.61 story corpus has
+   * zero usages so far).
+   */
+  dialogCharPos?: { x: number; y: number };
+  dialogCharScale?: { x: number; y: number };
   direction: string;
   durationMs: number;
   maskId: string;
@@ -488,6 +498,13 @@ export interface InterludeInput {
   size: { x: number; y: number };
   slot: string;
   style: number;
+  /**
+   * Whether the `switch` key was present on the command. Native `switch` only
+   * feeds the mask-template deco `TwoStateToggle`
+   * (`CutinTemplateDecoView.Render`); commands without the key must not touch
+   * visibility at all.
+   */
+  switchSet: boolean;
   switchOn: boolean;
   templateSizeDurationMs: number;
   templateSizeFrom: { x: number; y: number };

--- a/tests/interlude.spec.ts
+++ b/tests/interlude.spec.ts
@@ -24,6 +24,7 @@ function input(overrides: Partial<InterludeInput> = {}): InterludeInput {
     slot: "",
     style: 0,
     switchOn: true,
+    switchSet: true,
     templateSizeDurationMs: 0,
     templateSizeFrom: { x: 1, y: 1 },
     templateSizeTo: { x: 1, y: 1 },
@@ -39,6 +40,14 @@ async function tweenImmediately(
 ): Promise<void> {
   update(1);
   complete?.();
+}
+
+/** Tween stub that only advances half-way and never completes. */
+async function tweenHalfway(
+  _duration: number,
+  update: (progress: number) => void,
+): Promise<void> {
+  update(0.5);
 }
 
 describe("InterludePanel", () => {
@@ -67,9 +76,301 @@ describe("InterludePanel", () => {
     await panel.run(input({ slot: "m", switchOn: false, type: 2 }));
     const state = (panel as any).channels.get(3);
     expect(state.elements.get("m").visible).toBe(false);
+    // switch toggles the content layers only; the mask root stays visible.
+    expect(state.root.visible).toBe(true);
 
     await panel.run(input({ clear: true }));
     expect(layer.children).toHaveLength(0);
+  });
+
+  it("keeps everything visible when the switch key is absent (native: only the deco toggle consumes switch)", async () => {
+    const layer = new Container();
+    const panel = new InterludePanel(
+      layer,
+      async () => Texture.EMPTY,
+      tweenImmediately,
+    );
+
+    // Channel creation and element update without any switch key — these are
+    // the corpus shapes of e.g. obt/main/level_main_13-05_beg.txt.
+    await panel.run(input({ type: 0, switchSet: false, switchOn: false }));
+    await panel.run(
+      input({
+        name: "bg_test",
+        slot: "m",
+        type: 2,
+        switchSet: false,
+        switchOn: false,
+      }),
+    );
+    const state = (panel as any).channels.get(3);
+    expect(state.root.visible).toBe(true);
+    expect(state.elements.get("m").visible).toBe(true);
+
+    // A later command without the key must not change visibility either.
+    await panel.run(
+      input({ slot: "m", type: 2, switchSet: false, switchOn: false }),
+    );
+    expect(state.elements.get("m").visible).toBe(true);
+  });
+
+  it("runs alpha/pos/scale tweens in parallel with their own durations", async () => {
+    const layer = new Container();
+    const durations: number[] = [];
+    const tween = vi.fn(
+      async (
+        duration: number,
+        update: (progress: number) => void,
+        complete?: () => void,
+      ) => {
+        durations.push(duration);
+        update(1);
+        complete?.();
+      },
+    );
+    const panel = new InterludePanel(layer, async () => Texture.EMPTY, tween);
+
+    await panel.run(
+      input({
+        alphaDurationMs: 300,
+        durationMs: 1000,
+        name: "bg_test",
+        positionFrom: { x: 0, y: 0 },
+        positionTo: { x: 10, y: 0 },
+        scaleDurationMs: 500,
+        scaleFrom: { x: 1, y: 1 },
+        scaleTo: { x: 2, y: 2 },
+        slot: "m",
+        type: 2,
+      }),
+    );
+    // Element tweens keep their own durations (pos 1000 / scale 500 / alpha
+    // 300) and the new channel additionally waits the 1s show floor.
+    expect(durations).toEqual([1000, 500, 300, 1000]);
+
+    const state = (panel as any).channels.get(3);
+    const element = state.elements.get("m");
+    expect(element.alpha).toBe(1);
+    expect(element.position.x).toBe(10);
+    expect(element.scale.x).toBe(2);
+  });
+
+  it("gates the blocking show wait on the native style floors (1s, fade/both 3s, animator 0)", async () => {
+    for (const [style, expected] of [
+      [0, 1000],
+      [1, 3000],
+      [2, 3000],
+      [3, 0],
+    ] as const) {
+      const layer = new Container();
+      const durations: number[] = [];
+      const panel = new InterludePanel(
+        layer,
+        async () => Texture.EMPTY,
+        async (duration, update, complete) => {
+          durations.push(duration);
+          update(1);
+          complete?.();
+        },
+      );
+      await panel.run(input({ style, type: 0 }));
+      expect(durations).toEqual([expected]);
+    }
+  });
+
+  it("applies size/offset only when the channel is created, not on updates", async () => {
+    const layer = new Container();
+    const panel = new InterludePanel(
+      layer,
+      async () => Texture.EMPTY,
+      tweenImmediately,
+    );
+
+    await panel.run(
+      input({
+        type: 0,
+        offset: { x: 10, y: 20 },
+        size: { x: 300, y: 400 },
+        switchSet: false,
+      }),
+    );
+    const state = (panel as any).channels.get(3);
+    expect(state.root.position.x).toBe(640 + 10);
+    expect(state.root.position.y).toBe(360 - 20);
+
+    await panel.run(
+      input({
+        name: "bg_test",
+        offset: { x: 999, y: 999 },
+        size: { x: 5, y: 5 },
+        slot: "m",
+        switchSet: false,
+        type: 2,
+      }),
+    );
+    expect(state.root.position.x).toBe(640 + 10);
+    expect(state.root.position.y).toBe(360 - 20);
+    expect(state.size).toEqual({ x: 300, y: 400 });
+  });
+
+  it("starts the ts scale entry once at channel creation, never on updates", async () => {
+    const layer = new Container();
+    const durations: number[] = [];
+    const panel = new InterludePanel(
+      layer,
+      async () => Texture.EMPTY,
+      async (duration, update, complete) => {
+        durations.push(duration);
+        update(1);
+        complete?.();
+      },
+    );
+
+    await panel.run(
+      input({
+        style: 0,
+        templateSizeDurationMs: 500,
+        templateSizeFrom: { x: 0, y: 1 },
+        templateSizeTo: { x: 1, y: 1 },
+        type: 0,
+      }),
+    );
+    // ts entry (500) + show floor (1000).
+    expect(durations).toEqual([500, 1000]);
+
+    await panel.run(
+      input({
+        name: "bg_test",
+        slot: "m",
+        style: 0,
+        templateSizeDurationMs: 500,
+        templateSizeFrom: { x: 0, y: 1 },
+        templateSizeTo: { x: 1, y: 1 },
+        type: 2,
+      }),
+    );
+    // Update command: only the element alpha tween (aDuration 0), no new ts
+    // tween and no second show wait.
+    expect(durations).toEqual([500, 1000, 0]);
+  });
+
+  it("clears by scaling from the current template ratio to tsto (tsfrom not reused)", async () => {
+    const layer = new Container();
+    const panel = new InterludePanel(
+      layer,
+      async () => Texture.EMPTY,
+      tweenHalfway,
+    );
+
+    await panel.run(
+      input({
+        block: false,
+        style: 0,
+        templateSizeDurationMs: 500,
+        templateSizeFrom: { x: 0.2, y: 1 },
+        templateSizeTo: { x: 1, y: 1 },
+        type: 0,
+      }),
+    );
+    const state = (panel as any).channels.get(3);
+    // Half-way through the ts entry the ratio is 0.2 -> 1.0 at 50%.
+    expect(state.ratio.x).toBeCloseTo(0.6);
+    expect(state.ratio.y).toBe(1);
+
+    await panel.run(
+      input({
+        block: false,
+        clear: true,
+        templateSizeDurationMs: 400,
+        templateSizeFrom: { x: 9, y: 9 },
+        templateSizeTo: { x: 0, y: 1 },
+      }),
+    );
+    // Clear interpolates from the current ratio (0.6), not tsfrom (9).
+    expect(state.ratio.x).toBeCloseTo(0.3);
+    expect(state.ratio.y).toBe(1);
+  });
+
+  it("warns when a char/uichar element command has no slot but keeps the fallback", async () => {
+    const layer = new Container();
+    const warnings: string[] = [];
+    const panel = new InterludePanel(
+      layer,
+      async () => Texture.EMPTY,
+      tweenImmediately,
+      (detail) => warnings.push(detail),
+    );
+
+    await panel.run(
+      input({ name: "cutin_char_1", slot: "", type: 1, switchSet: false }),
+    );
+    expect(
+      warnings.some((detail) => detail.includes('falling back to "m"')),
+    ).toBe(true);
+    const state = (panel as any).channels.get(3);
+    expect(state.elements.get("m")).toBeTruthy();
+
+    // bg elements never use a slot natively, so no warning for type 2.
+    warnings.length = 0;
+    await panel.run(
+      input({ name: "bg_test", slot: "", type: 2, switchSet: false }),
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  it("warns when a blocking clear-all aggregates several channels", async () => {
+    const layer = new Container();
+    const warnings: string[] = [];
+    const panel = new InterludePanel(
+      layer,
+      async () => Texture.EMPTY,
+      tweenImmediately,
+      (detail) => warnings.push(detail),
+    );
+    await panel.run(input({ channel: 3 }));
+    await panel.run(input({ channel: 4 }));
+
+    await panel.run(input({ channel: -1, clear: true }));
+    expect(layer.children).toHaveLength(0);
+    expect(warnings.some((detail) => detail.includes("aggregates 2"))).toBe(
+      true,
+    );
+  });
+
+  it("refreshes the deco label in place and toggles it with switch", async () => {
+    const layer = new Container();
+    const panel = new InterludePanel(
+      layer,
+      async () => Texture.EMPTY,
+      tweenImmediately,
+    );
+
+    await panel.run(input({ charName: "Amiya", type: 0, switchSet: false }));
+    const state = (panel as any).channels.get(3);
+    expect(state.label.text).toBe("Amiya");
+
+    await panel.run(
+      input({
+        charName: "Kal'tsit",
+        name: "bg_test",
+        slot: "m",
+        switchSet: false,
+        type: 2,
+      }),
+    );
+    expect(state.label.text).toBe("Kal'tsit");
+
+    // An empty char name keeps the deco alive with empty text (native deco
+    // Render just assigns the text every update).
+    await panel.run(
+      input({ charName: "", slot: "m", switchSet: false, type: 2 }),
+    );
+    expect(state.label.text).toBe("");
+    expect(state.label).toBeTruthy();
+
+    await panel.run(input({ slot: "m", switchOn: false, type: 2 }));
+    expect(state.label.visible).toBe(false);
+    expect(state.root.visible).toBe(true);
   });
 
   it("clears every channel when channel is negative", async () => {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1331,9 +1331,10 @@ describe("StoryRuntime", () => {
     const warnings: RuntimeWarning[] = [];
     const runtime = new StoryRuntime(
       createContext([
-        '[interlude(channel=3,type=2,slot="m",name="bg_test",maskid="square",size="290,320",offset="10,-20",pfrom="1,2",pto="3,4",duration=2,sfrom="1,1",sto="2,2",sduration=1,afrom=0.2,ato=0.8,aduration=0.5,switch=true,block=true)]',
+        '[interlude(channel=3,type=2,slot="m",name="bg_test",maskid="square",size="290,320",offset="10,-20",pfrom="1,2",pto="3,4",duration=2,sfrom="1,1",sto="2,2",sduration=1,afrom=0.2,ato=0.8,aduration=0.5,switch=true,block=true,icharpos="1,2",icharscale="3,4")]',
         "[interlude(clear=true)]",
         "[interlude(channel=-1,clear=true)]",
+        '[interlude(channel=3,type=1,name="cutin_char_1")]',
         '[name="A"]ok',
       ]),
       renderer,
@@ -1343,13 +1344,15 @@ describe("StoryRuntime", () => {
 
     await runtime.start();
 
-    expect(renderer.interludeCalls).toHaveLength(2);
+    expect(renderer.interludeCalls).toHaveLength(3);
     expect(renderer.interludeCalls[0]).toMatchObject({
       alphaDurationMs: 250,
       alphaFrom: 0.2,
       alphaTo: 0.8,
       block: true,
       channel: 3,
+      dialogCharPos: { x: 1, y: 2 },
+      dialogCharScale: { x: 3, y: 4 },
       durationMs: 1000,
       maskId: "square",
       offset: { x: 10, y: -20 },
@@ -1361,11 +1364,19 @@ describe("StoryRuntime", () => {
       size: { x: 290, y: 320 },
       slot: "m",
       switchOn: true,
+      switchSet: true,
       type: 2,
     });
     expect(renderer.interludeCalls[1]).toMatchObject({
       channel: -1,
       clear: true,
+    });
+    // A command without the switch key must not be treated as switch=false.
+    expect(renderer.interludeCalls[2]).toMatchObject({
+      channel: 3,
+      switchOn: false,
+      switchSet: false,
+      type: 1,
     });
     expect(warnings).toEqual([
       expect.objectContaining({


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `interlude` 命令移植中的行为差异(共 9 项:P1×2、P2×4、P3×3,另加注释文档化)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的逆向分析(IDA 反编译复核),关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 interlude 机制(2.7.61 逆向结论)

- `Torappu.AVG.AVGCharacterCutinPanel._ExecuteInterlude` @ `0x183e499e0` / `_GenCutinParamWithCommand` @ `0x183e49c70`:参数层 channel 双读(校验默认 0,CutinParam 默认 −1)、四个 `*duration` 全过 `AVGUtils.CalculateFadetime`(= animateRatio × value,无 clamp)、`afrom`/`ato` 默认 −1、posSet/scaleSet 双存在判定。**2.7.61 新增 `icharpos`/`icharscale`**:非空时经 `_EnsureDialogExtra` @ `0x183e49310` 写入 `CutinParam.extra.dialog.charPos/charScale`,由新模板类 `CutinTemplateDialogView` 的 `_RefreshDialogChar` 消费(2.7.51 及此前版本无此二键)。
- `switch` 在 2.7.61 代码里的**唯一消费者**是 mask 模板 deco 的 `TwoStateToggle.set_selected`(`CutinTemplateDecoView.Render` @ `0x1813a11e0`,视觉作用由 prefab 布线决定);mask 与元素代码完全不读 switch。
- `CutinTemplate.ShowCutinMask` @ `0x1813a5760`:`size`/`offset`/`style`/`tsfrom`/`tsto`/`charName`/`switch` 只在 channel begin 时消费;show 序列先 `AppendInterval(1.0)`(**最短 1 秒**);style Fade(1)/Both(2) 再 Join **3 秒硬编码** mask 淡入;style Scale(0) 的 tsFrom→tsTo DOScale 是独立 tween,**不阻塞完成**;ANIMATOR(3) 完成走模板动画。
- `CutinTemplate.UpdateCutinMask`(基类,实体在 xLua base proxy @ `0x1813a1dd0` 内联):仅刷新 deco(name 文本 + switch 重渲染),**不更新 size/offset,不触碰任何可见性**。
- `CutinChannel._ProcessElement` @ `0x18139ea70`:元素三段 tween 并行、各按各自时长——SetCutinElement alpha(aFrom<0→0、aTo<0→1,aDuration)/ pos(duration)/ scale(sDuration);sequence 完成 = 全部完成。channel 复用时先 `DOKill` 元素 tween(不杀模板 DOScale)。
- `CutinTemplate.HideCutinMask` @ `0x1813a53b0`(clear 退场):style0 = DOScale(**当前比例**→tsTo, tsDuration),tsFrom 不参与。
- `CutinController._ProcessChannelClean` @ `0x18139fc10`:clear-all 逐 channel 各调一次完成回调,无聚合(零 channel 时不回调)。

## 修复内容

### 1. `switch` 被映射成整根可见性(P1)

- **前端问题**:`InterludePanel.updateTemplate` 每条命令都设 `root.visible = switchOn` 与 `element.visible = switchOn`;缺省 false 时,不带 `switch` key 的更新命令会把整个 channel 连 mask 一起隐藏(语料中大量文件整段不使用 switch,如 `level_main_13-05_beg.txt`,此前完全不渲染)。
- **修复**:`switch` 只作用于内容层(元素 + charName 标签,即 deco TwoStateToggle 的 Web 对应物),mask 根节点常显;且仅当命令携带 `switch` key 时应用(runtime 新增 `switchSet` 传递 key 是否出现),不带 key 的命令不再改变任何可见性。

### 2. 元素三段 tween 被折叠成单条 max(duration)(P1)

- **前端问题**:alpha/pos/scale 共用一条 `max(durationMs, scaleDurationMs, alphaDurationMs)` 的统一进度 tween,短时长段被拉长(如 aduration=1、duration=5 时 alpha 要 5 秒才到位)。
- **修复**:按 native `_ProcessElement` 拆为三条独立 tween 各按各自时长并行,`Promise.all` 聚合;block 等待 = 全部完成。alpha tween 仅在 `name` 非空(SetCutinElement 路径)时启动,起值 `max(afrom, 0)`、终值 `ato>=0 ? ato : 1`。

### 3. `style` 模板入场时序未实现(P2)

- **前端问题**:style 解析后透传但从未消费,block 等待时长只由元素 tween 决定。
- **修复**:按 `ShowCutinMask` 实现 show 完成时序——show 序列 1 秒下限,Fade/Both(style 1/2)为 3 秒硬编码,ANIMATOR(style 3)未移植立即完成;channel 创建命令带 block 时按此等待(与元素 tween 并行取 max)。

### 4. update 命令重设 size/offset(P2)

- **前端问题**:每条命令都用 offset 重设 root 位置、size(>0 轴)重画 mask。
- **修复**:对齐 native——size/offset 仅在 channel 创建(ShowCutinMask)时应用;更新命令只刷新 deco(见修复 1)。tsfrom/tsto/tsduration 的模板缩放入场也随之移到创建时启动(语料中 ts 键恰好只出现在创建与 clear 命令上)。

### 5. `icharpos`/`icharscale` 未支持(P2,2.7.61 新增)

- **前端问题**:未解析。
- **修复**:runtime 解析并透传(`dialogCharPos`/`dialogCharScale`,双存在语义与 pfrom/sfrom 一致按解析成功判定)。Web 端暂无对话框模板(`CutinTemplateDialogView` 未移植),字段在面板层保留待消费;语料统计 2.7.61 使用量为 0,属前瞻对齐。

### 6. ts tween 无竞争取消(P2)

- **前端问题**:`updateTemplate` 的 ts tween 不检查 session,连发命令时多条 tween 并发改同一 mask。
- **修复**:ts tween 加独立 `templateSessionId` 守卫(clear/重建时递增取消)。特意与元素 session 分离:native 元素命令的 `DOKill` 只作用于元素 tween,不会取消模板 DOScale。

### 7. clear 退场起点(P3)

- **前端问题**:一律按 clear 命令自身 tsfrom→tsto lerp;tsfrom 缺省({0,0})时 mask 直接从零尺寸开始,看不出收缩退场。
- **修复**:对齐 `HideCutinMask` style0 路径——从**当前模板比例**(入场 tween 实时记录)插到 tsto,tsfrom 不再复用。

### 8. clear-all 的 block 聚合(P3)

- **前端行为**:`Promise.all` 聚合为一次完成、零 channel 立即完成(native 为逐 channel 回调、零 channel 悬挂)。**有意偏离保留**,多 channel 聚合时补 onWarning 便于与 native 对账。

### 9. slot 缺省静默落 "m"(P3)

- **前端问题**:type=1/3 命令缺 slot 时静默落到中间槽(native 为元素查找失败 LogError + 立即回调)。
- **修复**:type=1/3 且无 slot 时报 warning(type=2 走 bg 元素路径不受 slot 影响,不警告),保留 `"m"` fallback 不破坏现网行为。

### 其它(有意省略,文档化)

- P3 type=0+block 立即完成(native 普通模板下会悬挂)、整数 type 非 1/2/3 归 0、type=3 name 不可解析的行为近似:按 review 结论保留,已在代码注释标注。
- P3 maskid/direction/charName 视觉未移植:Web 适配有意省略,已写入 `InterludePanel` 头注释(stencil 通道、deco 布线、模板动画以矩形 Graphics mask + 文字标签近似)。

## 验证用剧情文件

生产剧情语料(本地 `torappu/storage/asset/gamedata/latest/story`):

- **修复 1(switch)**:`obt/main/level_main_13-05_beg.txt` 10-14 行 —— 整段 interlude 序列完全不带 `switch`(创建 10 行、bg 入场 11 行、立绘 13 行、位移 14 行);修复前整个 channel 默认隐藏不可见,修复后正常显示。对照 `obt/main/level_main_15-14_end.txt` 39 行起(`switch = true, type = 3` 序列)确认显式开关仍生效。
- **修复 2(三段 tween)**:`activities/act33side/level_act33side_01_end.txt` 280 行 —— `aduration=1` 与 `duration=5` 同现(alpha 1 秒、位移 5 秒),修复前 alpha 被拉长到 5 秒才到位,修复后 1 秒淡满、位移继续。
- **修复 3(show 时序)**:语料中创建命令均不带 `block`(0 命中)——前瞻对齐,由单测锁定:`tests/interlude.spec.ts` 的 "gates the blocking show wait on the native style floors (1s, fade/both 3s, animator 0)"。
- **修复 4(size/offset 仅创建)**:`obt/main/level_main_13-05_beg.txt` 13 行 —— update 命令携带 `offset = "20,50"`(native 忽略),修复前会移动整个 mask 根节点。
- **修复 5(icharpos/icharscale)**:语料 0 命中 —— 前瞻对齐,由单测锁定:`tests/runtime.spec.ts` 的 "maps interlude parameters and preserves the native channel default mismatch"。
- **修复 6(ts 守卫)/ 修复 7(clear 起点)**:`obt/main/level_main_16-01_beg.txt` 212-219 行 —— 212 行创建命令 `tsfrom="0,1", tsto="1,1", tsduration=0.5, style=0`(入场展开),219 行 `clear = true, tsto="0,1", tsduration=0.5` **无 tsfrom**:修复前 clear 从缺省 {0,0} 起 lerp(瞬间消失),修复后从当前全尺寸比例收缩到 0 再销毁。同型样本:`obt/main/level_main_15-10_beg.txt` 325 行。
- **修复 8(clear-all 聚合 warn)**:语料 clear-all+block 0 命中 —— 单测锁定:"warns when a blocking clear-all aggregates several channels"。
- **修复 9(slot warn)**:语料 type=1/3 无 slot 0 命中 —— 单测锁定:"warns when a char/uichar element command has no slot but keeps the fallback"。

## 测试

- `pnpm test`:20 个文件 **231** 用例全部通过(基线 222,新增 interlude 面板用例 9 个 + runtime 参数映射断言扩充)。
- `pnpm exec vue-tsc -b` 通过。
- `pnpm exec eslint`(全部改动文件)通过。
- `STORY_CORPUS_ROOT=... pnpm test:story-log` 全语料 Log All 回归通过(interlude 不涉及文本可见性/分支语义,`engine/log/` 与 `tests/helpers/storyOracle.ts` 均无该命令,无需同步)。
