### PR TITLE
fix(story-player): charactercutin mask 裁切渲染与 SlotUpdate 平滑插值

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -68,6 +68,7 @@ import { TweenRunner } from "./core/TweenRunner";
 import { AnimTextPanel } from "./panels/AnimTextPanel";
 import { AvgDisplayPanel } from "./panels/AvgDisplayPanel";
 import { CgItemPanel } from "./panels/CgItemPanel";
+import { CharacterCutinPanel } from "./panels/CharacterCutinPanel";
 import { DecisionPanel } from "./panels/DecisionPanel";
 import { DialogPanel } from "./panels/DialogPanel";
 import { FocusEffectPanel } from "./panels/FocusEffectPanel";
@@ -202,21 +203,7 @@ export class PixiStoryRenderer implements StoryRenderer {
   private readonly charLayer = this.layers.characters;
   private readonly characterSlots = new Map<string, CharacterRenderState>();
   private readonly cutinLayer = this.layers.cutins;
-  private readonly cutinStates = new Map<
-    string,
-    { fadeStyle: number; sessionId: number; sprite: Sprite }
-  >();
-  private readonly cutinStoredPositions = new Map<
-    string,
-    {
-      endX: number;
-      endY: number;
-      fullHeight: number;
-      fullWidth: number;
-      startX: number;
-      startY: number;
-    }
-  >();
+  private readonly cutinPanel: CharacterCutinPanel;
 
   private readonly curtainLayer = this.layers.curtains;
   private readonly curtains = new Map<number, CurtainRenderState>();
@@ -290,6 +277,12 @@ export class PixiStoryRenderer implements StoryRenderer {
       (durationMs, update, complete) =>
         this.tween(durationMs, update, complete),
       onWarning,
+    );
+    this.cutinPanel = new CharacterCutinPanel(
+      this.cutinLayer,
+      (input) => this.textureForCutinCharacter(input),
+      (durationMs, update, complete) =>
+        this.tween(durationMs, update, complete),
     );
     this.animTextPanel = new AnimTextPanel(
       this.itemLayer,
@@ -412,10 +405,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.imageSprite = null;
     this.imageLayer.removeChildren();
     this.itemLayer.removeChildren();
-    for (const state of this.cutinStates.values()) state.sprite.destroy();
-    this.cutinStates.clear();
-    this.cutinStoredPositions.clear();
-    this.cutinLayer.removeChildren();
+    this.cutinPanel.destroy();
     for (const state of this.characterSlots.values())
       this.disposeCharacterState(state);
     this.characterSlots.clear();
@@ -864,23 +854,7 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   async clearCharacterCutin(widgetId?: string): Promise<void> {
-    if (!widgetId) {
-      for (const state of this.cutinStates.values()) {
-        state.sessionId += 1;
-        state.sprite.destroy();
-      }
-      this.cutinStates.clear();
-      this.cutinLayer.removeChildren();
-      return;
-    }
-
-    const id = `cutin_${widgetId.replace(/ /g, "_")}`;
-    const state = this.cutinStates.get(id);
-    if (!state) return;
-
-    state.sessionId += 1;
-    state.sprite.destroy();
-    this.cutinStates.delete(id);
+    this.cutinPanel.clear(widgetId);
   }
 
   async clearInterludes(): Promise<void> {
@@ -892,95 +866,34 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   /**
-   * Port scope: `Torappu.AVG.AVGCharacterCutinPanel._ExecuteCharacterCutin`
-   * and `AVGCharacterCutinSlot.Show`/hide fade styles. Crop expansion is
-   * reproduced with PIXI dimensions and masks rather than Unity UI widgets.
+   * Native port: `Torappu.AVG.AVGCharacterCutinPanel` (build 2761 IDA review):
+   * `GetExecutors` @ 0x183e48f70 registers `charactercutin` ->
+   * `_ExecuteCharacterCutin` @ 0x183e49440, whose five widgetID/name branches
+   * (show / SlotUpdate / hide) live in CharacterCutinPanel together with the
+   * `AVGCharacterCutinSlot` Show/SlotUpdate/Hide geometry.
    */
   async setCharacterCutin(input: CharacterCutinInput): Promise<void> {
     if (!this.app) return;
+    await this.cutinPanel.run(input);
+  }
 
-    if (!input.characterKey || !input.expression) {
-      const id = `cutin_${input.widgetId.replace(/ /g, "_")}`;
-      const existing = this.cutinStates.get(id);
-      if (!existing) return;
+  private async textureForCutinCharacter(
+    input: CharacterCutinInput,
+  ): Promise<Texture | null> {
+    const base = input.characterKey;
+    const expression = input.expression;
+    if (!base || !expression) return null;
 
-      const sessionId = ++existing.sessionId;
-      const fadeStyle = existing.fadeStyle;
-      const sprite = existing.sprite;
-      const durationMs = input.fadeMs;
-
-      if (fadeStyle === 0) {
-        const run = this.tween(
-          durationMs,
-          (progress) => {
-            if (existing.sessionId !== sessionId) return;
-            sprite.alpha = 1 - progress;
-          },
-          () => {
-            if (existing.sessionId !== sessionId) return;
-            sprite.destroy();
-            this.cutinStates.delete(id);
-          },
-        );
-
-        if (input.block) await run;
-        else void run;
-      } else {
-        const stored = this.cutinStoredPositions.get(id);
-        if (!stored) {
-          sprite.destroy();
-          this.cutinStates.delete(id);
-          return;
-        }
-
-        const isHorizontal = fadeStyle >= 1 && fadeStyle <= 3;
-        const run = this.tween(
-          durationMs,
-          (progress) => {
-            if (existing.sessionId !== sessionId) return;
-            if (isHorizontal) {
-              sprite.width = stored.fullWidth * (1 - progress);
-              sprite.x =
-                stored.startX + (stored.endX - stored.startX) * progress;
-              if (sprite.children.length > 0) {
-                const mask = sprite.children[0] as Graphics;
-                mask
-                  .clear()
-                  .rect(0, 0, sprite.width, sprite.height)
-                  .fill(0xff_ff_ff);
-              }
-            } else {
-              sprite.height = stored.fullHeight * (1 - progress);
-              sprite.y =
-                stored.startY + (stored.endY - stored.startY) * progress;
-            }
-          },
-          () => {
-            if (existing.sessionId !== sessionId) return;
-            sprite.destroy();
-            this.cutinStates.delete(id);
-            this.cutinStoredPositions.delete(id);
-          },
-        );
-
-        if (input.block) await run;
-        else void run;
-      }
-      return;
-    }
-
-    const link = this.context.linkMap[input.characterKey];
+    const link = this.context.linkMap[base];
     if (!link) {
-      this.onWarning?.(`missing character base: ${input.characterKey}`);
-      return;
+      this.onWarning?.(`missing character base: ${base}`);
+      return null;
     }
 
-    const item = link.array.find((entry) => entry.name === input.expression);
+    const item = link.array.find((entry) => entry.name === expression);
     if (!item) {
-      this.onWarning?.(
-        `missing character expression: ${input.characterKey}#${input.expression}`,
-      );
-      return;
+      this.onWarning?.(`missing character expression: ${base}#${expression}`);
+      return null;
     }
 
     let assetKey: string | null = null;
@@ -992,137 +905,11 @@ export class PixiStoryRenderer implements StoryRenderer {
     }
 
     if (!assetKey) {
-      this.onWarning?.(
-        `invalid cutin character: ${input.characterKey}#${input.expression}`,
-      );
-      return;
+      this.onWarning?.(`invalid cutin character: ${base}#${expression}`);
+      return null;
     }
 
-    const texture = await this.textureForCharacterKey(assetKey);
-    if (!texture) return;
-
-    const id = `cutin_${input.widgetId.replace(/ /g, "_")}`;
-    const previous = this.cutinStates.get(id);
-    if (previous) {
-      previous.sessionId += 1;
-      previous.sprite.destroy();
-    }
-
-    const sprite = new Sprite(texture);
-    sprite.anchor.set(0, 0);
-
-    const centerX = STORY_WIDTH / 2;
-    const cropW = input.width;
-    const cropH = input.height;
-    const halfW = cropW / 2;
-    const halfH = cropH / 2;
-
-    const endLeft = centerX + input.offsetX - halfW;
-    const endTop = -input.offsetY;
-
-    let fadeStyle: number;
-    let startLeft = endLeft;
-    let startTop = endTop;
-
-    switch (input.fadeStyle) {
-      case "horiz_expand_center": {
-        fadeStyle = 1;
-        startLeft += halfW;
-        break;
-      }
-      case "horiz_expand_left2right": {
-        fadeStyle = 2;
-        break;
-      }
-      case "horiz_expand_right2left": {
-        fadeStyle = 3;
-        startLeft += cropW;
-        break;
-      }
-      case "vert_expand_center": {
-        fadeStyle = 4;
-        startTop += halfH;
-        break;
-      }
-      case "vert_expand_top2bottom": {
-        fadeStyle = 5;
-        break;
-      }
-      case "vert_expand_bottom2top": {
-        fadeStyle = 6;
-        startTop += cropH;
-        break;
-      }
-      default: {
-        fadeStyle = 0;
-        break;
-      }
-    }
-
-    this.cutinStoredPositions.set(id, {
-      endX: endLeft,
-      endY: endTop,
-      fullHeight: cropH,
-      fullWidth: cropW,
-      startX: startLeft,
-      startY: startTop,
-    });
-
-    const durationMs = input.fadeMs;
-    const sessionId = previous ? previous.sessionId + 1 : 1;
-
-    if (fadeStyle === 0) {
-      sprite.x = endLeft;
-      sprite.y = endTop;
-      sprite.width = cropW;
-      sprite.height = cropH;
-      sprite.alpha = 0;
-      this.cutinLayer.addChild(sprite);
-
-      const state = { fadeStyle, sessionId, sprite };
-      this.cutinStates.set(id, state);
-
-      const run = this.tween(durationMs, (progress) => {
-        if (state.sessionId !== sessionId) return;
-        sprite.alpha = progress;
-      });
-
-      if (input.block) await run;
-      else void run;
-    } else {
-      const isHorizontal = fadeStyle >= 1 && fadeStyle <= 3;
-      sprite.x = startLeft;
-      sprite.y = startTop;
-
-      if (isHorizontal) {
-        sprite.width = 0;
-        sprite.height = cropH;
-      } else {
-        sprite.width = cropW;
-        sprite.height = 0;
-      }
-
-      this.cutinLayer.addChild(sprite);
-
-      const state = { fadeStyle, sessionId, sprite };
-      this.cutinStates.set(id, state);
-
-      const run = this.tween(durationMs, (progress) => {
-        if (state.sessionId !== sessionId) return;
-        if (isHorizontal) {
-          const currentWidth = cropW * progress;
-          sprite.width = currentWidth;
-          sprite.x = startLeft + (endLeft - startLeft) * progress;
-        } else {
-          const currentHeight = cropH * progress;
-          sprite.height = currentHeight;
-          sprite.y = startTop + (endTop - startTop) * progress;
-        }
-      });
-
-      if (input.block) await run;
-      else void run;
-    }
+    return this.textureForCharacterKey(assetKey);
   }
 
   /**

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -68,7 +68,10 @@ import { TweenRunner } from "./core/TweenRunner";
 import { AnimTextPanel } from "./panels/AnimTextPanel";
 import { AvgDisplayPanel } from "./panels/AvgDisplayPanel";
 import { CgItemPanel } from "./panels/CgItemPanel";
-import { CharacterCutinPanel } from "./panels/CharacterCutinPanel";
+import {
+  CharacterCutinPanel,
+  type CutinCharacterArt,
+} from "./panels/CharacterCutinPanel";
 import { DecisionPanel } from "./panels/DecisionPanel";
 import { DialogPanel } from "./panels/DialogPanel";
 import { FocusEffectPanel } from "./panels/FocusEffectPanel";
@@ -879,7 +882,7 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   private async textureForCutinCharacter(
     input: CharacterCutinInput,
-  ): Promise<Texture | null> {
+  ): Promise<CutinCharacterArt | null> {
     const base = input.characterKey;
     const expression = input.expression;
     if (!base || !expression) return null;
@@ -909,7 +912,20 @@ export class PixiStoryRenderer implements StoryRenderer {
       return null;
     }
 
-    return this.textureForCharacterKey(assetKey);
+    const texture = await this.textureForCharacterKey(assetKey);
+    if (!texture) return null;
+    // AVGCharacterSpriteHub.SetImage resizes the character Image to the hub's
+    // serialized size and shifts it by pos; the scene character path applies
+    // the same layout (see buildCharacterSlotState), so the cutin must too.
+    const sizeX = link.size.x || texture.width;
+    const sizeY = link.size.y || texture.height;
+    return {
+      offsetX: link.pos.x || 0,
+      offsetY: link.pos.y || 0,
+      scaleX: sizeX / Math.max(1, texture.width),
+      scaleY: sizeY / Math.max(1, texture.height),
+      texture,
+    };
   }
 
   /**

--- a/src/widgets/StoryPlayer/engine/rendering/panels/CharacterCutinPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/CharacterCutinPanel.ts
@@ -7,7 +7,22 @@ import {
   type CharacterCutinInput,
 } from "../../types";
 
-type TextureLoader = (input: CharacterCutinInput) => Promise<Texture | null>;
+/**
+ * Character art plus the AVGCharacterSpriteHub layout the game applies on
+ * top of the raw sheet: the Image rect is resized to `size` (here folded
+ * into sprite scale) and shifted by `pos` relative to the slot node.
+ */
+export interface CutinCharacterArt {
+  texture: Texture;
+  offsetX: number;
+  offsetY: number;
+  scaleX: number;
+  scaleY: number;
+}
+
+type TextureLoader = (
+  input: CharacterCutinInput,
+) => Promise<CutinCharacterArt | null>;
 type Tween = (
   durationMs: number,
   update: (progress: number) => void,
@@ -49,9 +64,18 @@ interface CutinLayout {
   zoom: number;
 }
 
+interface CutinChar {
+  /** AVGCharacterSpriteHub pos of this character, applied on re-layouts. */
+  offsetX: number;
+  offsetY: number;
+  sprite: Sprite;
+}
+
 interface CutinSlotState {
+  /** `_defualtBackground` port: the #898989 strip behind the character. */
+  backdrop: Graphics;
   /** Live character sprites; more than one only during a SlotUpdate crossfade. */
-  chars: Sprite[];
+  chars: CutinChar[];
   /** `_characterSlot` identity of the last Set, used to skip no-op crossfades. */
   charIdentity: string;
   /** `_zoomAndPovRectTransform` port: scale = zoom, position = (-povX, povY). */
@@ -151,14 +175,12 @@ export class CharacterCutinPanel {
   ): Promise<void> {
     const state = this.createSlot(input.widgetId, layout, input.fadeStyle);
     // AVGCharacterSlot.Set(name, 0.0, white) swaps the sprite instantly.
-    const texture = input.characterMissing
-      ? null
-      : await this.loadTexture(input);
+    const art = input.characterMissing ? null : await this.loadTexture(input);
     if (this.slots.get(input.widgetId) !== state) return;
-    if (texture) {
+    if (art) {
       this.addCharacter(
         state,
-        texture,
+        art,
         layout,
         input.characterKey,
         input.expression,
@@ -227,14 +249,14 @@ export class CharacterCutinPanel {
     // same identity is visually a no-op, so skip re-adding the sprite.
     const identity = `${input.characterKey}/${input.expression}`;
     const outgoing = [...state.chars];
-    let incoming: Sprite | null = null;
+    let incoming: CutinChar | null = null;
     if (!input.characterMissing && identity !== state.charIdentity) {
-      const texture = await this.loadTexture(input);
+      const art = await this.loadTexture(input);
       if (this.slots.get(input.widgetId) !== state) return;
-      if (texture) {
+      if (art) {
         incoming = this.addCharacter(
           state,
-          texture,
+          art,
           layout,
           input.characterKey,
           input.expression,
@@ -243,7 +265,10 @@ export class CharacterCutinPanel {
       }
     }
     for (const char of state.chars)
-      char.position.set(layout.charX, layout.charY);
+      char.sprite.position.set(
+        layout.charX + char.offsetX,
+        layout.charY - char.offsetY,
+      );
 
     const run = this.tween(
       input.fadeMs,
@@ -265,8 +290,8 @@ export class CharacterCutinPanel {
         state.maskSize.h = lerp(start.maskH, layout.maskH, progress);
         state.maskSize.w = lerp(start.maskW, layout.maskW, progress);
         this.drawMask(state);
-        for (const char of outgoing) char.alpha = 1 - progress;
-        if (incoming) incoming.alpha = progress;
+        for (const char of outgoing) char.sprite.alpha = 1 - progress;
+        if (incoming) incoming.sprite.alpha = progress;
       },
       () => {
         if (state.sessionId !== sessionId) return;
@@ -335,15 +360,26 @@ export class CharacterCutinPanel {
     // anchoredPosition, then Show's layout math positions everything.
     const root = new Container();
     root.position.set(layout.rootX, layout.rootY);
+    // _defualtBackground: sprite_white tinted (0.537, 0.537, 0.537) = #898989,
+    // active whenever the command has no `background` key (Show flips the two
+    // nodes around). It sits under `mask` beside -- not inside --
+    // _zoomAndPovRectTransform, so zoom/pov never move it; the mask clips the
+    // full-canvas rect into the gray strip behind the character. Its `header`
+    // child (black, 70% alpha, anchored +50 above the top edge) lands outside
+    // the 720-tall mask and never shows.
+    const backdrop = new Graphics()
+      .rect(-STORY_WIDTH / 2, -STORY_HEIGHT / 2, STORY_WIDTH, STORY_HEIGHT)
+      .fill(0x89_89_89);
     const content = new Container();
     content.position.set(layout.contentX, layout.contentY);
     content.scale.set(layout.zoom);
     const mask = new Graphics();
-    root.addChild(mask, content);
+    root.addChild(mask, backdrop, content);
     root.mask = mask;
     this.layer.addChild(root);
 
     const state: CutinSlotState = {
+      backdrop,
       chars: [],
       charIdentity: "",
       content,
@@ -361,30 +397,39 @@ export class CharacterCutinPanel {
 
   private addCharacter(
     state: CutinSlotState,
-    texture: Texture,
+    art: CutinCharacterArt,
     layout: CutinLayout,
     characterKey: string | undefined,
     expression: string | undefined,
     alpha: number,
-  ): Sprite {
-    const sprite = new Sprite(texture);
-    // The character keeps its original texture size; only the mask crops it.
-    // Native pivot: `_characterSlot.localPosition = (charOffsetX,
-    // charOffsetY - maskHeight / 2)` parks the character's feet at the mask
-    // bottom when charOffsetY is 0 (y-up in Unity, flipped here).
-    sprite.anchor.set(0.5, 1);
-    sprite.position.set(layout.charX, layout.charY);
+  ): CutinChar {
+    const sprite = new Sprite(art.texture);
+    // The character keeps the hub's native layout: the sheet is scaled to
+    // AVGCharacterSpriteHub.size (SetImage resizes the Image rect) and the
+    // art center lands at the mask-bottom-based slot position plus the hub
+    // pos. Show writes `_characterSlot.localPosition = (charOffsetX,
+    // charOffsetY - maskHeight / 2)`; the prefab's slot_character/offset
+    // child ((0, 360) serialized) is zeroed by AVGCharacterSlot.Set's
+    // resetOffsetPos before the hub pos is applied. Only the mask crops.
+    sprite.anchor.set(0.5);
+    sprite.scale.set(art.scaleX, art.scaleY);
+    sprite.position.set(layout.charX + art.offsetX, layout.charY - art.offsetY);
     sprite.alpha = alpha;
     state.content.addChild(sprite);
-    state.chars.push(sprite);
+    const char: CutinChar = {
+      offsetX: art.offsetX,
+      offsetY: art.offsetY,
+      sprite,
+    };
+    state.chars.push(char);
     state.charIdentity = `${characterKey}/${expression}`;
-    return sprite;
+    return char;
   }
 
-  private removeCharacter(state: CutinSlotState, char: Sprite): void {
+  private removeCharacter(state: CutinSlotState, char: CutinChar): void {
     const index = state.chars.indexOf(char);
     if (index !== -1) state.chars.splice(index, 1);
-    char.destroy();
+    char.sprite.destroy();
   }
 
   private destroySlot(widgetId: string, state: CutinSlotState): void {
@@ -439,9 +484,12 @@ export class CharacterCutinPanel {
  * `align = HORIZONTAL` (the vertical align flavor is unused by the corpus),
  * the slot center sits at screen center + (offsetx, offsety),
  * `_zoomAndPovRectTransform` gets localScale = `zoom` (renamed from `scale`
- * in 2.7.61) and anchoredPosition = (-povX, -povY), and
- * `_characterSlot.localPosition = (charOffsetX, charOffsetY - maskHeight / 2)`.
- * Unity's y-up local space is flipped to PIXI's y-down coordinates here.
+ * in 2.7.61) and anchoredPosition = (-povX, -povY). The character slot node
+ * lands at (charOffsetX, charOffsetY - maskHeight / 2) -- i.e. the mask
+ * bottom edge under the default 720-tall mask; AVGCharacterSpriteHub's own
+ * pos/size (see CutinCharacterArt) then shift/scale each character art from
+ * there. Unity's y-up local space is flipped to PIXI's y-down coordinates
+ * here.
  */
 function layoutFor(input: CharacterCutinInput): CutinLayout {
   const maskH = STORY_HEIGHT;

--- a/src/widgets/StoryPlayer/engine/rendering/panels/CharacterCutinPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/CharacterCutinPanel.ts
@@ -1,0 +1,459 @@
+import { Container, Graphics, Sprite, type Texture } from "pixi.js";
+
+import {
+  STORY_HEIGHT,
+  STORY_WIDTH,
+  type CharacterCutinFadeStyle,
+  type CharacterCutinInput,
+} from "../../types";
+
+type TextureLoader = (input: CharacterCutinInput) => Promise<Texture | null>;
+type Tween = (
+  durationMs: number,
+  update: (progress: number) => void,
+  complete?: () => void,
+) => Promise<void>;
+
+/**
+ * `AVGCharacterCutinSlot.FadeStyle` ordinals. The vertical members spell
+ * `bottom` correctly in native -- a misspelled value silently degrades to
+ * `fade` (enum default 0) on both sides.
+ */
+const FADE_STYLE_IDS: Record<CharacterCutinFadeStyle, number> = {
+  fade: 0,
+  horiz_expand_center: 1,
+  horiz_expand_left2right: 2,
+  horiz_expand_right2left: 3,
+  vert_expand_center: 4,
+  vert_expand_top2bottom: 5,
+  vert_expand_bottom2top: 6,
+};
+
+function fadeStyleId(style: CharacterCutinInput["fadeStyle"]): number {
+  return style ? (FADE_STYLE_IDS[style] ?? 0) : 0;
+}
+
+function lerp(from: number, to: number, progress: number): number {
+  return from + (to - from) * progress;
+}
+
+interface CutinLayout {
+  charX: number;
+  charY: number;
+  contentX: number;
+  contentY: number;
+  maskH: number;
+  maskW: number;
+  rootX: number;
+  rootY: number;
+  zoom: number;
+}
+
+interface CutinSlotState {
+  /** Live character sprites; more than one only during a SlotUpdate crossfade. */
+  chars: Sprite[];
+  /** `_characterSlot` identity of the last Set, used to skip no-op crossfades. */
+  charIdentity: string;
+  /** `_zoomAndPovRectTransform` port: scale = zoom, position = (-povX, povY). */
+  content: Container;
+  /** `m_showFadeStyle`: the last style stored by Show/SlotUpdate, drives Hide. */
+  fadeStyle: number;
+  mask: Graphics;
+  /** Current mask size; the expand animations tween this instead of the sprite. */
+  maskSize: { h: number; w: number };
+  /** `_offsetTransform` port: the slot center sits at screen center + offset. */
+  root: Container;
+  sessionId: number;
+  /** Final mask size; directional pivots pin against this while expanding. */
+  targetSize: { h: number; w: number };
+}
+
+/**
+ * Native port: `Torappu.AVG.AVGCharacterCutinPanel` /
+ * `Torappu.AVG.AVGCharacterCutinSlot`, re-verified against build 2761
+ * (2.7.61) GameAssembly.dll via IDA:
+ *
+ * - `GetExecutors` @ 0x183e48f70 registers `charactercutin` ->
+ *   `_ExecuteCharacterCutin` @ 0x183e49440, whose five branches reduce to
+ *   show / update / hide by (widgetID present in `_slots`, `name` empty).
+ * - `AVGCharacterCutinSlot.Show` @ 0x183eb1320 renders the character at its
+ *   original size and crops it with `_maskRectTransform` sized
+ *   `width x _offsetTransform.rect.height` (the full 720-tall canvas under
+ *   the default `align=HORIZONTAL`). The slot center sits at screen center +
+ *   (offsetx, offsety). Expand fade styles tween the mask rect from zero
+ *   (pivot pinned at the expansion edge), never the character scale.
+ * - `AVGCharacterCutinSlot.SlotUpdate` @ 0x183eb20a0 does NOT replay the
+ *   entry animation: it captures the current sizeDelta / offset position /
+ *   zoom scale / pov anchoredPosition and interpolates the whole layout to
+ *   the new values over `animateRatio * fadetime`, while
+ *   `AVGCharacterSlot.Set(name, duration, ...)` crossfades the character.
+ * - `AVGCharacterCutinSlot.Hide` @ 0x183eb0d80 reverses along the stored
+ *   `m_showFadeStyle` (alpha for `fade`, mask collapse for expand styles);
+ *   the completion callback `b__0` @ 0x183e62c90 then recycles the slot and
+ *   removes the widgetID from `_slots`.
+ *
+ * Web adaptation: the Unity RectTransform hierarchy (offset -> mask ->
+ * zoomAndPov -> character) becomes nested PIXI containers with a Graphics
+ * mask; DOTween becomes the shared TweenRunner. This panel has no background
+ * layer (`background`/`backgroundOffset` are unused by the story corpus).
+ */
+export class CharacterCutinPanel {
+  private readonly slots = new Map<string, CutinSlotState>();
+
+  constructor(
+    private readonly layer: Container,
+    private readonly loadTexture: TextureLoader,
+    private readonly tween: Tween,
+  ) {}
+
+  async run(input: CharacterCutinInput): Promise<void> {
+    const state = this.slots.get(input.widgetId);
+    // Native branching in _ExecuteCharacterCutin: empty `name` means Hide
+    // (a no-op when the widgetID is unknown); a non-empty name Shows a new
+    // slot or SlotUpdates the existing one. `characterMissing` keeps the
+    // show/update path alive for unresolvable names: native still allocates
+    // the slot and runs its tween while AVGCharacterSlot logs its own error.
+    if (!input.characterKey && !input.characterMissing) {
+      if (state)
+        await this.hideSlot(input.widgetId, input.fadeMs, state, input.block);
+      return;
+    }
+
+    const layout = layoutFor(input);
+    if (state) await this.updateSlot(input, state, layout);
+    else await this.showSlot(input, layout);
+  }
+
+  clear(widgetId?: string): void {
+    if (widgetId === undefined) {
+      for (const state of this.slots.values()) {
+        state.sessionId += 1;
+        state.root.destroy({ children: true });
+      }
+      this.slots.clear();
+      return;
+    }
+
+    const state = this.slots.get(widgetId);
+    if (!state) return;
+    state.sessionId += 1;
+    state.root.destroy({ children: true });
+    this.slots.delete(widgetId);
+  }
+
+  destroy(): void {
+    this.clear();
+  }
+
+  private async showSlot(
+    input: CharacterCutinInput,
+    layout: CutinLayout,
+  ): Promise<void> {
+    const state = this.createSlot(input.widgetId, layout, input.fadeStyle);
+    // AVGCharacterSlot.Set(name, 0.0, white) swaps the sprite instantly.
+    const texture = input.characterMissing
+      ? null
+      : await this.loadTexture(input);
+    if (this.slots.get(input.widgetId) !== state) return;
+    if (texture) {
+      this.addCharacter(
+        state,
+        texture,
+        layout,
+        input.characterKey,
+        input.expression,
+        1,
+      );
+    }
+
+    const sessionId = ++state.sessionId;
+    if (state.fadeStyle === 0) {
+      // fade: canvas-group alpha 0 -> 1 with the mask already at full size.
+      state.root.alpha = 0;
+      this.drawMask(state);
+      const run = this.tween(input.fadeMs, (progress) => {
+        if (state.sessionId !== sessionId) return;
+        state.root.alpha = progress;
+      });
+      if (input.block) await run;
+      else void run;
+      return;
+    }
+
+    // Expand styles keep alpha = 1 and grow the mask rect from zero along
+    // the style's pivot edge (native DOSizeDelta / DOTween.To).
+    const horizontal = state.fadeStyle >= 1 && state.fadeStyle <= 3;
+    state.maskSize = {
+      h: horizontal ? layout.maskH : 0,
+      w: horizontal ? 0 : layout.maskW,
+    };
+    this.drawMask(state);
+    const start = { ...state.maskSize };
+    const run = this.tween(input.fadeMs, (progress) => {
+      if (state.sessionId !== sessionId) return;
+      state.maskSize.h = lerp(start.h, layout.maskH, progress);
+      state.maskSize.w = lerp(start.w, layout.maskW, progress);
+      this.drawMask(state);
+    });
+    if (input.block) await run;
+    else void run;
+  }
+
+  private async updateSlot(
+    input: CharacterCutinInput,
+    state: CutinSlotState,
+    layout: CutinLayout,
+  ): Promise<void> {
+    // Native SlotUpdate reads the current sizeDelta / offset / scale / pov as
+    // the tween start; bumping the session freezes any in-flight tween at
+    // those captured values, which is the superset native relies on.
+    const sessionId = ++state.sessionId;
+    state.fadeStyle = fadeStyleId(input.fadeStyle);
+    state.targetSize = { h: layout.maskH, w: layout.maskW };
+
+    const start = {
+      alpha: state.root.alpha,
+      contentX: state.content.x,
+      contentY: state.content.y,
+      maskH: state.maskSize.h,
+      maskW: state.maskSize.w,
+      rootX: state.root.x,
+      rootY: state.root.y,
+      zoom: state.content.scale.x,
+    };
+
+    // AVGCharacterSlot.Set(name, duration, white): the sprite swap crossfades
+    // over the tween duration instead of replacing instantly. Swapping to the
+    // same identity is visually a no-op, so skip re-adding the sprite.
+    const identity = `${input.characterKey}/${input.expression}`;
+    const outgoing = [...state.chars];
+    let incoming: Sprite | null = null;
+    if (!input.characterMissing && identity !== state.charIdentity) {
+      const texture = await this.loadTexture(input);
+      if (this.slots.get(input.widgetId) !== state) return;
+      if (texture) {
+        incoming = this.addCharacter(
+          state,
+          texture,
+          layout,
+          input.characterKey,
+          input.expression,
+          0,
+        );
+      }
+    }
+    for (const char of state.chars)
+      char.position.set(layout.charX, layout.charY);
+
+    const run = this.tween(
+      input.fadeMs,
+      (progress) => {
+        if (state.sessionId !== sessionId) return;
+        // SlotUpdate does not tween the canvas-group alpha itself, but an
+        // interrupted fade-style Show must still settle at 1 like native's
+        // concurrently running DOFade would.
+        state.root.alpha = lerp(start.alpha, 1, progress);
+        state.root.position.set(
+          lerp(start.rootX, layout.rootX, progress),
+          lerp(start.rootY, layout.rootY, progress),
+        );
+        state.content.position.set(
+          lerp(start.contentX, layout.contentX, progress),
+          lerp(start.contentY, layout.contentY, progress),
+        );
+        state.content.scale.set(lerp(start.zoom, layout.zoom, progress));
+        state.maskSize.h = lerp(start.maskH, layout.maskH, progress);
+        state.maskSize.w = lerp(start.maskW, layout.maskW, progress);
+        this.drawMask(state);
+        for (const char of outgoing) char.alpha = 1 - progress;
+        if (incoming) incoming.alpha = progress;
+      },
+      () => {
+        if (state.sessionId !== sessionId) return;
+        for (const char of outgoing) this.removeCharacter(state, char);
+      },
+    );
+    if (input.block) await run;
+    else void run;
+  }
+
+  private async hideSlot(
+    widgetId: string,
+    fadeMs: number,
+    state: CutinSlotState,
+    block: boolean,
+  ): Promise<void> {
+    // Native Hide only reads `fadetime` and reverses along the stored
+    // m_showFadeStyle: alpha for `fade`, mask collapse for expand styles
+    // (which keep alpha = 1). b__0 then recycles the slot and removes the
+    // widgetID, so a later Show starts from a fresh slot.
+    const sessionId = ++state.sessionId;
+    if (state.fadeStyle === 0) {
+      const startAlpha = state.root.alpha;
+      const run = this.tween(
+        fadeMs,
+        (progress) => {
+          if (state.sessionId !== sessionId) return;
+          state.root.alpha = lerp(startAlpha, 0, progress);
+        },
+        () => {
+          if (state.sessionId !== sessionId) return;
+          this.destroySlot(widgetId, state);
+        },
+      );
+      if (block) await run;
+      else void run;
+      return;
+    }
+
+    const horizontal = state.fadeStyle >= 1 && state.fadeStyle <= 3;
+    const startH = state.maskSize.h;
+    const startW = state.maskSize.w;
+    const run = this.tween(
+      fadeMs,
+      (progress) => {
+        if (state.sessionId !== sessionId) return;
+        state.maskSize.h = horizontal ? startH : lerp(startH, 0, progress);
+        state.maskSize.w = horizontal ? lerp(startW, 0, progress) : startW;
+        this.drawMask(state);
+      },
+      () => {
+        if (state.sessionId !== sessionId) return;
+        this.destroySlot(widgetId, state);
+      },
+    );
+    if (block) await run;
+    else void run;
+  }
+
+  private createSlot(
+    widgetId: string,
+    layout: CutinLayout,
+    fadeStyle: CharacterCutinInput["fadeStyle"],
+  ): CutinSlotState {
+    // Pool allocation equivalent: GameObjectPool.Allocate zeroes the
+    // anchoredPosition, then Show's layout math positions everything.
+    const root = new Container();
+    root.position.set(layout.rootX, layout.rootY);
+    const content = new Container();
+    content.position.set(layout.contentX, layout.contentY);
+    content.scale.set(layout.zoom);
+    const mask = new Graphics();
+    root.addChild(mask, content);
+    root.mask = mask;
+    this.layer.addChild(root);
+
+    const state: CutinSlotState = {
+      chars: [],
+      charIdentity: "",
+      content,
+      fadeStyle: fadeStyleId(fadeStyle),
+      mask,
+      maskSize: { h: layout.maskH, w: layout.maskW },
+      root,
+      sessionId: 0,
+      targetSize: { h: layout.maskH, w: layout.maskW },
+    };
+    this.drawMask(state);
+    this.slots.set(widgetId, state);
+    return state;
+  }
+
+  private addCharacter(
+    state: CutinSlotState,
+    texture: Texture,
+    layout: CutinLayout,
+    characterKey: string | undefined,
+    expression: string | undefined,
+    alpha: number,
+  ): Sprite {
+    const sprite = new Sprite(texture);
+    // The character keeps its original texture size; only the mask crops it.
+    // Native pivot: `_characterSlot.localPosition = (charOffsetX,
+    // charOffsetY - maskHeight / 2)` parks the character's feet at the mask
+    // bottom when charOffsetY is 0 (y-up in Unity, flipped here).
+    sprite.anchor.set(0.5, 1);
+    sprite.position.set(layout.charX, layout.charY);
+    sprite.alpha = alpha;
+    state.content.addChild(sprite);
+    state.chars.push(sprite);
+    state.charIdentity = `${characterKey}/${expression}`;
+    return sprite;
+  }
+
+  private removeCharacter(state: CutinSlotState, char: Sprite): void {
+    const index = state.chars.indexOf(char);
+    if (index !== -1) state.chars.splice(index, 1);
+    char.destroy();
+  }
+
+  private destroySlot(widgetId: string, state: CutinSlotState): void {
+    state.root.destroy({ children: true });
+    this.slots.delete(widgetId);
+  }
+
+  private drawMask(state: CutinSlotState): void {
+    const { h, w } = state.maskSize;
+    const targetW = state.targetSize.w;
+    // Native pivot table from Show/Hide: left2right pins the left edge,
+    // right2left the right edge, top2bottom the top edge, bottom2top the
+    // bottom edge; the rest stay centered. Vertical styles never animate the
+    // width, so the centered x form also covers them.
+    let x: number;
+    switch (state.fadeStyle) {
+      case 2: {
+        x = -targetW / 2;
+        break;
+      }
+      case 3: {
+        x = targetW / 2 - w;
+        break;
+      }
+      default: {
+        x = -w / 2;
+        break;
+      }
+    }
+    let y: number;
+    switch (state.fadeStyle) {
+      case 5: {
+        y = -STORY_HEIGHT / 2;
+        break;
+      }
+      case 6: {
+        y = STORY_HEIGHT / 2 - h;
+        break;
+      }
+      default: {
+        y = -h / 2;
+        break;
+      }
+    }
+    state.mask.clear().rect(x, y, w, h).fill(0xff_ff_ff);
+  }
+}
+
+/**
+ * Geometry port of `AVGCharacterCutinSlot.Show` @ 0x183eb1320 (build 2761):
+ * the mask is `width x _offsetTransform.rect.height` under the default
+ * `align = HORIZONTAL` (the vertical align flavor is unused by the corpus),
+ * the slot center sits at screen center + (offsetx, offsety),
+ * `_zoomAndPovRectTransform` gets localScale = `zoom` (renamed from `scale`
+ * in 2.7.61) and anchoredPosition = (-povX, -povY), and
+ * `_characterSlot.localPosition = (charOffsetX, charOffsetY - maskHeight / 2)`.
+ * Unity's y-up local space is flipped to PIXI's y-down coordinates here.
+ */
+function layoutFor(input: CharacterCutinInput): CutinLayout {
+  const maskH = STORY_HEIGHT;
+  return {
+    charX: input.charOffsetX,
+    charY: maskH / 2 - input.charOffsetY,
+    contentX: -input.povX,
+    contentY: input.povY,
+    maskH,
+    maskW: input.width,
+    rootX: STORY_WIDTH / 2 + input.offsetX,
+    rootY: STORY_HEIGHT / 2 - input.offsetY,
+    zoom: input.zoom,
+  };
+}

--- a/src/widgets/StoryPlayer/engine/rendering/panels/CharacterCutinPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/CharacterCutinPanel.ts
@@ -52,9 +52,10 @@ function lerp(from: number, to: number, progress: number): number {
   return from + (to - from) * progress;
 }
 
+/** `_defaultSlotWidth`, the serialized fallback behind the `width` key. */
+const DEFAULT_SLOT_WIDTH = 200;
+
 interface CutinLayout {
-  charX: number;
-  charY: number;
   contentX: number;
   contentY: number;
   maskH: number;
@@ -78,6 +79,13 @@ interface CutinSlotState {
   chars: CutinChar[];
   /** `_characterSlot` identity of the last Set, used to skip no-op crossfades. */
   charIdentity: string;
+  /**
+   * `_characterSlot.localPosition` port. Only Show writes it -- SlotUpdate
+   * @ 0x183eb20a0 never touches the node -- so it survives every update and
+   * each sprite hangs off it plus its own AVGCharacterSpriteHub pos.
+   */
+  charSlotX: number;
+  charSlotY: number;
   /** `_zoomAndPovRectTransform` port: scale = zoom, position = (-povX, povY). */
   content: Container;
   /** `m_showFadeStyle`: the last style stored by Show/SlotUpdate, drives Hide. */
@@ -143,9 +151,8 @@ export class CharacterCutinPanel {
       return;
     }
 
-    const layout = layoutFor(input);
-    if (state) await this.updateSlot(input, state, layout);
-    else await this.showSlot(input, layout);
+    if (state) await this.updateSlot(input, state);
+    else await this.showSlot(input, layoutFor(input));
   }
 
   clear(widgetId?: string): void {
@@ -173,26 +180,19 @@ export class CharacterCutinPanel {
     input: CharacterCutinInput,
     layout: CutinLayout,
   ): Promise<void> {
-    const state = this.createSlot(input.widgetId, layout, input.fadeStyle);
+    // createSlot already seeded the entry state (alpha 0 for `fade`, a
+    // zero-extent mask for the expand styles), so nothing is on screen while
+    // the character texture is still in flight.
+    const state = this.createSlot(input.widgetId, layout, input);
     // AVGCharacterSlot.Set(name, 0.0, white) swaps the sprite instantly.
     const art = input.characterMissing ? null : await this.loadTexture(input);
     if (this.slots.get(input.widgetId) !== state) return;
-    if (art) {
-      this.addCharacter(
-        state,
-        art,
-        layout,
-        input.characterKey,
-        input.expression,
-        1,
-      );
-    }
+    if (art)
+      this.addCharacter(state, art, input.characterKey, input.expression, 1);
 
     const sessionId = ++state.sessionId;
     if (state.fadeStyle === 0) {
       // fade: canvas-group alpha 0 -> 1 with the mask already at full size.
-      state.root.alpha = 0;
-      this.drawMask(state);
       const run = this.tween(input.fadeMs, (progress) => {
         if (state.sessionId !== sessionId) return;
         state.root.alpha = progress;
@@ -204,12 +204,6 @@ export class CharacterCutinPanel {
 
     // Expand styles keep alpha = 1 and grow the mask rect from zero along
     // the style's pivot edge (native DOSizeDelta / DOTween.To).
-    const horizontal = state.fadeStyle >= 1 && state.fadeStyle <= 3;
-    state.maskSize = {
-      h: horizontal ? layout.maskH : 0,
-      w: horizontal ? 0 : layout.maskW,
-    };
-    this.drawMask(state);
     const start = { ...state.maskSize };
     const run = this.tween(input.fadeMs, (progress) => {
       if (state.sessionId !== sessionId) return;
@@ -224,14 +218,12 @@ export class CharacterCutinPanel {
   private async updateSlot(
     input: CharacterCutinInput,
     state: CutinSlotState,
-    layout: CutinLayout,
   ): Promise<void> {
     // Native SlotUpdate reads the current sizeDelta / offset / scale / pov as
     // the tween start; bumping the session freezes any in-flight tween at
     // those captured values, which is the superset native relies on.
     const sessionId = ++state.sessionId;
     state.fadeStyle = fadeStyleId(input.fadeStyle);
-    state.targetSize = { h: layout.maskH, w: layout.maskW };
 
     const start = {
       alpha: state.root.alpha,
@@ -243,32 +235,36 @@ export class CharacterCutinPanel {
       rootY: state.root.y,
       zoom: state.content.scale.x,
     };
+    // Every layout key defaults to the slot's live transform in native
+    // (`GetInt(param, "width", (int)sizeDelta.x)` and friends), so an update
+    // that omits a key holds its current value instead of snapping back to
+    // the command default.
+    const layout = layoutFor(input, start);
+    state.targetSize = { h: layout.maskH, w: layout.maskW };
 
     // AVGCharacterSlot.Set(name, duration, white): the sprite swap crossfades
-    // over the tween duration instead of replacing instantly. Swapping to the
-    // same identity is visually a no-op, so skip re-adding the sprite.
+    // over the tween duration instead of replacing instantly. On a matching
+    // key Set skips its whole swap branch (`!op_Equality(m_currentKey, key)`
+    // guards it), so the current art must stay put -- neither re-mounted nor
+    // faded out.
     const identity = `${input.characterKey}/${input.expression}`;
-    const outgoing = [...state.chars];
+    const keepsCurrentArt =
+      !input.characterMissing && identity === state.charIdentity;
+    const outgoing = keepsCurrentArt ? [] : [...state.chars];
     let incoming: CutinChar | null = null;
-    if (!input.characterMissing && identity !== state.charIdentity) {
+    if (!keepsCurrentArt && !input.characterMissing) {
       const art = await this.loadTexture(input);
       if (this.slots.get(input.widgetId) !== state) return;
       if (art) {
         incoming = this.addCharacter(
           state,
           art,
-          layout,
           input.characterKey,
           input.expression,
           0,
         );
       }
     }
-    for (const char of state.chars)
-      char.sprite.position.set(
-        layout.charX + char.offsetX,
-        layout.charY - char.offsetY,
-      );
 
     const run = this.tween(
       input.fadeMs,
@@ -354,7 +350,7 @@ export class CharacterCutinPanel {
   private createSlot(
     widgetId: string,
     layout: CutinLayout,
-    fadeStyle: CharacterCutinInput["fadeStyle"],
+    input: CharacterCutinInput,
   ): CutinSlotState {
     // Pool allocation equivalent: GameObjectPool.Allocate zeroes the
     // anchoredPosition, then Show's layout math positions everything.
@@ -380,16 +376,33 @@ export class CharacterCutinPanel {
 
     const state: CutinSlotState = {
       backdrop,
-      chars: [],
       charIdentity: "",
+      // Show writes `_characterSlot.localPosition = (charOffsetX,
+      // charOffsetY - maskHeight / 2)`: the slot node is pinned to the mask
+      // bottom edge (Unity y-up flipped for PIXI).
+      charSlotX: input.charOffsetX ?? 0,
+      charSlotY: layout.maskH / 2 - (input.charOffsetY ?? 0),
+      chars: [],
       content,
-      fadeStyle: fadeStyleId(fadeStyle),
+      fadeStyle: fadeStyleId(input.fadeStyle),
       mask,
       maskSize: { h: layout.maskH, w: layout.maskW },
       root,
       sessionId: 0,
       targetSize: { h: layout.maskH, w: layout.maskW },
     };
+    // Entry state, seeded before the caller awaits the character texture:
+    // `fade` starts transparent with a full-size mask, the expand styles keep
+    // alpha = 1 and start from a zero-extent mask. Without this the slot would
+    // render at full size for the frames the texture request takes.
+    if (state.fadeStyle === 0) root.alpha = 0;
+    else {
+      const horizontal = state.fadeStyle >= 1 && state.fadeStyle <= 3;
+      state.maskSize = {
+        h: horizontal ? layout.maskH : 0,
+        w: horizontal ? 0 : layout.maskW,
+      };
+    }
     this.drawMask(state);
     this.slots.set(widgetId, state);
     return state;
@@ -398,7 +411,6 @@ export class CharacterCutinPanel {
   private addCharacter(
     state: CutinSlotState,
     art: CutinCharacterArt,
-    layout: CutinLayout,
     characterKey: string | undefined,
     expression: string | undefined,
     alpha: number,
@@ -406,14 +418,16 @@ export class CharacterCutinPanel {
     const sprite = new Sprite(art.texture);
     // The character keeps the hub's native layout: the sheet is scaled to
     // AVGCharacterSpriteHub.size (SetImage resizes the Image rect) and the
-    // art center lands at the mask-bottom-based slot position plus the hub
-    // pos. Show writes `_characterSlot.localPosition = (charOffsetX,
-    // charOffsetY - maskHeight / 2)`; the prefab's slot_character/offset
+    // art center lands at the slot node (`charSlot*`, pinned to the mask
+    // bottom by Show) plus the hub pos. The prefab's slot_character/offset
     // child ((0, 360) serialized) is zeroed by AVGCharacterSlot.Set's
     // resetOffsetPos before the hub pos is applied. Only the mask crops.
     sprite.anchor.set(0.5);
     sprite.scale.set(art.scaleX, art.scaleY);
-    sprite.position.set(layout.charX + art.offsetX, layout.charY - art.offsetY);
+    sprite.position.set(
+      state.charSlotX + art.offsetX,
+      state.charSlotY - art.offsetY,
+    );
     sprite.alpha = alpha;
     state.content.addChild(sprite);
     const char: CutinChar = {
@@ -459,14 +473,15 @@ export class CharacterCutinPanel {
         break;
       }
     }
+    const targetH = state.targetSize.h;
     let y: number;
     switch (state.fadeStyle) {
       case 5: {
-        y = -STORY_HEIGHT / 2;
+        y = -targetH / 2;
         break;
       }
       case 6: {
-        y = STORY_HEIGHT / 2 - h;
+        y = targetH / 2 - h;
         break;
       }
       default: {
@@ -484,24 +499,48 @@ export class CharacterCutinPanel {
  * `align = HORIZONTAL` (the vertical align flavor is unused by the corpus),
  * the slot center sits at screen center + (offsetx, offsety),
  * `_zoomAndPovRectTransform` gets localScale = `zoom` (renamed from `scale`
- * in 2.7.61) and anchoredPosition = (-povX, -povY). The character slot node
- * lands at (charOffsetX, charOffsetY - maskHeight / 2) -- i.e. the mask
- * bottom edge under the default 720-tall mask; AVGCharacterSpriteHub's own
- * pos/size (see CutinCharacterArt) then shift/scale each character art from
- * there. Unity's y-up local space is flipped to PIXI's y-down coordinates
- * here.
+ * in 2.7.61) and anchoredPosition = (-povX, -povY). Unity's y-up local space
+ * is flipped to PIXI's y-down coordinates here. (`charOffsetX`/`charOffsetY`
+ * live on the slot node instead -- see `CutinSlotState.charSlot*`.)
+ *
+ * `current` carries the SlotUpdate flavour @ 0x183eb20a0: there every key is
+ * read with the slot's live transform as its `GetFloat`/`GetInt` default
+ * (`GetInt(param, "width", (int)sizeDelta.x)`, `GetFloat(param, "offsetx",
+ * localPosition.x)`, ...), so an omitted key holds rather than resets. Show
+ * has no such slot state yet and falls back to the serialized prefab values.
+ *
+ * One native quirk is deliberately not ported: SlotUpdate computes povX as
+ * `-GetFloat("povX", anchoredPosition.x)`, and since anchoredPosition.x is
+ * already `-povX`, omitting the key flips its sign every update. Holding the
+ * current value is what the key's own default was reaching for; no corpus
+ * line hits the difference (0 SlotUpdates omit a pov the Show had set).
  */
-function layoutFor(input: CharacterCutinInput): CutinLayout {
+function layoutFor(
+  input: CharacterCutinInput,
+  current?: CutinLayout,
+): CutinLayout {
   const maskH = STORY_HEIGHT;
+  const fallback = current ?? {
+    contentX: 0,
+    contentY: 0,
+    maskW: DEFAULT_SLOT_WIDTH,
+    rootX: STORY_WIDTH / 2,
+    rootY: STORY_HEIGHT / 2,
+    zoom: 1,
+  };
   return {
-    charX: input.charOffsetX,
-    charY: maskH / 2 - input.charOffsetY,
-    contentX: -input.povX,
-    contentY: input.povY,
+    contentX: input.povX === undefined ? fallback.contentX : -input.povX,
+    contentY: input.povY === undefined ? fallback.contentY : input.povY,
     maskH,
-    maskW: input.width,
-    rootX: STORY_WIDTH / 2 + input.offsetX,
-    rootY: STORY_HEIGHT / 2 - input.offsetY,
-    zoom: input.zoom,
+    maskW: input.width ?? fallback.maskW,
+    rootX:
+      input.offsetX === undefined
+        ? fallback.rootX
+        : STORY_WIDTH / 2 + input.offsetX,
+    rootY:
+      input.offsetY === undefined
+        ? fallback.rootY
+        : STORY_HEIGHT / 2 - input.offsetY,
+    zoom: input.zoom ?? fallback.zoom,
   };
 }

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -556,7 +556,12 @@ export class StoryRuntime {
     }
 
     this.pendingInputEffect = null;
+    // Native port: both executors on AVGCharacterCutinPanel reset on skip --
+    // ShouldResetOnSkip() @ 0x183e492b0 returns true and _Reset @ 0x183e4af80
+    // empties the slot pool / _slots before resetting the interlude
+    // controller, so a skipped node must not leave cutin slots behind.
     await this.renderer.clearInterludes();
+    await this.renderer.clearCharacterCutin();
     await this.renderer.clearSpellStickers();
 
     this.cancelTyping();
@@ -1867,19 +1872,25 @@ export class StoryRuntime {
 
         const nameRef = toString(args.name).trim();
         const resolved = nameRef ? this.resolveCharacterName(nameRef) : null;
-        // Native port: Torappu.AVG.AVGCharacterCutinPanel._ExecuteCharacterCutin.
-        // Defaults come from the cutin slot's serialized fields
-        // (_defaultFadetime = 0.4, _defaultSlotWidth = 200), not from PRTS's
-        // 0.14 / 150. `block` really is the key here, unlike the rest of the
-        const fadeMs = Math.max(
-          0,
-          Math.round(toNumber(args.fadetime, 0.4) * 1000),
-        );
+        // Native port: Torappu.AVG.AVGCharacterCutinPanel._ExecuteCharacterCutin
+        // (build 2761: 0x183e49440). Defaults come from the cutin slot's
+        // serialized fields (_defaultFadetime = 0.4, _defaultSlotWidth = 200),
+        // not from PRTS's 0.14 / 150. `block` really is the key here, unlike
+        // the rest of the character family's `isblock`.
+        //
+        // AVGCharacterCutinSlot implements IFadeTimeRatio: every Show /
+        // SlotUpdate / Hide duration is `animateRatio * fadetime` (Show
+        // 0x183eb1320, SlotUpdate 0x183eb20a0, Hide 0x183eb0d80), so fadeMs
+        // must route through calculateFadeMs instead of a bare *1000.
+        const fadeMs = Math.round(this.calculateFadeMs(args.fadetime, 0.4));
         const block = toBoolean(args.block, false);
 
+        // Native: an unresolvable `name` still allocates the slot and runs
+        // its tween (AVGCharacterSlot logs its own error internally), so only
+        // the character art is missing while the block timing survives. Keep
+        // the warning for diagnostics and flag the renderer accordingly.
         if (nameRef && !resolved) {
           this.warn("missing_asset", `charactercutin: ${nameRef}`);
-          return "continue";
         }
 
         const fadeStyleRaw = toString(args.fadestyle).trim().toLowerCase();
@@ -1898,17 +1909,27 @@ export class StoryRuntime {
           ? (fadeStyleRaw as (typeof validFadeStyles)[number])
           : undefined;
 
+        // Native port: slot-layout keys are read verbatim by
+        // AVGCharacterCutinSlot.Show/SlotUpdate (0x183eb1320 / 0x183eb20a0).
+        // 2.7.61 renamed the slot scale key `scale` -> `zoom` (default 1);
+        // povX/povY/charOffsetX/charOffsetY keep their CamelCase spelling --
+        // native looks them up in a case-sensitive dictionary.
         await this.renderer.setCharacterCutin({
           block,
           characterKey: resolved?.base,
+          characterMissing: Boolean(nameRef) && !resolved,
+          charOffsetX: toNumber(args.charOffsetX, 0),
+          charOffsetY: toNumber(args.charOffsetY, 0),
           expression: resolved?.expression,
           fadeMs,
           fadeStyle,
-          height: toNumber(args.height, 540),
           offsetX: toNumber(args.offsetx, 0),
           offsetY: toNumber(args.offsety, 0),
+          povX: toNumber(args.povX, 0),
+          povY: toNumber(args.povY, 0),
           widgetId,
           width: toNumber(args.width, 200),
+          zoom: toNumber(args.zoom, 1),
         });
         return "continue";
       }

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1911,25 +1911,30 @@ export class StoryRuntime {
 
         // Native port: slot-layout keys are read verbatim by
         // AVGCharacterCutinSlot.Show/SlotUpdate (0x183eb1320 / 0x183eb20a0).
-        // 2.7.61 renamed the slot scale key `scale` -> `zoom` (default 1);
+        // 2.7.61 renamed the slot scale key `scale` -> `zoom`;
         // povX/povY/charOffsetX/charOffsetY keep their CamelCase spelling --
         // native looks them up in a case-sensitive dictionary.
+        //
+        // These stay `undefined` when absent rather than collapsing to a
+        // default here: Show and SlotUpdate disagree about what an omitted
+        // key means (prefab default vs. hold the slot's current value), and
+        // only the panel knows which branch it is on.
         await this.renderer.setCharacterCutin({
           block,
           characterKey: resolved?.base,
           characterMissing: Boolean(nameRef) && !resolved,
-          charOffsetX: toNumber(args.charOffsetX, 0),
-          charOffsetY: toNumber(args.charOffsetY, 0),
+          charOffsetX: toOptionalNumber(args.charOffsetX),
+          charOffsetY: toOptionalNumber(args.charOffsetY),
           expression: resolved?.expression,
           fadeMs,
           fadeStyle,
-          offsetX: toNumber(args.offsetx, 0),
-          offsetY: toNumber(args.offsety, 0),
-          povX: toNumber(args.povX, 0),
-          povY: toNumber(args.povY, 0),
+          offsetX: toOptionalNumber(args.offsetx),
+          offsetY: toOptionalNumber(args.offsety),
+          povX: toOptionalNumber(args.povX),
+          povY: toOptionalNumber(args.povY),
           widgetId,
-          width: toNumber(args.width, 200),
-          zoom: toNumber(args.zoom, 1),
+          width: toOptionalNumber(args.width),
+          zoom: toOptionalNumber(args.zoom),
         });
         return "continue";
       }

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -455,14 +455,31 @@ export type CharacterCutinFadeStyle =
 export interface CharacterCutinInput {
   block: boolean;
   characterKey?: string;
+  /**
+   * Native provenance: when `name` cannot be resolved, native still allocates
+   * the slot and runs its Show/SlotUpdate tween (only AVGCharacterSlot logs
+   * an internal error), so `block` timing must survive a missing character.
+   */
+  characterMissing?: boolean;
+  /**
+   * `_characterSlot.localPosition` keys; `charOffsetY` carries native's
+   * `- maskHeight / 2` correction in the renderer layout math.
+   */
+  charOffsetX: number;
+  charOffsetY: number;
   expression?: string;
+  /** `animateRatio * fadetime` in ms; AVGCharacterCutinSlot is IFadeTimeRatio. */
   fadeMs: number;
   fadeStyle?: CharacterCutinFadeStyle;
-  height: number;
   offsetX: number;
   offsetY: number;
+  /** `_zoomAndPovRectTransform.anchoredPosition = (-povX, -povY)`. */
+  povX: number;
+  povY: number;
   widgetId: string;
+  /** Mask size along the main axis; `_zoomAndPovRectTransform.localScale`. */
   width: number;
+  zoom: number;
 }
 
 export type InterludeElementType = 0 | 1 | 2 | 3;

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -462,24 +462,31 @@ export interface CharacterCutinInput {
    */
   characterMissing?: boolean;
   /**
+   * Slot-layout keys. `undefined` means the script omitted the key, which is
+   * load-bearing: Show falls back to the serialized prefab defaults, while
+   * SlotUpdate (@ 0x183eb20a0) passes the slot's live transform as each
+   * `GetFloat`/`GetInt` default, so an omitted key holds its current value
+   * instead of snapping back.
+   *
    * `_characterSlot.localPosition` keys; `charOffsetY` carries native's
-   * `- maskHeight / 2` correction in the renderer layout math.
+   * `- maskHeight / 2` correction in the renderer layout math. Only Show
+   * reads them -- SlotUpdate never touches the slot node.
    */
-  charOffsetX: number;
-  charOffsetY: number;
+  charOffsetX?: number;
+  charOffsetY?: number;
   expression?: string;
   /** `animateRatio * fadetime` in ms; AVGCharacterCutinSlot is IFadeTimeRatio. */
   fadeMs: number;
   fadeStyle?: CharacterCutinFadeStyle;
-  offsetX: number;
-  offsetY: number;
+  offsetX?: number;
+  offsetY?: number;
   /** `_zoomAndPovRectTransform.anchoredPosition = (-povX, -povY)`. */
-  povX: number;
-  povY: number;
+  povX?: number;
+  povY?: number;
   widgetId: string;
   /** Mask size along the main axis; `_zoomAndPovRectTransform.localScale`. */
-  width: number;
-  zoom: number;
+  width?: number;
+  zoom?: number;
 }
 
 export type InterludeElementType = 0 | 1 | 2 | 3;

--- a/tests/characterCutinPanel.spec.ts
+++ b/tests/characterCutinPanel.spec.ts
@@ -56,6 +56,18 @@ async function instantTween(
   complete?.();
 }
 
+/** A texture loader whose promise the test resolves by hand. */
+function deferredArt(): {
+  loadTexture: () => Promise<CutinCharacterArt>;
+  release: (value: CutinCharacterArt) => void;
+} {
+  let resolve!: (value: CutinCharacterArt) => void;
+  const pending = new Promise<CutinCharacterArt>((r) => {
+    resolve = r;
+  });
+  return { loadTexture: () => pending, release: (v) => resolve(v) };
+}
+
 /** Captures tween callbacks so tests can drive progress manually. */
 function captureTween() {
   const updates: Update[] = [];
@@ -260,8 +272,101 @@ describe("CharacterCutinPanel", () => {
     expect(state.maskSize).toEqual({ h: 720, w: 250 });
     expect(state.root.alpha).toBe(1);
     expect(state.chars).toHaveLength(1);
+    expect(state.chars[0].sprite.alpha).toBe(1);
     expect(loadTexture).toHaveBeenCalledTimes(1);
     expect(layer.children).toHaveLength(1);
+
+    // Drive the tween to completion: a same-key Set skips its whole swap
+    // branch in native, so the art must survive the update rather than being
+    // treated as an outgoing crossfade layer.
+    second.drive(0, 1);
+    expect(state.chars).toHaveLength(1);
+    expect(state.chars[0].sprite.alpha).toBe(1);
+    expect(state.chars[0].sprite.destroyed).toBe(false);
+  });
+
+  it("SlotUpdate keeps the art of a repeated name (story_hibisc_1_1.txt:350/360)", async () => {
+    const layer = new Container();
+    const loadTexture = vi.fn().mockResolvedValue(art(120, 300));
+    const panel = new CharacterCutinPanel(layer, loadTexture, instantTween);
+    // Both lines are byte-identical, including `fadetime=0` -- which makes the
+    // tween settle synchronously, so a mishandled crossfade drops the art on
+    // the spot instead of over 400ms.
+    const line = input({
+      fadeStyle: "horiz_expand_center",
+      offsetX: 300,
+      width: 200,
+    });
+
+    await panel.run(line);
+    await panel.run({ ...line });
+
+    const state = (panel as any).slots.get("1");
+    expect(state.chars).toHaveLength(1);
+    expect(state.chars[0].sprite.alpha).toBe(1);
+    // Set never re-loads for a matching key either.
+    expect(loadTexture).toHaveBeenCalledTimes(1);
+  });
+
+  it("SlotUpdate holds layout keys the command omits", async () => {
+    const layer = new Container();
+    const panel = new CharacterCutinPanel(
+      layer,
+      async () => art(120, 300),
+      instantTween,
+    );
+
+    await panel.run(input({ offsetX: -300, povX: -50, width: 400, zoom: 1.5 }));
+    // Native reads every layout key with the live transform as its default
+    // (`GetInt(param, "width", (int)sizeDelta.x)` etc.), so a name-only
+    // update must not animate the slot back to the prefab defaults.
+    await panel.run(
+      input({
+        expression: "2$2",
+        offsetX: undefined,
+        povX: undefined,
+        width: undefined,
+        zoom: undefined,
+      }),
+    );
+
+    const state = (panel as any).slots.get("1");
+    expect(state.root.x).toBe(340);
+    expect(state.maskSize).toEqual({ h: 720, w: 400 });
+    expect(state.content.x).toBe(50);
+    expect(state.content.scale.x).toBe(1.5);
+  });
+
+  it("does not render a full-size slot while the character texture loads", async () => {
+    const layer = new Container();
+    const { loadTexture, release } = deferredArt();
+    const panel = new CharacterCutinPanel(layer, loadTexture, instantTween);
+
+    const pending = panel.run(
+      input({ fadeMs: 400, fadeStyle: "horiz_expand_center" }),
+    );
+    // The slot is already in the scene graph, so whatever it looks like here
+    // is what renders for the frames the texture request takes.
+    const state = (panel as any).slots.get("1");
+    expect(state.maskSize).toEqual({ h: 720, w: 0 });
+
+    release(art(120, 300));
+    await pending;
+    expect(state.maskSize).toEqual({ h: 720, w: 200 });
+  });
+
+  it("does not render an opaque fade-style slot while the texture loads", async () => {
+    const layer = new Container();
+    const { loadTexture, release } = deferredArt();
+    const panel = new CharacterCutinPanel(layer, loadTexture, instantTween);
+
+    const pending = panel.run(input({ fadeMs: 400 }));
+    const state = (panel as any).slots.get("1");
+    expect(state.root.alpha).toBe(0);
+
+    release(art(120, 300));
+    await pending;
+    expect(state.root.alpha).toBe(1);
   });
 
   it("SlotUpdate crossfades to a new character over the tween duration", async () => {

--- a/tests/characterCutinPanel.spec.ts
+++ b/tests/characterCutinPanel.spec.ts
@@ -1,7 +1,10 @@
-import { Container, Rectangle, Texture } from "pixi.js";
+import { Container, Graphics, Rectangle, Texture } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 
-import { CharacterCutinPanel } from "../src/widgets/StoryPlayer/engine/rendering/panels/CharacterCutinPanel";
+import {
+  CharacterCutinPanel,
+  type CutinCharacterArt,
+} from "../src/widgets/StoryPlayer/engine/rendering/panels/CharacterCutinPanel";
 
 import type { CharacterCutinInput } from "../src/widgets/StoryPlayer/engine/types";
 
@@ -31,6 +34,17 @@ function input(
 
 function texture(width: number, height: number): Texture {
   return new Texture({ frame: new Rectangle(0, 0, width, height) });
+}
+
+/** Art descriptor with a no-op hub (identity pos/size), as texture() implies. */
+function art(width: number, height: number): CutinCharacterArt {
+  return {
+    offsetX: 0,
+    offsetY: 0,
+    scaleX: 1,
+    scaleY: 1,
+    texture: texture(width, height),
+  };
 }
 
 async function instantTween(
@@ -66,7 +80,7 @@ function captureTween() {
 describe("CharacterCutinPanel", () => {
   it("renders the character at original size in a full-height mask at screen center + offset", async () => {
     const layer = new Container();
-    const tex = texture(120, 300);
+    const tex = art(120, 300);
     const loadTexture = vi.fn().mockResolvedValue(tex);
     const panel = new CharacterCutinPanel(layer, loadTexture, instantTween);
 
@@ -83,13 +97,16 @@ describe("CharacterCutinPanel", () => {
     expect(state.maskSize).toEqual({ h: 720, w: 200 });
     expect(root.mask).toBe(state.mask);
 
-    const sprite = state.chars[0];
+    const sprite = state.chars[0].sprite;
     expect(sprite.anchor.x).toBe(0.5);
-    expect(sprite.anchor.y).toBe(1);
+    expect(sprite.anchor.y).toBe(0.5);
     // No stretching: the texture keeps its original scale, only the mask crops.
     expect(sprite.scale.x).toBe(1);
     expect(sprite.scale.y).toBe(1);
-    // charOffsetY = 0 parks the feet on the mask bottom (720 / 2).
+    // charOffsetY = 0 parks the slot node on the mask bottom (720 / 2); the
+    // hub pos of the character (see the hub test below) shifts the art from
+    // there. AVGCharacterSlot.Set zeroes the prefab's (0, 360) offset child
+    // before the hub pos applies.
     expect(sprite.x).toBe(0);
     expect(sprite.y).toBe(360);
     // fade style: alpha tween completed to 1 with the mask at full size.
@@ -100,7 +117,7 @@ describe("CharacterCutinPanel", () => {
     const layer = new Container();
     const panel = new CharacterCutinPanel(
       layer,
-      async () => texture(120, 300),
+      async () => art(120, 300),
       instantTween,
     );
 
@@ -120,8 +137,60 @@ describe("CharacterCutinPanel", () => {
     expect(state.content.scale.x).toBe(2);
     expect(state.content.x).toBe(50);
     expect(state.content.y).toBe(30);
-    expect(state.chars[0].x).toBe(5);
-    expect(state.chars[0].y).toBe(380);
+    expect(state.chars[0].sprite.x).toBe(5);
+    expect(state.chars[0].sprite.y).toBe(380);
+  });
+
+  it("applies the AVGCharacterSpriteHub pos/size on top of the slot position", async () => {
+    const layer = new Container();
+    // avg_486_espumo_1 (act12side_01_beg line 214): hub size 1210x1210 over a
+    // 1024x1024 sheet, pos (0, 110). Native: art center lands at
+    // charOffsetY - maskHeight/2 + pos.y = -250 (Unity y-up) -> PIXI +250.
+    const espumo: CutinCharacterArt = {
+      offsetX: 0,
+      offsetY: 110,
+      scaleX: 1210 / 1024,
+      scaleY: 1210 / 1024,
+      texture: texture(1024, 1024),
+    };
+    const panel = new CharacterCutinPanel(
+      layer,
+      async () => espumo,
+      instantTween,
+    );
+
+    await panel.run(input({ offsetX: -300, width: 200 }));
+
+    const state = (panel as any).slots.get("1");
+    const sprite = state.chars[0].sprite;
+    expect(sprite.y).toBe(250);
+    expect(sprite.x).toBe(0);
+    expect(sprite.scale.x).toBeCloseTo(1210 / 1024);
+    expect(sprite.scale.y).toBeCloseTo(1210 / 1024);
+  });
+
+  it("renders the #898989 defaultBackground strip behind the character", async () => {
+    const layer = new Container();
+    const panel = new CharacterCutinPanel(
+      layer,
+      async () => art(120, 300),
+      instantTween,
+    );
+
+    await panel.run(input({}));
+
+    const state = (panel as any).slots.get("1");
+    // _defualtBackground: under the mask (clipped), below the zoomAndPov
+    // content, static full-canvas rect -- revealed as the mask expands.
+    expect(state.backdrop).toBeInstanceOf(Graphics);
+    expect(state.root.mask).toBe(state.mask);
+    expect(state.root.children.indexOf(state.backdrop)).toBeLessThan(
+      state.root.children.indexOf(state.content),
+    );
+    // The backdrop is drawn once at full-canvas size; it never resizes with
+    // the mask (native rect is 2560x720, only the mask clips it).
+    expect(state.backdrop.scale.x).toBe(1);
+    expect(state.backdrop.scale.y).toBe(1);
   });
 
   it("expands the mask rect from the pinned edge instead of scaling the sprite", async () => {
@@ -129,7 +198,7 @@ describe("CharacterCutinPanel", () => {
     const { drive, tween } = captureTween();
     const panel = new CharacterCutinPanel(
       layer,
-      async () => texture(120, 300),
+      async () => art(120, 300),
       tween,
     );
 
@@ -145,8 +214,8 @@ describe("CharacterCutinPanel", () => {
     const state = (panel as any).slots.get("1");
     expect(state.maskSize).toEqual({ h: 720, w: 100 });
     expect(state.root.alpha).toBe(1);
-    expect(state.chars[0].scale.x).toBe(1);
-    expect(state.chars[0].x).toBe(0);
+    expect(state.chars[0].sprite.scale.x).toBe(1);
+    expect(state.chars[0].sprite.x).toBe(0);
 
     drive(0, 1);
     expect(state.maskSize).toEqual({ h: 720, w: 200 });
@@ -154,7 +223,7 @@ describe("CharacterCutinPanel", () => {
 
   it("SlotUpdate interpolates from the current layout instead of replaying the entry", async () => {
     const layer = new Container();
-    const loadTexture = vi.fn().mockResolvedValue(texture(120, 300));
+    const loadTexture = vi.fn().mockResolvedValue(art(120, 300));
     const first = captureTween();
     let active = first.tween;
     const panel = new CharacterCutinPanel(layer, loadTexture, (d, u, c) =>
@@ -197,8 +266,8 @@ describe("CharacterCutinPanel", () => {
 
   it("SlotUpdate crossfades to a new character over the tween duration", async () => {
     const layer = new Container();
-    const texA = texture(120, 300);
-    const texB = texture(140, 300);
+    const texA = art(120, 300);
+    const texB = art(140, 300);
     const loadTexture = vi.fn(async (cutin: CharacterCutinInput) =>
       cutin.expression === "2$2" ? texB : texA,
     );
@@ -218,13 +287,13 @@ describe("CharacterCutinPanel", () => {
 
     const state = (panel as any).slots.get("1");
     expect(state.chars).toHaveLength(2);
-    expect(state.chars[0].alpha).toBeCloseTo(0.5);
-    expect(state.chars[1].alpha).toBeCloseTo(0.5);
+    expect(state.chars[0].sprite.alpha).toBeCloseTo(0.5);
+    expect(state.chars[1].sprite.alpha).toBeCloseTo(0.5);
 
     second.drive(0, 1);
     expect(state.chars).toHaveLength(1);
-    expect(state.chars[0].texture).toBe(texB);
-    expect(state.chars[0].alpha).toBe(1);
+    expect(state.chars[0].sprite.texture).toBe(texB.texture);
+    expect(state.chars[0].sprite.alpha).toBe(1);
   });
 
   it("hide collapses the mask along the stored style and removes the slot", async () => {
@@ -232,7 +301,7 @@ describe("CharacterCutinPanel", () => {
     const { drive, tween } = captureTween();
     const panel = new CharacterCutinPanel(
       layer,
-      async () => texture(120, 300),
+      async () => art(120, 300),
       tween,
     );
 
@@ -272,7 +341,7 @@ describe("CharacterCutinPanel", () => {
     const { drive, tween } = captureTween();
     const panel = new CharacterCutinPanel(
       layer,
-      async () => texture(120, 300),
+      async () => art(120, 300),
       tween,
     );
 
@@ -327,7 +396,7 @@ describe("CharacterCutinPanel", () => {
     const layer = new Container();
     const panel = new CharacterCutinPanel(
       layer,
-      async () => texture(120, 300),
+      async () => art(120, 300),
       instantTween,
     );
 

--- a/tests/characterCutinPanel.spec.ts
+++ b/tests/characterCutinPanel.spec.ts
@@ -1,0 +1,344 @@
+import { Container, Rectangle, Texture } from "pixi.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { CharacterCutinPanel } from "../src/widgets/StoryPlayer/engine/rendering/panels/CharacterCutinPanel";
+
+import type { CharacterCutinInput } from "../src/widgets/StoryPlayer/engine/types";
+
+type Update = (progress: number) => void;
+
+function input(
+  overrides: Partial<CharacterCutinInput> = {},
+): CharacterCutinInput {
+  return {
+    block: true,
+    characterKey: "avg_test",
+    charOffsetX: 0,
+    charOffsetY: 0,
+    expression: "1$1",
+    fadeMs: 0,
+    fadeStyle: undefined,
+    offsetX: 0,
+    offsetY: 0,
+    povX: 0,
+    povY: 0,
+    widgetId: "1",
+    width: 200,
+    zoom: 1,
+    ...overrides,
+  };
+}
+
+function texture(width: number, height: number): Texture {
+  return new Texture({ frame: new Rectangle(0, 0, width, height) });
+}
+
+async function instantTween(
+  _durationMs: number,
+  update: Update,
+  complete?: () => void,
+): Promise<void> {
+  update(1);
+  complete?.();
+}
+
+/** Captures tween callbacks so tests can drive progress manually. */
+function captureTween() {
+  const updates: Update[] = [];
+  const completions: Array<() => void> = [];
+  const tween = async (
+    _durationMs: number,
+    update: Update,
+    complete?: () => void,
+  ): Promise<void> => {
+    updates.push(update);
+    completions.push(() => complete?.());
+  };
+  return {
+    drive(index: number, progress: number): void {
+      updates[index]!(progress);
+      if (progress >= 1) completions[index]!();
+    },
+    tween,
+  };
+}
+
+describe("CharacterCutinPanel", () => {
+  it("renders the character at original size in a full-height mask at screen center + offset", async () => {
+    const layer = new Container();
+    const tex = texture(120, 300);
+    const loadTexture = vi.fn().mockResolvedValue(tex);
+    const panel = new CharacterCutinPanel(layer, loadTexture, instantTween);
+
+    await panel.run(input({ offsetX: -300, offsetY: 40 }));
+
+    expect(layer.children).toHaveLength(1);
+    const root = layer.children[0]!;
+    // Slot center = screen center + (offsetx, offsety) (Unity y-up flipped).
+    expect(root.x).toBe(340);
+    expect(root.y).toBe(320);
+
+    const state = (panel as any).slots.get("1");
+    // Mask is width x full canvas height under the default align.
+    expect(state.maskSize).toEqual({ h: 720, w: 200 });
+    expect(root.mask).toBe(state.mask);
+
+    const sprite = state.chars[0];
+    expect(sprite.anchor.x).toBe(0.5);
+    expect(sprite.anchor.y).toBe(1);
+    // No stretching: the texture keeps its original scale, only the mask crops.
+    expect(sprite.scale.x).toBe(1);
+    expect(sprite.scale.y).toBe(1);
+    // charOffsetY = 0 parks the feet on the mask bottom (720 / 2).
+    expect(sprite.x).toBe(0);
+    expect(sprite.y).toBe(360);
+    // fade style: alpha tween completed to 1 with the mask at full size.
+    expect(root.alpha).toBe(1);
+  });
+
+  it("applies zoom, pov, and charOffset keys to the slot hierarchy", async () => {
+    const layer = new Container();
+    const panel = new CharacterCutinPanel(
+      layer,
+      async () => texture(120, 300),
+      instantTween,
+    );
+
+    await panel.run(
+      input({
+        charOffsetX: 5,
+        charOffsetY: -20,
+        povX: -50,
+        povY: 30,
+        zoom: 2,
+      }),
+    );
+
+    const state = (panel as any).slots.get("1");
+    // _zoomAndPovRectTransform: localScale = zoom, anchoredPosition =
+    // (-povX, -povY) in Unity y-up, flipped for PIXI.
+    expect(state.content.scale.x).toBe(2);
+    expect(state.content.x).toBe(50);
+    expect(state.content.y).toBe(30);
+    expect(state.chars[0].x).toBe(5);
+    expect(state.chars[0].y).toBe(380);
+  });
+
+  it("expands the mask rect from the pinned edge instead of scaling the sprite", async () => {
+    const layer = new Container();
+    const { drive, tween } = captureTween();
+    const panel = new CharacterCutinPanel(
+      layer,
+      async () => texture(120, 300),
+      tween,
+    );
+
+    await panel.run(
+      input({
+        block: false,
+        fadeMs: 100,
+        fadeStyle: "horiz_expand_left2right",
+      }),
+    );
+    drive(0, 0.5);
+
+    const state = (panel as any).slots.get("1");
+    expect(state.maskSize).toEqual({ h: 720, w: 100 });
+    expect(state.root.alpha).toBe(1);
+    expect(state.chars[0].scale.x).toBe(1);
+    expect(state.chars[0].x).toBe(0);
+
+    drive(0, 1);
+    expect(state.maskSize).toEqual({ h: 720, w: 200 });
+  });
+
+  it("SlotUpdate interpolates from the current layout instead of replaying the entry", async () => {
+    const layer = new Container();
+    const loadTexture = vi.fn().mockResolvedValue(texture(120, 300));
+    const first = captureTween();
+    let active = first.tween;
+    const panel = new CharacterCutinPanel(layer, loadTexture, (d, u, c) =>
+      active(d, u, c),
+    );
+
+    await panel.run(
+      input({
+        block: false,
+        fadeMs: 100,
+        fadeStyle: "horiz_expand_left2right",
+        offsetX: -300,
+      }),
+    );
+    first.drive(0, 1);
+
+    const second = captureTween();
+    active = second.tween;
+    await panel.run(
+      input({
+        block: false,
+        fadeMs: 100,
+        fadeStyle: "horiz_expand_left2right",
+        offsetX: 300,
+        width: 300,
+      }),
+    );
+    second.drive(0, 0.5);
+
+    const state = (panel as any).slots.get("1");
+    // Root glides 340 -> 940, mask width 200 -> 300; no fresh entry replay
+    // and no second sprite for the same character identity.
+    expect(state.root.x).toBe(640);
+    expect(state.maskSize).toEqual({ h: 720, w: 250 });
+    expect(state.root.alpha).toBe(1);
+    expect(state.chars).toHaveLength(1);
+    expect(loadTexture).toHaveBeenCalledTimes(1);
+    expect(layer.children).toHaveLength(1);
+  });
+
+  it("SlotUpdate crossfades to a new character over the tween duration", async () => {
+    const layer = new Container();
+    const texA = texture(120, 300);
+    const texB = texture(140, 300);
+    const loadTexture = vi.fn(async (cutin: CharacterCutinInput) =>
+      cutin.expression === "2$2" ? texB : texA,
+    );
+    const first = captureTween();
+    let active = first.tween;
+    const panel = new CharacterCutinPanel(layer, loadTexture, (d, u, c) =>
+      active(d, u, c),
+    );
+
+    await panel.run(input({ block: false, fadeMs: 100 }));
+    first.drive(0, 1);
+
+    const second = captureTween();
+    active = second.tween;
+    await panel.run(input({ block: false, expression: "2$2", fadeMs: 100 }));
+    second.drive(0, 0.5);
+
+    const state = (panel as any).slots.get("1");
+    expect(state.chars).toHaveLength(2);
+    expect(state.chars[0].alpha).toBeCloseTo(0.5);
+    expect(state.chars[1].alpha).toBeCloseTo(0.5);
+
+    second.drive(0, 1);
+    expect(state.chars).toHaveLength(1);
+    expect(state.chars[0].texture).toBe(texB);
+    expect(state.chars[0].alpha).toBe(1);
+  });
+
+  it("hide collapses the mask along the stored style and removes the slot", async () => {
+    const layer = new Container();
+    const { drive, tween } = captureTween();
+    const panel = new CharacterCutinPanel(
+      layer,
+      async () => texture(120, 300),
+      tween,
+    );
+
+    await panel.run(
+      input({
+        block: false,
+        fadeMs: 100,
+        fadeStyle: "horiz_expand_right2left",
+      }),
+    );
+    drive(0, 1);
+    expect((panel as any).slots.size).toBe(1);
+
+    await panel.run(
+      input({
+        block: false,
+        characterKey: undefined,
+        expression: undefined,
+        fadeMs: 100,
+        fadeStyle: undefined,
+      }),
+    );
+    drive(1, 0.5);
+
+    const state = (panel as any).slots.get("1");
+    expect(state.maskSize).toEqual({ h: 720, w: 100 });
+    expect(state.root.alpha).toBe(1);
+
+    drive(1, 1);
+    // Native b__0 @ 0x183e62c90 recycles the slot and drops the widgetID.
+    expect((panel as any).slots.has("1")).toBe(false);
+    expect(layer.children).toHaveLength(0);
+  });
+
+  it("hide of a fade-style slot tweens alpha back to zero", async () => {
+    const layer = new Container();
+    const { drive, tween } = captureTween();
+    const panel = new CharacterCutinPanel(
+      layer,
+      async () => texture(120, 300),
+      tween,
+    );
+
+    await panel.run(input({ block: false, fadeMs: 100 }));
+    drive(0, 1);
+
+    await panel.run(
+      input({
+        block: false,
+        characterKey: undefined,
+        expression: undefined,
+        fadeMs: 100,
+      }),
+    );
+    drive(1, 0.5);
+
+    const state = (panel as any).slots.get("1");
+    expect(state.root.alpha).toBeCloseTo(0.5);
+    expect(state.maskSize).toEqual({ h: 720, w: 200 });
+
+    drive(1, 1);
+    expect((panel as any).slots.has("1")).toBe(false);
+  });
+
+  it("still runs the show tween for an unresolvable name to keep block timing", async () => {
+    const layer = new Container();
+    const { drive, tween } = captureTween();
+    const tweenSpy = vi.fn(tween);
+    const loadTexture = vi.fn();
+    const panel = new CharacterCutinPanel(layer, loadTexture, tweenSpy);
+
+    await panel.run(
+      input({
+        block: false,
+        characterKey: undefined,
+        characterMissing: true,
+        expression: undefined,
+        fadeMs: 250,
+      }),
+    );
+
+    expect(tweenSpy).toHaveBeenCalledWith(250, expect.any(Function));
+    expect(loadTexture).not.toHaveBeenCalled();
+    const state = (panel as any).slots.get("1");
+    expect(state.chars).toHaveLength(0);
+
+    drive(0, 1);
+    expect((panel as any).slots.has("1")).toBe(true);
+  });
+
+  it("clear drops one widget or every slot", async () => {
+    const layer = new Container();
+    const panel = new CharacterCutinPanel(
+      layer,
+      async () => texture(120, 300),
+      instantTween,
+    );
+
+    await panel.run(input({ widgetId: "1" }));
+    await panel.run(input({ widgetId: "2" }));
+    panel.clear("1");
+    expect((panel as any).slots.has("1")).toBe(false);
+    expect((panel as any).slots.has("2")).toBe(true);
+
+    panel.clear();
+    expect((panel as any).slots.size).toBe(0);
+    expect(layer.children).toHaveLength(0);
+  });
+});

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1412,6 +1412,33 @@ describe("StoryRuntime", () => {
     ]);
   });
 
+  it("leaves omitted charactercutin layout keys undefined for the panel to resolve", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[charactercutin(widgetID="1",name="avg_npc_1#1",width=400)]',
+        '[charactercutin(widgetID="1",name="avg_npc_1#2")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // Show and SlotUpdate disagree about what an omitted key means (prefab
+    // default vs. hold the live value), so the runtime must not collapse the
+    // distinction by substituting 200 / 0 / 1 here.
+    expect(renderer.characterCutinCalls[0]).toMatchObject({ width: 400 });
+    expect(renderer.characterCutinCalls[1]).toMatchObject({
+      charOffsetX: undefined,
+      offsetX: undefined,
+      povX: undefined,
+      width: undefined,
+      zoom: undefined,
+    });
+  });
+
   it("keeps charactercutin block timing when the name cannot be resolved", async () => {
     const renderer = new FakeRenderer();
     const warnings: RuntimeWarning[] = [];

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -52,6 +52,7 @@ class FakeRenderer implements StoryRenderer {
   }> = [];
   characterCalls: CharacterSlotInput[] = [];
   characterCutinCalls: CharacterCutinInput[] = [];
+  clearCharacterCutinCalls: string[] = [];
   clearedSlots: Array<{ fadeMs?: number; slot?: string }> = [];
   clearItemsCalls: Array<{ block: boolean; fadeMs: number }> = [];
   clearCgItemCalls: Array<{
@@ -182,7 +183,8 @@ class FakeRenderer implements StoryRenderer {
     if (input) this.timerClearCalls.push(input);
   }
 
-  clearCharacterCutin(_widgetId?: string): Promise<void> {
+  clearCharacterCutin(widgetId?: string): Promise<void> {
+    this.clearCharacterCutinCalls.push(widgetId ?? "");
     return Promise.resolve();
   }
 
@@ -1373,6 +1375,85 @@ describe("StoryRuntime", () => {
         type: "parse",
       }),
     ]);
+  });
+
+  it("maps charactercutin slot layout keys and scales fadetime by animateRatio", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[charactercutin(widgetID="1",name="avg_npc_1#1",fadetime=0.4,offsetx=-300,offsety=25,width=220,zoom=1.5,povX=-50,povY=30,charOffsetX=5,charOffsetY=-10,fadestyle="horiz_expand_left2right",block=true)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { animateRatio: 0.5 },
+    );
+
+    await runtime.start();
+
+    expect(renderer.characterCutinCalls).toEqual([
+      {
+        block: true,
+        characterKey: "avg_npc_1",
+        characterMissing: false,
+        charOffsetX: 5,
+        charOffsetY: -10,
+        expression: "1$1",
+        fadeMs: 200,
+        fadeStyle: "horiz_expand_left2right",
+        offsetX: -300,
+        offsetY: 25,
+        povX: -50,
+        povY: 30,
+        widgetId: "1",
+        width: 220,
+        zoom: 1.5,
+      },
+    ]);
+  });
+
+  it("keeps charactercutin block timing when the name cannot be resolved", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[charactercutin(widgetID="1",name="avg_ghost#1",fadetime=0.5,block=true)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    // Native still allocates the slot and runs its tween for an unresolvable
+    // name; only the character art is absent.
+    expect(renderer.characterCutinCalls).toHaveLength(1);
+    expect(renderer.characterCutinCalls[0]).toMatchObject({
+      characterMissing: true,
+      fadeMs: 500,
+      widgetId: "1",
+    });
+    expect(warnings).toEqual([
+      expect.objectContaining({ type: "missing_asset" }),
+    ]);
+  });
+
+  it("clears charactercutin slots when skipping the story", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[charactercutin(widgetID="1",name="avg_npc_1",block=true)]',
+        '[skipnode(mode="skip")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+    await runtime.start();
+    await runtime.skipNode();
+    expect(renderer.clearCharacterCutinCalls).toEqual([""]);
   });
 
   it("maps interlude parameters and preserves the native channel default mismatch", async () => {


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `charactercutin` 命令移植中 review 出的全部可修复行为差异(P1×4、P2×3、P3×2),把渲染层从「拉伸贴图」改为对齐 native 的「原始尺寸 + mask 裁切」模型,并按实机对照完成两轮几何修正(`AVGCharacterSpriteHub` pos/size、`_defualtBackground` 灰条)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity 2021.3.39f1,IL2CPP)GameAssembly.dll 的逆向分析 + APK/PC 资源解包,关键结论(含 VA)在下文直接给出,不依赖外部文档。

## 背景:native 的 charactercutin 机制(2.7.61 / build 2761 IDA 反编译复核)

- `Torappu.AVG.AVGCharacterCutinPanel.GetExecutors` @ `0x183e48f70`:注册 `charactercutin` → `_ExecuteCharacterCutin` @ `0x183e49440`(全函数只读 `widgetID`/`block`/`name`),五分支:空 widgetID 报错返回;name 空 + slot 命中 → `Hide`;name 空 + 未命中 → 不渲染;name 非空 + 命中 → `SlotUpdate`;name 非空 + 未命中 → 池化新 slot 后 `Show`。
- `AVGCharacterCutinSlot.Show` @ `0x183eb1320`:立绘按 **hub 尺寸**渲染(见修复 11),由 `_maskRectTransform`(默认 `align=HORIZONTAL` 时为 `width × 全屏高 720`)裁切;slot 中心 = 屏幕中心 + `(offsetx, offsety)`;`_zoomAndPov.localScale = zoom`(**2.7.61 已把 key 从 `scale` 改名为 `zoom`**),`anchoredPosition = (-povX, -povY)`;`_characterSlot.localPosition = (charOffsetX, charOffsetY − maskHeight/2)`(slot 节点钉在 mask 底边;`AVGCharacterSlot.Set` 的 `resetOffsetPos` 会把 prefab 内 `slot_character/offset` 子节点的 (0,360) 序列化偏移清零,该偏移运行时不生效)。扩展式 fadestyle 动的是 mask 尺寸(pivot 钉在扩展起点),不是立绘缩放;`fade` 式动 CanvasGroup alpha。
- `AVGCharacterSlot.Set(name, duration, …)`:立绘切换带时长交叉过渡(prefab `image_one`/`image_two` 前后景),Show 用瞬时 `Set(name, 0.0, …)`、SlotUpdate 用带时长版本;`AVGCharacterSpriteHub` 按 hub 序列化数据设置 Image 的尺寸与位置(见修复 11)。
- `AVGCharacterCutinSlot.SlotUpdate` @ `0x183eb20a0`:**不重播入场动画**——以当前 `sizeDelta`/`localPosition`/`localScale`/`anchoredPosition` 为起点,单条 `DOTween.To` 把整个 slot 布局平滑插值到新值。
- `AVGCharacterCutinSlot.Hide` @ `0x183eb0d80`:只读 `fadetime`,按 slot 上最后一次 Show/Update 存的 `m_showFadeStyle` 反向收束(`fade` 动 alpha,扩展式把 mask 尺寸收回 0 且 alpha 保持 1);完成回调 `b__0` @ `0x183e62c90` **立即回收 slot 并从 `_slots` 移除**(2.7.61 行为,2.7.51 旧文档的"不移除"已过时)。
- 时长:slot 实现 `IFadeTimeRatio`,Show/SlotUpdate/Hide 一律 `duration = AVGController.animateRatio × fadetime`(默认 `fadetime=0.4`、`width=200` 来自序列化字段)。
- 生命周期:`ShouldResetOnSkip` @ `0x183e492b0` 返回 `true`;`_Reset` @ `0x183e4af80` 清空 slot 池与 `_slots`(interlude channel 一并清)。

## 修复内容

(编号对应本地 review 差异清单 + 实机对照追加项;native/前端行为列为结论摘录)

### 1. skip/重置不清 cutin slot(P1 #1)

- native:`ShouldResetOnSkip()=true`,`_Reset` 清空 slot 池 + `_slots`。前端 `skipNode()` 只调 `clearInterludes()`,`clearCharacterCutin` 全库无调用,skip 后 cutin 残留。
- 修复:`runtime.ts` `skipNode()` 在 `clearInterludes()` 后追加 `clearCharacterCutin()`(两个 executor 同属 `AVGCharacterCutinPanel`,与 interlude 一并清理)。按本次复核结论只给本 panel 开清理,未动其他 panel。

### 2. SlotUpdate 语义缺失(P1 #2)

- native:同 widgetID + 带 name → 从当前布局平滑插值到新布局,立绘按 duration 交叉淡入。前端销毁旧 sprite 后重跑完整入场动画,立绘瞬切。
- 修复:渲染层对已存在的 widgetID 走 `SlotUpdate` 路径:以当前 mask 尺寸/offset/zoom/pov 为起点单条 tween 插值到新值;立绘更换时新旧 sprite 在同一 tween 内交叉淡入(相同立绘跳过重挂,新旧立绘各用各的 hub 布局);被截断的 fade 式入场 alpha 在插值中收敛到 1(等价 native 并行 DOFade 收尾)。新入场动画只在 slot 不存在时播放。

### 3. fadeMs 未乘 animateRatio(P1 #3)

- native:Show/SlotUpdate/Hide 一律 `animateRatio × fadetime`。前端直接 `fadetime*1000`。
- 修复:改用现成的 `calculateFadeMs(args.fadetime, 0.4)`(即 `AVGUtils.CalculateFadetime` 的移植),自动播放/快速播放倍速现在对 cutin 生效。

### 4. 立绘拉伸而非裁切 + 竖直几何偏差(P1 #4)

- native:立绘原始尺寸渲染,mask 裁 `width × 720` 窗口,slot 中心 = 屏幕中心 + offset。前端把纹理拉伸进 `width × 540` 矩形,盒子中心 y 恒偏高 90px、窗口矮 180px、长宽比失真。
- 修复:新渲染层用「root 容器(槽中心)→ Graphics mask(`width × STORY_HEIGHT`,按 fadestyle pivot 钉边)→ zoom/pov 容器 → hub 尺寸 Sprite(中心锚点)」复刻 native 层级;扩展式动画改为插值 mask 矩形而非缩放置图。立绘最终定位 = 三层叠加(修复 11)。

### 5. slot 缩放 key 未实现(P2 #5)

- native:2.7.61 key 为 `zoom`(2.7.51 是 `scale`)→ `_zoomAndPov.localScale`。前端不读取。
- 修复:补 `zoom` 参数(用 2.7.61 新 key,不用历史文档的 `scale`),映射到 zoom/pov 容器的 scale,Show/SlotUpdate 均生效。

### 6. charOffsetX/charOffsetY(P2 #6)

- native:`_characterSlot.localPosition = (charOffsetX, charOffsetY − maskHeight/2)`,slot 节点钉在 mask 底边。前端未实现。
- 修复:补 `charOffsetX`/`charOffsetY`(CamelCase key 原样读取),按 2.7.61 公式换算为 mask 底边基准的 slot 节点位置。

### 7. name 解析失败时的行为(P2 #7)

- native:仍创建 slot 并执行 Show(block=true 时等待 tween 时长,资源缺失由 AVGCharacterSlot 内部报错)。前端 warn 后直接 continue,不渲染、不等待,丢失 block 时序。
- 修复:保留 `missing_asset` 警告,但带 `characterMissing` 标记继续走渲染层——slot 照常创建并按 fadetime 跑空动画,只有立绘缺席,block 时序与 native 一致。

### 8. povX/povY 未支持(P3 #8,按语料命中补全)

- native:`_zoomAndPovRectTransform.anchoredPosition = (-povX, -povY)`(CamelCase key)。前端忽略(2.7.51 语料 `povX` 8 次,现行语料仍有 6 个文件使用)。
- 修复:补 `povX`/`povY`,按取负 + y 翻转映射到 zoom/pov 容器位置。`align`/`background`/`backgroundOffset` 语料 0 命中,维持有意省略(默认灰条见修复 12)。

### 9. 自创 `height` key(P3 #9)

- native:不存在该参数。前端 `toNumber(args.height, 540)`(语料无此 key)。
- 修复:删除 `height` 参数与类型字段;裁切窗口副轴恒为全屏高 720(修复 4),与 native 一致。

### 10. tween 竞争处理(P3 #10)

- native 不 DOKill 旧 tween;前端 sessionId 守卫是更安全的超集,语义兼容——**维持现状**,并在 SlotUpdate 中复用该守卫冻结被截断的旧 tween。

### 11. 立绘漏套 `AVGCharacterSpriteHub` pos/size(实机对照追加)

- native:立绘 Image 的最终几何**不在 cutin 代码里**——`AVGCharacterSlot._LoadImage` @ `0x183eb4f60` → `AVGCharacterSpriteHub.SetImage` @ `0x183ec89d0` → `_PickSetImageImpl` @ `0x183ec8cc0` → `_SetImage` @ `0x183ec8f50` 调用 `GUIUtils.AssignLocalSettings(imageRect, hubRect)`,把 hub 自身 RectTransform 的 size/pos **整份拷贝到立绘 Image 上**。每个角色 hub 数据不同(如 `avg_486_espumo_1` = `size 1210×1210 / pos (0,110)`,底层贴图 1024×1024)。
- 症状:act12side_01_beg 214 行(Espumo cutin)与实机对照,前端先后出现下半身 / 偏低 110px / 偏高 250px 三轮偏差——前两轮是 slot 几何理解错,第三轮才定位到缺 hub 层。完整链:立绘中心(mask 中心系,y-up)= `charOffsetY − maskHeight/2 + hub.pos.y`。
- 修复:`textureForCutinCharacter` 返回 `CutinCharacterArt` 描述符(`scale = hub.size / texture 尺寸`、`offset = hub.pos`,数据源与正常 `character` 命令的 linkMap 同源);panel 内每个立绘 sprite 携带自己的 hub 布局(交叉淡入时新旧立绘各用各的),slot 节点保持 mask 底边基准。实机对照位置一致。

### 12. 立绘身后的灰色背景条(实机对照追加)

- native:cutin prefab `mask` 节点下第一个孩子是 `defaultBackground`(Image,`sprite_white`,color (0.537,0.537,0.537,1) = #898989,2560×720);`Show` 在 `background` key 为空时激活它、停用 `background` 节点(两者互斥,`background` 非空时加载 Sprite 按宽高比重排)。灰条在 mask 下、`zoomAndPov` 旁(不随 zoom/pov),被 200×720 mask 裁成立绘身后的灰竖条,随 mask 扩展动画露出。prefab 依据:2.7.51 APK 与 2.7.61 PC(经启动器 CDN 拉取 `Arknights_Data/level1`)逐字段一致。
- 修复:`createSlot` 加静态全屏 `#898989` backdrop Graphics(挂在 root 下、mask 裁切内、content 之下,不参与任何 tween/缩放)。`background` key(语料 0 命中)与其 `header` 装饰(黑色 70%,序列化位置在 mask 顶之外、实际不可见)维持省略。

## 实现结构

渲染从 `PixiStoryRenderer` 内联实现(约 230 行)抽出为 `engine/rendering/panels/CharacterCutinPanel.ts`,与同源 native panel 的 `InterludePanel` 并列;`setCharacterCutin`/`clearCharacterCutin` 委托给 panel,立绘资源解析(linkMap → expression → assetKey → hub pos/size)保留在 renderer 层。每个行为点均带 Native provenance 注释(函数名 + VA)。

## 验证用剧情文件

生产剧情文件位于本地 `torappu/storage/asset/gamedata/latest/story`:

- **修复 2/3/4/8/11(Show + SlotUpdate 序列、povX、时长、hub 几何)**:`obt/main/level_main_12-09_end.txt` 12-87 行——第 12 行 Show(widgetID="1",povX=-50,offsetx=-300)、第 15 行 Show(widgetID="2",offsetx=300)、第 17 行起同 widgetID 带 name 的 SlotUpdate 链(`fadetime=0` 立绘连切)、第 20/21/37/38/86/87 行 Hide。验证:双槽并立、SlotUpdate 平滑换立绘不再重播展开动画、povX 生效。
- **修复 4/8/11/12(展开几何 + hub 几何 + 灰条,已实机对照)**:`activities/act12side/level_act12side_01_beg.txt` 214/237/277/297 行——`horiz_expand_center` 完整 Show/Hide/SlotUpdate 生命周期(Show `avg_486_espumo_1` → Hide → SlotUpdate `avg_486_espumo_1#1` → Hide)。214 行与游戏截图逐像素对照:立绘位置(头距条带顶 ~64px、露出上半身)、灰色背景条均一致。
- **修复 8(povX)**:`obt/main/level_st_14-01.txt` 896 行(povX=-50)、`activities/act30side/level_act30side_03_beg.txt` 213 行(povX=-50,offsetx=-300)。验证:立绘在条带内按 pov 偏移。
- **修复 1(skip 清 cutin)**:语料中没有任何文件同时含 `[CharacterCutin]` 与 `[skipnode]`,**前瞻对齐,由单测锁定**——`tests/runtime.spec.ts` `clears charactercutin slots when skipping the story`。
- **修复 5/6(zoom/charOffset)**:语料 0 命中,**前瞻对齐,由单测锁定**——`tests/characterCutinPanel.spec.ts` `applies zoom, pov, and charOffset keys to the slot hierarchy`、`tests/runtime.spec.ts` `maps charactercutin slot layout keys and scales fadetime by animateRatio`。
- **修复 7(name 解析失败)**:生产语料所有 name 均可解析,**由单测锁定**——`tests/characterCutinPanel.spec.ts` `still runs the show tween for an unresolvable name to keep block timing`、`tests/runtime.spec.ts` `keeps charactercutin block timing when the name cannot be resolved`。
- **修复 3(animateRatio)**:倍速播放任意含 cutin 的剧情(如上 `level_main_12-09_end.txt`)对比淡入节奏即可;单测 `maps charactercutin slot layout keys and scales fadetime by animateRatio` 以 `animateRatio: 0.5` 锁定数值。
- **修复 11(hub pos/size)**:`tests/characterCutinPanel.spec.ts` `applies the AVGCharacterSpriteHub pos/size on top of the slot position`(Espumo 实测数据:y=250、scale=1210/1024)。
- **修复 12(灰条)**:`tests/characterCutinPanel.spec.ts` `renders the #898989 defaultBackground strip behind the character`。

## 测试

- `pnpm test`:21 个文件 245 个用例全部通过(基线 222,新增 23:CharacterCutinPanel 11 + runtime cutin 相关 3 + 既有回归)。
- `pnpm exec vue-tsc --noEmit`:通过。
- `pnpm exec eslint <改动文件>`:通过。
