### PR TITLE
fix(story-player): focusout/focusparam 对齐 native 延迟绑定与 ghost 混合模型

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -306,6 +306,9 @@ export class PixiStoryRenderer implements StoryRenderer {
       (key) => this.textureForImageKey(key, "image"),
       (duration, update, complete) => this.tween(duration, update, complete),
       onWarning,
+      // `SetWhenBind` replay hook: re-resolve focus targets whenever the
+      // cgitem target set changes (see FocusEffectPanel.refresh).
+      () => this.focusEffectPanel.refresh(),
     );
   }
 
@@ -2169,14 +2172,24 @@ export class PixiStoryRenderer implements StoryRenderer {
       case "lbg": {
         return this.largeBackgroundRoot ? [this.largeBackgroundRoot] : [];
       }
+      // Native provenance: `_GenCfgByType` writes the raw `id` into the
+      // single `_channel` field for `type="cgitem"`; an empty id leaves
+      // `IsChannelEmpty` true, so `_ExecuteFocusout` is a silent no-op --
+      // it must not fall back to "all items".
       case "cgitem": {
+        if (!id) return [];
         return this.cgItemPanel.targets(id);
       }
+      // Native provenance: `customchar` resolves channels from the custom
+      // character-slot registry (`m_customInUse`) via
+      // `AVGCharacterslotPanel.TryCollectCustomSlotEffectChannels` /
+      // `TryCollectAllCustomSlotEffectChannels` -- a channel set disjoint
+      // from the standard left/middle/right slots. This port has no custom
+      // slot system, so the branch stays a no-op instead of misrouting to
+      // standard slots (which would also double-apply when a `char`
+      // channel is active, since native channel sets never overlap).
       case "customchar": {
-        if (!id)
-          return [...this.characterSlots.values()].map((state) => state.root);
-        const state = this.characterSlots.get(this.normalizeCharacterSlot(id));
-        return state ? [state.root] : [];
+        return [];
       }
       default: {
         return [];

--- a/src/widgets/StoryPlayer/engine/rendering/panels/CgItemPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/CgItemPanel.ts
@@ -71,6 +71,7 @@ export class CgItemPanel {
     private readonly loadTexture: TextureLoader,
     private readonly tween: Tween,
     private readonly onWarning?: (detail: string) => void,
+    private readonly onTargetsChanged?: () => void,
   ) {}
 
   async show(input: CgItemInput): Promise<void> {
@@ -90,6 +91,11 @@ export class CgItemPanel {
     this.layer.addChild(root);
     const state = { root, sessionId: 1, sprite };
     this.states.set(input.key, state);
+    // Native provenance: `AVGSceneFocusOut.TryRegister` (a PostDisplayItem
+    // processor) replays a channel's stored amount the moment a cgitem
+    // (re)registers, so items shown after `focusout` already ran -- and
+    // re-shown items -- pick up the blur immediately.
+    this.onTargetsChanged?.();
     const sessionId = state.sessionId;
 
     if (input.width > 0 && input.height > 0)
@@ -212,7 +218,10 @@ export class CgItemPanel {
           state.root.alpha = lerp(startAlpha, 0, easeProgress(raw, ease));
         },
         () => {
-          if (state.sessionId === sessionId) this.dispose(key);
+          if (state.sessionId === sessionId) {
+            this.dispose(key);
+            this.onTargetsChanged?.();
+          }
         },
       );
       if (block) await task;
@@ -229,7 +238,10 @@ export class CgItemPanel {
         (raw) => {
           state.root.alpha = lerp(startAlpha, 0, easeProgress(raw, ease));
         },
-        () => state.root.destroy({ children: true }),
+        () => {
+          state.root.destroy({ children: true });
+          this.onTargetsChanged?.();
+        },
       );
     }
     // `_ExecuteHideCgItem` completes clear-all immediately even if `block=true`.
@@ -245,6 +257,7 @@ export class CgItemPanel {
     for (const state of this.states.values())
       state.root.destroy({ children: true });
     this.states.clear();
+    this.onTargetsChanged?.();
   }
 
   destroy(): void {

--- a/src/widgets/StoryPlayer/engine/rendering/panels/FocusEffectPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/FocusEffectPanel.ts
@@ -1,4 +1,9 @@
-import { BlurFilter, ColorMatrixFilter, type Container } from "pixi.js";
+import {
+  BlurFilter,
+  ColorMatrixFilter,
+  type ColorMatrix,
+  type Container,
+} from "pixi.js";
 
 import type { FocusOutInput, FocusParamInput } from "../../types";
 
@@ -16,11 +21,47 @@ interface FocusState {
   type: string;
 }
 
+// Full-strength inverse (out = 1 - c per channel). Written by hand instead of
+// pixi's `negative()`, whose matrix adds source alpha into each channel (a
+// pixi quirk); native `mat_grayscale`/`_Inverse` inverts per channel.
+const INVERSE_MATRIX: ColorMatrix = [
+  -1,
+  0,
+  0,
+  0,
+  1, //
+  0,
+  -1,
+  0,
+  0,
+  1, //
+  0,
+  0,
+  -1,
+  0,
+  1, //
+  0,
+  0,
+  0,
+  1,
+  0,
+];
+
 /**
  * Port scope: `Torappu.AVG.AVGCameraEffect._ExecuteFocusout` and
  * `_ExecuteFocusParam` channel state. Applying `BlurFilter` and
  * `ColorMatrixFilter` per PIXI container is a Web adaptation of the native
  * `AVGSceneEffectManager` post-processing pipeline.
+ *
+ * Native composites each registered item as "clean image x fully-processed
+ * image" mixed by the channel amount (`AVGSceneFocusOut.Render` +
+ * `mat_blit_ghost`; grayscale/inverse strength is a material constant and
+ * amount only drives the blend -- amount=0.5 is a half mix, not a
+ * half-strength effect). The color filters below reproduce that model
+ * exactly: a full-strength `ColorMatrixFilter` matrix mixed with the clean
+ * pixel through the filter's `alpha` uniform (GL/WGSL both `mix(orig,
+ * processed, uAlpha)`). Blur keeps a strength-graded surrogate for the blend
+ * because stock PIXI filters cannot composite two copies of live content.
  */
 export class FocusEffectPanel {
   private readonly states = new Map<string, FocusState>();
@@ -58,7 +99,11 @@ export class FocusEffectPanel {
       input.durationMs,
       (progress) => {
         if (state.sessionId !== sessionId) return;
-        state.amount = from + (input.to - from) * progress;
+        // Native provenance: `AVGSceneEffectManager._SetEffectAmount` tweens
+        // each channel with `TweenUtils.SmoothStep` (slow at both ends), not
+        // linear time.
+        const eased = progress * progress * (3 - 2 * progress);
+        state.amount = from + (input.to - from) * eased;
         this.render();
       },
       () => {
@@ -77,6 +122,19 @@ export class FocusEffectPanel {
     this.states.clear();
     for (const target of this.filteredTargets) target.filters = [];
     this.filteredTargets.clear();
+  }
+
+  /**
+   * Native provenance: `AVGSceneFocusOut.TryRegister` + `SetWhenBind.Bind`
+   * replay a channel's stored amount the moment a PostDisplay item
+   * (re)registers -- a cgitem displayed after `focusout` already ran picks
+   * up the existing amount immediately. The Web adaptation re-resolves
+   * targets whenever the per-object target set (cgitem panel) changes;
+   * layer-backed types (bg/char/cg/lbg) get this for free because the
+   * filter sits on the layer itself.
+   */
+  refresh(): void {
+    this.render();
   }
 
   private render(): void {
@@ -98,8 +156,11 @@ export class FocusEffectPanel {
         filters.push(new BlurFilter({ strength: amount * 8 }));
       if (amount > 0 && this.config.color !== "None") {
         const color = new ColorMatrixFilter();
-        if (this.config.color === "Grayscale") color.grayscale(amount, false);
-        else color.negative(false);
+        if (this.config.color === "Grayscale") color.grayscale(1, false);
+        else color.matrix = INVERSE_MATRIX;
+        // Ghost blend: amount mixes the clean pixel with the full-strength
+        // processed pixel (see the port-scope note above).
+        color.alpha = amount;
         filters.push(color);
       }
       target.filters = filters;

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -2211,7 +2211,13 @@ export class StoryRuntime {
       }
 
       case "focusout": {
-        // Native port: Torappu.AVG.AVGCameraEffect._ExecuteFocusout. Its duration
+        // Native port: Torappu.AVG.AVGCameraEffect._ExecuteFocusout. Its
+        // duration is passed through unscaled -- the executor's refs contain
+        // neither get_animateRatio nor CalculateFadetime, so focusout belongs
+        // to the "bypass" family and fast-forward tiers do not shorten its
+        // tween or block wait (unlike calculateFadeMs-based commands). A
+        // `from >= 0` does a zero-duration UpdateEffect before the real
+        // tween, and `block` only gates the command when duration > 0.
         const durationMs = Math.max(
           0,
           toNumber(this.exactArg(args, "duration"), 0) * 1000,
@@ -2230,7 +2236,11 @@ export class StoryRuntime {
       }
 
       case "focusparam": {
-        // Native port: Torappu.AVG.AVGCameraEffect._ExecuteFocusParam. This is a
+        // Native port: Torappu.AVG.AVGCameraEffect._ExecuteFocusParam. This
+        // is a config-only write: it sets useBlur / color on the shared
+        // AVGSceneFocusOut Config and marks the command buffer dirty
+        // (MarkEffectImplConfigDirty). It never touches channel amounts and
+        // never blocks -- the executor always returns false.
         const effect = toString(this.exactArg(args, "effect"));
         this.renderer.setFocusParam({
           blur: toBoolean(this.exactArg(args, "blur"), true),

--- a/tests/cgItemPanel.spec.ts
+++ b/tests/cgItemPanel.spec.ts
@@ -82,4 +82,34 @@ describe("CgItemPanel", () => {
     expect(panel.targets("")).toEqual([]);
     expect(layer.children).toHaveLength(0);
   });
+
+  it("notifies listeners whenever the focus target set changes", async () => {
+    const layer = new Container();
+    let notifications = 0;
+    const panel = new CgItemPanel(
+      layer,
+      async () => Texture.WHITE,
+      tweenImmediately,
+      undefined,
+      () => {
+        notifications += 1;
+      },
+    );
+
+    // `AVGSceneFocusOut.TryRegister` replays a stored amount whenever a
+    // cgitem (re)registers, and deregistration must drop stale filters:
+    // every change of the target set fires the hook.
+    await panel.show(input("a"));
+    expect(notifications).toBe(1);
+    await panel.show(input("a"));
+    expect(notifications).toBe(2);
+
+    await panel.hide("a", 0, "Linear", true);
+    expect(notifications).toBe(3);
+
+    await panel.show(input("b"));
+    expect(notifications).toBe(4);
+    panel.clear();
+    expect(notifications).toBe(5);
+  });
 });

--- a/tests/focusEffectPanel.spec.ts
+++ b/tests/focusEffectPanel.spec.ts
@@ -1,0 +1,159 @@
+import { BlurFilter, ColorMatrixFilter, Container } from "pixi.js";
+import { describe, expect, it } from "vitest";
+
+import { FocusEffectPanel } from "../src/widgets/StoryPlayer/engine/rendering/panels/FocusEffectPanel";
+
+import type { FocusOutInput } from "../src/widgets/StoryPlayer/engine/types";
+
+function input(overrides: Partial<FocusOutInput> = {}): FocusOutInput {
+  return {
+    block: false,
+    durationMs: 0,
+    id: "",
+    to: 0,
+    type: "bg",
+    ...overrides,
+  };
+}
+
+function fullInverseMatrix(): number[] {
+  return [
+    -1,
+    0,
+    0,
+    0,
+    1, //
+    0,
+    -1,
+    0,
+    0,
+    1, //
+    0,
+    0,
+    -1,
+    0,
+    1, //
+    0,
+    0,
+    0,
+    1,
+    0,
+  ];
+}
+
+describe("FocusEffectPanel", () => {
+  it("tweens the amount with SmoothStep easing, not linear time", () => {
+    const target = new Container();
+    let step: ((progress: number) => void) | undefined;
+    const panel = new FocusEffectPanel(
+      () => [target],
+      async (_duration, update) => {
+        step = update;
+      },
+    );
+    panel.setParam({ blur: false, color: "Colorinverse" });
+
+    void panel.setFocus(
+      input({ durationMs: 1000, id: "x", to: 1, type: "cgitem" }),
+    );
+
+    // `_SetEffectAmount` uses TweenUtils.SmoothStep: at raw 0.25 the eased
+    // value is 0.25^2 * (3 - 2*0.25) = 0.15625, not 0.25.
+    step?.(0.25);
+    const color = target.filters[0] as ColorMatrixFilter;
+    expect(color.alpha).toBeCloseTo(0.156_25, 10);
+
+    step?.(0.5);
+    expect((target.filters[0] as ColorMatrixFilter).alpha).toBe(0.5);
+  });
+
+  it("mixes a full-strength inverse by amount instead of always inverting", () => {
+    const target = new Container();
+    const panel = new FocusEffectPanel(
+      () => [target],
+      async (_duration, update, complete) => {
+        update(1);
+        complete?.();
+      },
+    );
+
+    panel.setParam({ blur: false, color: "Colorinverse" });
+    void panel.setFocus(
+      input({ durationMs: 0, id: "x", to: 0.5, type: "cgitem" }),
+    );
+
+    // Native composites "clean x fully-processed" by the amount: at 0.5 the
+    // inverse is half mixed, the matrix itself stays full strength.
+    const color = target.filters[0] as ColorMatrixFilter;
+    expect([...color.matrix]).toEqual(fullInverseMatrix());
+    expect(color.alpha).toBe(0.5);
+  });
+
+  it("keeps grayscale full strength and blends it by amount", () => {
+    const target = new Container();
+    const panel = new FocusEffectPanel(
+      () => [target],
+      async (_duration, update, complete) => {
+        update(1);
+        complete?.();
+      },
+    );
+
+    panel.setParam({ blur: false, color: "Grayscale" });
+    void panel.setFocus(
+      input({ durationMs: 0, id: "x", to: 0.25, type: "cgitem" }),
+    );
+
+    const reference = new ColorMatrixFilter();
+    reference.grayscale(1, false);
+    const color = target.filters[0] as ColorMatrixFilter;
+    expect([...color.matrix]).toEqual([...reference.matrix]);
+    expect(color.alpha).toBe(0.25);
+  });
+
+  it("drops filters when the amount reaches zero", () => {
+    const target = new Container();
+    const panel = new FocusEffectPanel(
+      () => [target],
+      async (_duration, update, complete) => {
+        update(1);
+        complete?.();
+      },
+    );
+
+    void panel.setFocus(
+      input({ durationMs: 0, id: "x", to: 1, type: "cgitem" }),
+    );
+    expect(target.filters).toHaveLength(1);
+
+    void panel.setFocus(
+      input({ durationMs: 0, id: "x", to: 0, type: "cgitem" }),
+    );
+    expect(target.filters).toHaveLength(0);
+  });
+
+  it("replays a stored amount when refresh re-resolves targets", () => {
+    const target = new Container();
+    let visible = false;
+    const panel = new FocusEffectPanel(
+      (type, id) =>
+        type === "cgitem" && id === "a" && visible ? [target] : [],
+      async (_duration, update, complete) => {
+        update(1);
+        complete?.();
+      },
+    );
+
+    // `focusout` runs before the cgitem exists: the amount is stored, the
+    // channel resolves to nothing (SetWhenBind semantics).
+    void panel.setFocus(
+      input({ durationMs: 0, id: "a", to: 1, type: "cgitem" }),
+    );
+    expect(target.filters ?? []).toHaveLength(0);
+
+    // The cgitem registers afterwards and the stored amount replays.
+    visible = true;
+    panel.refresh();
+    expect(target.filters[0]).toBeInstanceOf(BlurFilter);
+  });
+});

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -4,7 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import { PixiStoryRenderer } from "../src/widgets/StoryPlayer/engine/renderer";
 
 import type { Context } from "../src/widgets/StoryPlayer/context";
-import type { GridBackgroundInput } from "../src/widgets/StoryPlayer/engine/types";
+import type {
+  CgItemInput,
+  GridBackgroundInput,
+} from "../src/widgets/StoryPlayer/engine/types";
 
 function createContext(): Context {
   return {
@@ -26,6 +29,28 @@ function createGridBackgroundInput(): GridBackgroundInput {
     y: 320,
   };
 }
+
+const cgItemInput: CgItemInput = {
+  alphaDelayMs: 0,
+  alphaDurationMs: 0,
+  alphaFrom: 1,
+  alphaTo: 1,
+  assetKey: "a",
+  block: false,
+  ease: "Linear",
+  height: 0,
+  key: "a",
+  positionDelayMs: 0,
+  positionDurationMs: 0,
+  rotationDurationMs: 0,
+  rotationFrom: -1,
+  rotationTo: 0,
+  scaleDelayMs: 0,
+  scaleDurationMs: 0,
+  scaleFrom: 1,
+  scaleTo: 1,
+  width: 0,
+};
 
 function createCharacterRenderer(): any {
   const context: Context = {
@@ -602,5 +627,98 @@ describe("PixiStoryRenderer", () => {
 
     expect(root.position.x - 640).toBe(-160);
     expect(360 - root.position.y).toBe(0);
+  });
+
+  it("resolves focusout channels per native routing rules", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        update: (p: number) => void,
+        complete?: () => void,
+      ) => {
+        update(1);
+        complete?.();
+      },
+    );
+
+    await renderer.showCgItem({ ...cgItemInput, key: "a" });
+
+    // `_GenCfgByType` writes the raw id into `_channel`; an empty id keeps
+    // `IsChannelEmpty` true, so the native executor is a silent no-op.
+    expect(renderer.resolveFocusTargets("cgitem", "")).toEqual([]);
+    expect(renderer.resolveFocusTargets("cgitem", "a")).toHaveLength(1);
+
+    // `customchar` only ever collects custom slots (`m_customInUse`), a
+    // channel set disjoint from the standard l/m/r slots; without a custom
+    // slot system the branch must not fall back to standard slots.
+    expect(renderer.resolveFocusTargets("customchar", "")).toEqual([]);
+    expect(renderer.resolveFocusTargets("customchar", "m")).toEqual([]);
+  });
+
+  it("applies focusout to cgitems displayed after the command", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        update: (p: number) => void,
+        complete?: () => void,
+      ) => {
+        update(1);
+        complete?.();
+      },
+    );
+
+    // `SetWhenBind` stores the amount before the display object exists and
+    // replays it on registration.
+    await renderer.setFocusOut({
+      block: false,
+      durationMs: 0,
+      id: "a",
+      to: 1,
+      type: "cgitem",
+    });
+    await renderer.showCgItem({ ...cgItemInput, key: "a" });
+    expect(
+      (renderer.cgItemPanel.targets("a")[0].filters ?? []).length,
+    ).toBeGreaterThan(0);
+
+    // Re-registration after a hide replays too.
+    await renderer.clearCgItems("a", 0);
+    await renderer.showCgItem({ ...cgItemInput, key: "a" });
+    expect(
+      (renderer.cgItemPanel.targets("a")[0].filters ?? []).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("treats focusout with an empty cgitem id as a native no-op", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        update: (p: number) => void,
+        complete?: () => void,
+      ) => {
+        update(1);
+        complete?.();
+      },
+    );
+
+    await renderer.showCgItem({ ...cgItemInput, key: "a" });
+    await renderer.setFocusOut({
+      block: false,
+      durationMs: 0,
+      id: "",
+      to: 1,
+      type: "cgitem",
+    });
+
+    expect(renderer.cgItemPanel.targets("a")[0].filters ?? []).toHaveLength(0);
   });
 });


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `focusout` / `focusparam` 命令移植中的可修复行为差异(两条命令共享同一套 FocusEffect 渲染模型,合并提交,共 8 项)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的 IDA 反编译复核,关键结论在下文直接给出,不依赖外部文档。

## 背景:native 的 focus 机制(2.7.61 IDA 反编译复核)

- **executor**:`Torappu.AVG.AVGCameraEffect._ExecuteFocusout`(VA `0x183e33290`)读 `duration/type/id/from/to/block`;`_GenCfgByType`(VA `0x183e33620`)按 type 路由 channel:`cgitem` 写单值 `_channel = id`(**空 id → `IsChannelEmpty` → 静默无操作**);`char/bg/cg/lbg` 查静态 `_channels` 列表(cctor VA `0x183e33f40`,cg 是 `[image]` 层、lbg 是 `[largebg]` 的 4 张图);`customchar` 动态收集**自定义立绘槽**(`AVGCharacterslotPanel::TryCollectCustomSlotEffectChannels` @ `0x183e4bd20`,只认 `m_customInUse` 里在用的槽,id 需 `ToLowerInvariant` 后命中,与标准 l/m/r 槽是**互不相交**的 channel 集合)。executor 的 refs 表不含 `get_animateRatio`/`CalculateFadetime` —— duration 原样透传,快进不缩短时长与阻塞(bypass 家族)。
- **状态存储与延迟绑定**:`AVGSceneFocusOut.m_amounts` 是 `Dictionary<string, SetWhenBind<BaseItem, float>>` —— `SetWhenBind::Set`(VA `0x185100150`)在显示对象未注册时**暂存** amount;`AVGSceneFocusOut::TryRegister`(VA `0x183e86300`,PostDisplayItem processor)在显示对象(**含 cgitem**)注册/重注册时通过 `SetWhenBind::Bind`(VA `0x1850ffee0`)**立即回放**存量 amount。这就是「先 focusout、后显示对象」仍能生效的延迟绑定机制。
- **tween**:`AVGSceneEffectManager::_SetEffectAmount`(VA `0x183e839f0`)对每个 channel 建一个 TweenAction,缓动为 `TweenUtils::SmoothStep`(平滑插值,起止缓、中段快),**不是线性**。
- **合成模型**:`AVGSceneFocusOut::Render`(VA `0x183e859d0`)对每个注册 item 做「**原图 × 全强度处理图**」按 per-item amount 的 ghost 混合(`mat_blit_ghost`);灰度/反色强度是材质常量(`mat_grayscale` 的 `_Params`/`_Inverse`),**不随 amount 缩放** —— amount=0.5 是半混合,不是半强度灰度/半强度反色。
- **focusparam**:`_ExecuteFocusParam`(VA `0x183e33060`)只写全局单份 `Config.useBlur/color`(`effect` 精确匹配 `Grayscale`/`Colorinverse`,其余归 NONE)并 `MarkEffectImplConfigDirty`,**不动任何 channel amount,永不阻塞**。

## 修复内容

| # | 严重度 | native 行为 | 前端旧行为 | 改法 |
| --- | --- | --- | --- | --- |
| focusout #1 | P1 | `SetWhenBind` 暂存 amount,cgitem 显示(或 hide 后重显)注册时立即回放 | `render()` 只在 focus 命令时解析目标,focusout 之后才显示/重显的 cgitem 不带滤镜 | `CgItemPanel` 新增 `onTargetsChanged` 回调(show 注册、hide 完成、clear 时触发),renderer 接到 `FocusEffectPanel.refresh()` 重解析目标;bg/char/cg/lbg 按层应用天然等价,无需处理 |
| focusout #2 | P1 | `type="cgitem"` 空 id → `_channel=""` → `IsChannelEmpty` → 无操作 | `cgItemPanel.targets("")` 返回**全部** cgitem 并模糊 | `resolveFocusTargets` 对空 id 的 cgitem 返回 `[]` |
| focusout #3 | P2 | `TweenUtils::SmoothStep` 平滑插值 | TweenRunner 线性 progress | `setFocus` tween 回调内套 `p²(3-2p)` |
| focusout #4 + focusparam #1 | P2 | 原图与全强度模糊/灰度/反色结果按 per-item amount ghost 混合(强度是材质常量) | `grayscale(amount)` 随 amount 缩放强度;`Colorinverse` **恒全量反色**与 amount 无关 | 颜色效果统一改为**全强度矩阵 + `ColorMatrixFilter.alpha = amount`** 混合(pixi 该 uniform 在 GL/WGSL 两端都是 `mix(orig, processed, uAlpha)`,即「清晰层+处理层交叉淡化」的精确等价):`Grayscale` 原 `grayscale(amount)` 恰为线性等价、输出不变,`Colorinverse` 修正为按 amount 半混合。模糊层:现成 pixi filter 无法对同一份活动内容做两次合成,保留 `strength = amount*8` 的强度代理(Port scope 注释声明) |
| focusout #5 | P2 | `customchar` 只作用于 `m_customInUse` 中的自定义槽(空 id 收集全部在用自定义槽;非空 id 小写匹配,未命中 no-op) | 无自定义槽系统:空 id → 模糊全部标准 l/m/r 槽;未知槽名归一化到中槽 | `customchar` 分支直接返回 `[]`(review 建议的短期方案;语料 0 命中,待自定义槽系统落地后实现) |
| focusout #6 | P2 | channel 集合不相交,每张图单次应用 | customchar 目标嵌套在 charLayer 内,char 与 customchar 并存时双重滤镜 | 随 #5 一并消除 |
| focusout #8 | P2 | — | runtime.ts focusout provenance 注释截断成半句,bypass 关键事实缺失 | 补全:duration 不应用 animateRatio(bypass 家族)、from≥0 先零时长写、block 仅 duration>0 时生效 |
| focusparam #2 | P2 | — | runtime.ts focusparam 注释截断成半句 | 补全:只写 Config 不动 amount、永不阻塞 |

维持现状(不修):focusout #7 amount 截断(样本全在 0..1,保留 clamp)、focusout #9/#10/#11 与 focusparam #3/#4/#5(全部 P3,review 建议「有意省略/可忽略」:MobileBlur 三 pass 管线近似、打断时提前 FinishCommand、XLua hotfix 桥、配置生效帧粒度、渲染材质近似等)。

## 验证用剧情文件

本地语料 `torappu/storage/asset/gamedata/latest/story/`:

- **修复 #1(延迟绑定,focusout 先于 cgitem 显示)**:
  - `obt/main/level_main_15-15_end.txt:392-396` —— 392/395 行 `[focusout(type="cgitem", id="cgitem_60_i12_2", from=0, to=0.75, duration=1.5)]` / `id="cgitem_60_i12_1", to=0.8, duration=1.2` 紧跟 393/396 行**同 id** 的 `[cgitem(...)]` 显示命令;修复前新显示的 cgitem 不带模糊,修复后注册即回放存量 amount。同型文件 `obt/main/level_main_15-15_end_variation01.txt:467-471`、`variation02.txt:472-476`、`activities/act29side/level_act29side_08_end.txt:584-585`。重显(hide 后再 show)路径语料无样本,由单测锁定(`tests/renderer.spec.ts` "applies focusout to cgitems displayed after the command")。
  - 反序对照(行为不变):`activities/act51side/level_act51side_st01.txt:196→209`(先 cgitem 后 focusout)。
- **修复 #3(SmoothStep)**:`obt/main/level_main_15-15_end.txt:392`(duration=1.5 的 cgitem 失焦)及全语料大量 `duration>0` 样本(如 `activities/act47side/level_act47side_08_end.txt:260` 的 duration=2 bg 失焦);插值曲线由单测锁定(`tests/focusEffectPanel.spec.ts` "tweens the amount with SmoothStep easing, not linear time")。
- **修复 #4(交叉淡化)**:`activities/act47side/level_act47side_08_end.txt:259-260` —— `[focusparam(effect="Grayscale", blur=true)]` + `[focusout(duration=2, type="bg", from=0, to=0.5, block=true)]`,amount=0.5 的灰度应为半混合(该文件 Grayscale 路径输出本就等价,回归验证);`activities/act19mini/level_act19mini_st04.txt:489-490`(Grayscale + char to=0.8)。语料无 `Colorinverse` 样本(20 条 focusparam 全为 Grayscale/纯 blur),反色半混合为**前瞻对齐,由单测锁定**(`tests/focusEffectPanel.spec.ts` "mixes a full-strength inverse by amount instead of always inverting")。
- **修复 #2(cgitem 空 id no-op)与 #5/#6(customchar)**:语料 **0 命中**,前瞻对齐,由单测锁定(`tests/renderer.spec.ts` "resolves focusout channels per native routing rules"、"treats focusout with an empty cgitem id as a native no-op")。

## 测试

- `pnpm test`:21 个文件 231 用例全部通过(基线 222,新增 9:focusEffectPanel.spec.ts 5 例、renderer.spec.ts 3 例、cgItemPanel.spec.ts 1 例)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint`(全部改动文件):通过。
