### PR TITLE
fix(story-player): subtitle 自动播放推进、skip 清场与淡入/换行/逐行对齐对齐 native

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -112,6 +112,21 @@ function easeOutCubic(progress: number): number {
 }
 
 /**
+ * Native `Torappu.AVG.AVGTypeWriterText.BeginText` hides the unrevealed tail
+ * behind a fully transparent `<color=#00000000>` span so the whole message is
+ * laid out (and wrapped) from t0 -- revealing characters never re-wraps the
+ * lines already on screen.
+ */
+const SUBTITLE_HIDDEN_TAIL_COLOR = "#00000000";
+
+function subtitleHiddenTail(chars: RichChar[]): RichChar[] {
+  return chars.map(({ char }) => ({
+    char,
+    color: SUBTITLE_HIDDEN_TAIL_COLOR,
+  }));
+}
+
+/**
  * Canvas 渲染分辨率：逻辑坐标系固定 1280x720，实际像素数按宿主 CSS 尺寸
  * × devicePixelRatio 反推，避免画布被 CSS 拉伸发糊。取宽高比例的较大值，
  * 宿主短暂偏离 16:9 时也不会欠采样。
@@ -310,6 +325,12 @@ export class PixiStoryRenderer implements StoryRenderer {
   >();
   private readonly stickerTypingSessionIds = new Map<string, number>();
   private subtitleFadeSessionId = 0;
+  /**
+   * Native port: `SubtitlePanel._SetHiddenInternal`'s `m_hidden`. Flips the
+   * moment `set_isHidden` is called, while the alpha tween catches up. A
+   * `setSubtitle` on an already-shown panel must not replay the fade-in.
+   */
+  private subtitleHidden = true;
   private subtitleText: Text | null = null;
   private subtitleTypingTarget: {
     alignment: SubtitleInput["alignment"];
@@ -492,6 +513,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.stickerTypingTargets.clear();
     this.stickerTypingSessionIds.clear();
     this.subtitleFadeSessionId += 1;
+    this.subtitleHidden = true;
     this.subtitleTypingTarget = null;
     this.subtitleTypingSessionId += 1;
     this.stickerRichChars.clear();
@@ -1791,6 +1813,9 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.subtitleTypingSessionId += 1;
     this.subtitleFadeSessionId += 1;
     this.subtitleTypingTarget = null;
+    // Native `set_isHidden(true)` flips `m_hidden` immediately; the fade only
+    // animates the visible alpha towards it.
+    this.subtitleHidden = true;
 
     const subtitle = this.subtitleText;
     if (!subtitle) return;
@@ -2260,20 +2285,28 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.subtitleTypingSessionId += 1;
     this.subtitleFadeSessionId += 1;
     this.subtitleTypingTarget = null;
-    subtitle.alpha = 0;
-    subtitle.visible = true;
 
-    const fadeSessionId = this.subtitleFadeSessionId;
-    void this.tween(
-      150,
-      (progress) => {
-        if (this.subtitleFadeSessionId === fadeSessionId)
-          subtitle.alpha = progress;
-      },
-      () => {
-        if (this.subtitleFadeSessionId === fadeSessionId) subtitle.alpha = 1;
-      },
-    );
+    // Native `SubtitlePanel._SetHiddenInternal` (2.7.61 VA 0x183e94ff0):
+    // `set_isHidden(false)` is a no-op while the panel is already visible, so
+    // consecutive subtitles swap text seamlessly without replaying the 150ms
+    // Linear fade-in. A hidden panel fades in from its current alpha, which
+    // also covers interrupting an in-flight fade-out (DOKill + DOFade).
+    if (this.subtitleHidden) {
+      this.subtitleHidden = false;
+      const startAlpha = subtitle.visible ? subtitle.alpha : 0;
+      subtitle.visible = true;
+      const fadeSessionId = this.subtitleFadeSessionId;
+      void this.tween(
+        150,
+        (progress) => {
+          if (this.subtitleFadeSessionId === fadeSessionId)
+            subtitle.alpha = startAlpha + (1 - startAlpha) * progress;
+        },
+        () => {
+          if (this.subtitleFadeSessionId === fadeSessionId) subtitle.alpha = 1;
+        },
+      );
+    }
 
     const prevChars: RichChar[] = [];
     const newChars = parseRichChars(input.text);
@@ -2281,7 +2314,17 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     const colors = collectColors(allChars);
     const style = this.createOverlayTextStyle(input.sizePx, input.widthPx);
-    if (colors.length > 0) style.tagStyles = buildTagStyles(colors);
+    // Native maps alignment to TextAnchor.UpperLeft/UpperCenter/UpperRight,
+    // which horizontally aligns *every wrapped line* inside the width box;
+    // PIXI needs the per-line `align` style in addition to the whole-block
+    // offset that layoutSubtitle applies.
+    style.align = input.alignment;
+    // The transparent hidden tail below needs its tag registered while typing.
+    const tagStyles = buildTagStyles([
+      ...colors,
+      ...(input.delayMs > 0 ? [SUBTITLE_HIDDEN_TAIL_COLOR] : []),
+    ]);
+    if (Object.keys(tagStyles).length > 0) style.tagStyles = tagStyles;
     subtitle.style = style;
     subtitle.y = input.y;
 
@@ -2289,11 +2332,20 @@ export class PixiStoryRenderer implements StoryRenderer {
     if (input.delayMs <= 0) {
       subtitle.text = fullText;
       this.layoutSubtitle(subtitle, input.x, input.widthPx, input.alignment);
+      // Nothing to type: the typewriter is done the moment the text is shown.
+      input.onTypingComplete?.();
       return;
     }
 
     const sessionId = this.subtitleTypingSessionId;
-    subtitle.text = richCharsToTaggedText(prevChars);
+    // Native `AVGTypeWriterText.BeginText` lays out the full message from t0
+    // by keeping the unrevealed tail in the text wrapped in a fully
+    // transparent <color=#00000000> span; revealing chars never re-wraps the
+    // lines that are already on screen.
+    subtitle.text = richCharsToTaggedText([
+      ...prevChars,
+      ...subtitleHiddenTail(newChars),
+    ]);
     this.layoutSubtitle(subtitle, input.x, input.widthPx, input.alignment);
     this.subtitleTypingTarget = {
       alignment: input.alignment,
@@ -2305,8 +2357,9 @@ export class PixiStoryRenderer implements StoryRenderer {
       alignment: input.alignment,
       baseX: input.x,
       delayMs: input.delayMs,
-      prevChars,
       newChars,
+      onTypingComplete: input.onTypingComplete,
+      prevChars,
       widthPx: input.widthPx,
     });
   }
@@ -3776,8 +3829,9 @@ export class PixiStoryRenderer implements StoryRenderer {
       alignment: SubtitleInput["alignment"];
       baseX: number;
       delayMs: number;
-      prevChars: RichChar[];
       newChars: RichChar[];
+      onTypingComplete?: () => void;
+      prevChars: RichChar[];
       widthPx: number;
     },
   ): Promise<void> {
@@ -3788,9 +3842,12 @@ export class PixiStoryRenderer implements StoryRenderer {
 
       if (!this.app || this.subtitleTypingSessionId !== sessionId) return;
 
+      // The transparent tail keeps the full-text line layout fixed while the
+      // visible prefix grows (native BeginText hidden-string port).
       subtitle.text = richCharsToTaggedText([
         ...input.prevChars,
         ...input.newChars.slice(0, index + 1),
+        ...subtitleHiddenTail(input.newChars.slice(index + 1)),
       ]);
       this.layoutSubtitle(
         subtitle,
@@ -3800,8 +3857,13 @@ export class PixiStoryRenderer implements StoryRenderer {
       );
     }
 
-    if (this.subtitleTypingSessionId === sessionId)
+    if (this.subtitleTypingSessionId === sessionId) {
       this.subtitleTypingTarget = null;
+      // Native `SubtitlePanel._OnTypeWriterEnd` (2.7.61 VA 0x183e94e80):
+      // typing that finishes on its own raises the auto click; without this,
+      // auto mode would sit on the subtitle waiting for a manual click.
+      input.onTypingComplete?.();
+    }
   }
 
   private async runStickerTyping(

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -23,6 +23,7 @@ import {
 import {
   buildTagStyles,
   collectColors,
+  colorTagName,
   parseRichChars,
   richCharsToTaggedText,
   type RichChar,
@@ -118,6 +119,21 @@ function easeOutCubic(progress: number): number {
  * lines already on screen.
  */
 const SUBTITLE_HIDDEN_TAIL_COLOR = "#00000000";
+const SUBTITLE_HIDDEN_TAIL_TAG = colorTagName(SUBTITLE_HIDDEN_TAIL_COLOR);
+
+/**
+ * Web-only counterpart to the transparent tail: PIXI's tagged-text drop shadow
+ * pass forces an opaque fill (`CanvasTextGenerator._setupDropShadow`) and never
+ * reads the run's own fill, so an `alpha = 0` run still casts the style's
+ * shadow -- the "hidden" tail would read as legible grey ghost text. Unity
+ * modulates its shadow by vertex alpha instead, so native has nothing to turn
+ * off here. Disabling the shadow per tag hits PIXI's own skip branch and leaves
+ * the measured layout byte-identical.
+ */
+const SUBTITLE_HIDDEN_TAIL_STYLE = {
+  dropShadow: false,
+  fill: SUBTITLE_HIDDEN_TAIL_COLOR,
+} as const;
 
 function subtitleHiddenTail(chars: RichChar[]): RichChar[] {
   return chars.map(({ char }) => ({
@@ -2283,7 +2299,6 @@ export class PixiStoryRenderer implements StoryRenderer {
     if (!subtitle) return;
 
     this.subtitleTypingSessionId += 1;
-    this.subtitleFadeSessionId += 1;
     this.subtitleTypingTarget = null;
 
     // Native `SubtitlePanel._SetHiddenInternal` (2.7.61 VA 0x183e94ff0):
@@ -2291,10 +2306,17 @@ export class PixiStoryRenderer implements StoryRenderer {
     // consecutive subtitles swap text seamlessly without replaying the 150ms
     // Linear fade-in. A hidden panel fades in from its current alpha, which
     // also covers interrupting an in-flight fade-out (DOKill + DOFade).
+    //
+    // The fade session is only bumped when a fade actually starts: native's
+    // no-op branch never reaches DOKill either, so a fade-in that is still
+    // running when the next subtitle arrives must keep animating to 1. Bumping
+    // it unconditionally would orphan that tween and strand the panel at
+    // whatever alpha it had reached.
     if (this.subtitleHidden) {
       this.subtitleHidden = false;
       const startAlpha = subtitle.visible ? subtitle.alpha : 0;
       subtitle.visible = true;
+      this.subtitleFadeSessionId += 1;
       const fadeSessionId = this.subtitleFadeSessionId;
       void this.tween(
         150,
@@ -2319,11 +2341,12 @@ export class PixiStoryRenderer implements StoryRenderer {
     // PIXI needs the per-line `align` style in addition to the whole-block
     // offset that layoutSubtitle applies.
     style.align = input.alignment;
-    // The transparent hidden tail below needs its tag registered while typing.
-    const tagStyles = buildTagStyles([
-      ...colors,
-      ...(input.delayMs > 0 ? [SUBTITLE_HIDDEN_TAIL_COLOR] : []),
-    ]);
+    // The transparent hidden tail below needs its tag registered while typing,
+    // with the drop shadow disabled so the unrevealed text stays invisible.
+    const tagStyles: NonNullable<TextStyle["tagStyles"]> =
+      buildTagStyles(colors);
+    if (input.delayMs > 0)
+      tagStyles[SUBTITLE_HIDDEN_TAIL_TAG] = { ...SUBTITLE_HIDDEN_TAIL_STYLE };
     if (Object.keys(tagStyles).length > 0) style.tagStyles = tagStyles;
     subtitle.style = style;
     subtitle.y = input.y;

--- a/src/widgets/StoryPlayer/engine/richtext.ts
+++ b/src/widgets/StoryPlayer/engine/richtext.ts
@@ -51,7 +51,7 @@ export function collectColors(chars: RichChar[]): string[] {
   return result;
 }
 
-function colorTagName(color: string): string {
+export function colorTagName(color: string): string {
   return `_c${color.replace("#", "")}`;
 }
 

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -745,6 +745,10 @@ export class StoryRuntime {
     await this.renderer.clearInterludes();
     await this.renderer.clearCharacterCutin();
     await this.renderer.clearSpellStickers();
+    // Native: SubtitlePanel.ShouldResetOnSkip() is true, so a skip resets the
+    // panel through OnReset -- alpha to 0 immediately (no tween) plus a
+    // typewriter reset. A stale subtitle must not survive the skip.
+    await this.renderer.clearSubtitle(0);
 
     this.cancelTyping();
     if (shouldResume) {
@@ -2551,11 +2555,19 @@ export class StoryRuntime {
         if (x < 0 || x > 1280 || y < 0 || y > 720) return "continue";
 
         this.displayedLineIndex = line.lineNumber;
+        // Native `_OnTypeWriterEnd` (2.7.61 VA 0x183e94e80) raises the auto
+        // click with the subtitle's own `typeWriter.messageLength`. Track the
+        // subtitle in the shared typing state so auto mode both advances when
+        // typing ends naturally and waits for the subtitle's length instead of
+        // the previous dialogue's leftovers.
+        this.cancelTyping();
+        this.currentMessageLength = parseRichChars(text).length;
         await this.renderer.setSubtitle({
           alignment:
             this.parseSubtitleAlignment(this.exactArg(args, "alignment")) ??
             "left",
           delayMs: this.getCurrentSpeed().typeWriterDelayMs,
+          onTypingComplete: () => this.onTypingComplete(),
           sizePx: toNumber(this.exactArg(args, "size"), 24),
           text,
           widthPx: Math.min(

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -2560,6 +2560,11 @@ export class StoryRuntime {
         // subtitle in the shared typing state so auto mode both advances when
         // typing ends naturally and waits for the subtitle's length instead of
         // the previous dialogue's leftovers.
+        //
+        // `get_messageLength` (VA 0x183ed87e0) returns `m_message.Length` on
+        // the raw, still-marked-up string, so native also bills the
+        // `<color=#......>` characters. We count visible characters instead,
+        // matching how the dialogue path fills `currentMessageLength`.
         this.cancelTyping();
         this.currentMessageLength = parseRichChars(text).length;
         await this.renderer.setSubtitle({

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -389,6 +389,15 @@ export interface CgItemInput {
 export interface SubtitleInput {
   alignment: "center" | "left" | "right";
   delayMs: number;
+  /**
+   * Native port: `Torappu.AVG.SubtitlePanel._OnTypeWriterEnd` (2.7.61 VA
+   * 0x183e94e80). Invoked exactly once when the subtitle typewriter finishes
+   * on its own (or shows instantly with `delayMs <= 0`) so the runtime can
+   * run its `RaiseAutoClick(typeWriter.messageLength)` equivalent. The
+   * click-to-finish path never invokes it -- native `_OnClicked` ->
+   * `TryFinish()` is driven by the runtime's own click handler.
+   */
+  onTypingComplete?: () => void;
   sizePx: number;
   text: string;
   widthPx: number;

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1703,15 +1703,21 @@ describe("PixiStoryRenderer blocker", () => {
 
 function createSubtitleRenderer() {
   const renderer = new PixiStoryRenderer(createContext()) as any;
+  const manual = createManualClock();
+  renderer.tweenRunner = new TweenRunner(() => true, manual.clock);
   renderer.subtitleText = new Text({
     style: renderer.createOverlayTextStyle(24, 1280),
     text: "",
   });
   renderer.subtitleText.visible = false;
   renderer.app = {};
-  renderer.tween = vi.fn(async () => {});
   renderer.layoutSubtitle = vi.fn();
-  return renderer;
+  // Count the fades, but keep the real runner behind the spy: stubbing the
+  // tween out entirely hides whether the alpha ever reaches its terminal value.
+  const original = renderer.tween.bind(renderer);
+  const tween = vi.fn((...args: unknown[]) => original(...args));
+  renderer.tween = tween;
+  return { manual, renderer, tween };
 }
 
 describe("PixiStoryRenderer subtitle", () => {
@@ -1726,33 +1732,58 @@ describe("PixiStoryRenderer subtitle", () => {
   };
 
   it("fades a hidden subtitle in but never replays the fade for consecutive ones", async () => {
-    const renderer = createSubtitleRenderer();
+    const { manual, renderer, tween } = createSubtitleRenderer();
     const subtitle = renderer.subtitleText;
 
     await renderer.setSubtitle({ ...baseInput });
     expect(subtitle.visible).toBe(true);
-    expect(renderer.tween).toHaveBeenCalledTimes(1);
-    expect(renderer.tween.mock.calls[0][0]).toBe(150);
+    expect(tween).toHaveBeenCalledTimes(1);
+    expect(tween.mock.calls[0][0]).toBe(150);
+    manual.advance(150);
+    manual.drainFrame();
+    expect(subtitle.alpha).toBe(1);
 
-    renderer.tween.mockClear();
+    tween.mockClear();
     await renderer.setSubtitle({ ...baseInput, text: "world" });
     // Native `_SetHiddenInternal`: set_isHidden(false) is a no-op while the
     // panel is already visible -- seamless text swap, no second fade-in.
-    expect(renderer.tween).not.toHaveBeenCalled();
+    expect(tween).not.toHaveBeenCalled();
     expect(subtitle.text).toBe("world");
+    expect(subtitle.alpha).toBe(1);
 
     // After a real hide, the next subtitle fades in again.
     await renderer.clearSubtitle(0);
     expect(subtitle.visible).toBe(false);
     await renderer.setSubtitle({ ...baseInput, text: "again" });
-    expect(renderer.tween).toHaveBeenCalledTimes(1);
+    expect(tween).toHaveBeenCalledTimes(1);
     expect(subtitle.text).toBe("again");
+  });
+
+  it("lets an interrupted fade-in finish instead of stranding the alpha", async () => {
+    const { manual, renderer, tween } = createSubtitleRenderer();
+    const subtitle = renderer.subtitleText;
+
+    await renderer.setSubtitle({ ...baseInput });
+    manual.advance(30);
+    manual.drainFrame();
+    expect(subtitle.alpha).toBeCloseTo(0.2);
+
+    // quick_play schedules its auto click 25-100ms apart, so the next subtitle
+    // routinely lands inside the 150ms fade. Native's no-op set_isHidden(false)
+    // never reaches DOKill, so the running DOFade keeps going to 1.
+    await renderer.setSubtitle({ ...baseInput, text: "world" });
+    expect(tween).toHaveBeenCalledTimes(1);
+    for (let i = 0; i < 4; i += 1) {
+      manual.advance(50);
+      manual.drainFrame();
+    }
+    expect(subtitle.alpha).toBe(1);
   });
 
   it("types against a transparent tail so the full-text layout is fixed from t0", async () => {
     vi.useFakeTimers();
     try {
-      const renderer = createSubtitleRenderer();
+      const { renderer } = createSubtitleRenderer();
       const onTypingComplete = vi.fn();
 
       const pending = renderer.setSubtitle({
@@ -1764,6 +1795,13 @@ describe("PixiStoryRenderer subtitle", () => {
       // t0 already carries the whole message as a hidden span, so wrapping
       // matches the final layout instead of re-flowing per character.
       expect(subtitle.text).toBe("<_c00000000>hello</_c00000000>");
+      // PIXI's tagged-text shadow pass forces an opaque fill and ignores the
+      // run's own, so the tail has to opt out of the drop shadow or every
+      // unrevealed character shows up as legible grey ghosting.
+      expect(subtitle.style.tagStyles._c00000000).toEqual({
+        dropShadow: false,
+        fill: "#00000000",
+      });
       await vi.advanceTimersByTimeAsync(10);
       expect(subtitle.text).toBe("h<_c00000000>ello</_c00000000>");
       await vi.advanceTimersByTimeAsync(40);
@@ -1778,7 +1816,7 @@ describe("PixiStoryRenderer subtitle", () => {
   });
 
   it("reports instant subtitles as finished and applies per-line alignment", async () => {
-    const renderer = createSubtitleRenderer();
+    const { renderer } = createSubtitleRenderer();
     const onTypingComplete = vi.fn();
 
     await renderer.setSubtitle({

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1,6 +1,7 @@
 import {
   Container,
   Sprite,
+  Text,
   Texture,
   TextureSource,
   TilingSprite,
@@ -1697,5 +1698,98 @@ describe("PixiStoryRenderer blocker", () => {
     expect(renderer.blockerSlideFilter).toBe(filter);
     // The instant color write still routes through the attached filter.
     expect(filter.alpha).toBe(0);
+  });
+});
+
+function createSubtitleRenderer() {
+  const renderer = new PixiStoryRenderer(createContext()) as any;
+  renderer.subtitleText = new Text({
+    style: renderer.createOverlayTextStyle(24, 1280),
+    text: "",
+  });
+  renderer.subtitleText.visible = false;
+  renderer.app = {};
+  renderer.tween = vi.fn(async () => {});
+  renderer.layoutSubtitle = vi.fn();
+  return renderer;
+}
+
+describe("PixiStoryRenderer subtitle", () => {
+  const baseInput = {
+    alignment: "left" as const,
+    delayMs: 0,
+    sizePx: 24,
+    text: "hello",
+    widthPx: 1280,
+    x: 0,
+    y: 100,
+  };
+
+  it("fades a hidden subtitle in but never replays the fade for consecutive ones", async () => {
+    const renderer = createSubtitleRenderer();
+    const subtitle = renderer.subtitleText;
+
+    await renderer.setSubtitle({ ...baseInput });
+    expect(subtitle.visible).toBe(true);
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+    expect(renderer.tween.mock.calls[0][0]).toBe(150);
+
+    renderer.tween.mockClear();
+    await renderer.setSubtitle({ ...baseInput, text: "world" });
+    // Native `_SetHiddenInternal`: set_isHidden(false) is a no-op while the
+    // panel is already visible -- seamless text swap, no second fade-in.
+    expect(renderer.tween).not.toHaveBeenCalled();
+    expect(subtitle.text).toBe("world");
+
+    // After a real hide, the next subtitle fades in again.
+    await renderer.clearSubtitle(0);
+    expect(subtitle.visible).toBe(false);
+    await renderer.setSubtitle({ ...baseInput, text: "again" });
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+    expect(subtitle.text).toBe("again");
+  });
+
+  it("types against a transparent tail so the full-text layout is fixed from t0", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = createSubtitleRenderer();
+      const onTypingComplete = vi.fn();
+
+      const pending = renderer.setSubtitle({
+        ...baseInput,
+        delayMs: 10,
+        onTypingComplete,
+      });
+      const subtitle = renderer.subtitleText;
+      // t0 already carries the whole message as a hidden span, so wrapping
+      // matches the final layout instead of re-flowing per character.
+      expect(subtitle.text).toBe("<_c00000000>hello</_c00000000>");
+      await vi.advanceTimersByTimeAsync(10);
+      expect(subtitle.text).toBe("h<_c00000000>ello</_c00000000>");
+      await vi.advanceTimersByTimeAsync(40);
+      expect(subtitle.text).toBe("hello");
+      await pending;
+
+      expect(onTypingComplete).toHaveBeenCalledTimes(1);
+      expect(renderer.subtitleTypingTarget).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports instant subtitles as finished and applies per-line alignment", async () => {
+    const renderer = createSubtitleRenderer();
+    const onTypingComplete = vi.fn();
+
+    await renderer.setSubtitle({
+      ...baseInput,
+      alignment: "center",
+      onTypingComplete,
+    });
+
+    expect(onTypingComplete).toHaveBeenCalledTimes(1);
+    // Native TextAnchor.UpperCenter aligns every wrapped line, not just the
+    // block.
+    expect(renderer.subtitleText.style.align).toBe("center");
   });
 });

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -298,6 +298,19 @@ class FakeRenderer implements StoryRenderer {
   async setSubtitle(input: SubtitleInput): Promise<void> {
     this.subtitleCalls.push(input);
     this.typingActive = input.delayMs > 0;
+    // Faithful to PixiStoryRenderer: an instant subtitle is done typing the
+    // moment it is shown.
+    if (input.delayMs <= 0) input.onTypingComplete?.();
+  }
+
+  /**
+   * Emulates the real renderer clearing its typing target and running the
+   * `SubtitlePanel._OnTypeWriterEnd` callback when the typewriter ends on its
+   * own (as opposed to a click finishing it).
+   */
+  finishSubtitleTypingNaturally(): void {
+    this.typingActive = false;
+    this.subtitleCalls.at(-1)?.onTypingComplete?.();
   }
 
   async setTimerSticker(input: TimerStickerInput): Promise<void> {
@@ -2859,6 +2872,7 @@ describe("StoryRuntime", () => {
       {
         alignment: "center",
         delayMs: 0,
+        onTypingComplete: expect.any(Function),
         sizePx: 24,
         text: "HELLO",
         widthPx: 400,
@@ -2957,6 +2971,62 @@ describe("StoryRuntime", () => {
     await runtime.advance();
     expect(runtime.getState()).toBe("waiting_input");
     expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "ok" });
+  });
+
+  it("auto mode advances a subtitle once its typewriter ends naturally", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = new FakeRenderer();
+      const runtime = new StoryRuntime(
+        createContext([
+          '[subtitle(text="HELLO",alignment="center")]',
+          '[name="A"]ok',
+        ]),
+        renderer,
+        new FakeAudio(),
+        { typingIntervalMs: 40 },
+      );
+
+      await runtime.start();
+      expect(runtime.getState()).toBe("waiting_input");
+
+      runtime.setAutoPlayMode("button_auto");
+      // Enabling auto mid-typing must not fire a click before the typewriter
+      // has ended (native only raises the auto click from _OnTypeWriterEnd).
+      await vi.advanceTimersByTimeAsync(1600);
+      expect(renderer.lastDialogue).toEqual({ speaker: "", text: "" });
+
+      renderer.finishSubtitleTypingNaturally();
+      // Auto wait = 1.5s + messageLength(5) * 0.03s = 1.65s; the subtitle's
+      // own length must drive the wait, not the previous message's.
+      await vi.advanceTimersByTimeAsync(1500);
+      expect(renderer.lastDialogue).toEqual({ speaker: "", text: "" });
+      await vi.advanceTimersByTimeAsync(200);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "ok" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the subtitle immediately when skipping the story", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[subtitle(text="HELLO",alignment="center")]',
+        '[skipnode(mode="skip")]',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+    expect(runtime.getState()).toBe("waiting_input");
+
+    await runtime.skipNode();
+    // Native OnReset on skip clears the panel immediately (alpha=0, no fade).
+    expect(renderer.subtitleClearCalls).toEqual([0]);
+    expect(runtime.getState()).toBe("finished");
   });
 
   it("click skips typewriter first, then advances", async () => {


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `subtitle` 命令移植中的全部可修复行为差异(1 项 P1、4 项 P2、1 项 P3,共 6 项)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的逆向分析(IDA 反编译复核),关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 subtitle 机制(2.7.61 逆向结论)

- `Torappu.AVG.SubtitlePanel._ExecuteSubtitle`(VA `0x183e94780`):六参数 `text/x/y/width/size/alignment` 读取、默认值(0/0/1280/24/"left")、`x∈[0,1280]`/`y∈[0,720]` 闭区间越界拒绝、`width+x>1280` clamp、`y` 取负的坐标系映射、`alignment` 映射 `TextAnchor.UpperLeft/UpperCenter/UpperRight`(未知值 fallthrough left)、`delay` 参数完全忽略、空文本 = 隐藏 + 非阻塞、非空 = 恒阻塞 —— 前端此前已全部一致,本 PR 未改动。
- `SubtitlePanel._OnTypeWriterEnd`(VA `0x183e94e80`):打字自然结束时(溢出告警后)调 **`RaiseAutoClick(typeWriter.messageLength)`**,这是 auto 模式下 subtitle 自动推进的唯一入口。
- `SubtitlePanel._SetHiddenInternal`(VA `0x183e94ff0`):`m_hidden == value` 时为 no-op —— **面板已可见时 `set_isHidden(false)` 不重放 150ms 淡入**,连续 subtitle 无缝换字;隐藏面板则 DOKill + DOFade 从当前 alpha 淡入。
- `SubtitlePanel.OnReset`(VA `0x183e942b0`)/`ShouldResetOnSkip`(VA `0x183e94720` 返回 true):skip 时面板立即 `alpha=0`(无 tween)+ typewriter 复位。
- `AVGTypeWriterText.BeginText`:以隐藏尾串(`<color=#00000000>全文</color>`)一次性按**全文**布局,打字只是逐字"挪出"透明区,换行从 t0 固定,不随打字进度重排。
- `TextAnchor.UpperCenter/UpperRight` 对**每一行**做水平对齐,而非只平移整块。

## 修复内容

### 1. 自动播放不推进 subtitle(P1)

- **native 行为**:打字自然结束 → `_OnTypeWriterEnd` → `RaiseAutoClick(messageLength)` → auto 模式按等待公式自动点进下一条。
- **前端行为**:`runSubtitleTyping` 自然结束只清 typing target,无任何回调进 runtime;`onTypingComplete`(→ `scheduleAutoClick`)只在点击路径被触发。`button_auto`/`quick_play` 下每条 subtitle 打完字即停死,必须手动点击。
- **修复**:`SubtitleInput` 新增 `onTypingComplete` 回调,渲染器在打字自然结束(或 `delayMs<=0` 直出全文)时调用;runtime 在 subtitle 执行时挂接 `() => this.onTypingComplete()`(对齐 `RaiseAutoClick`)。点击瞬显路径不触发该回调(由 `advanceFromClick` 自行调 `onTypingComplete`),与 native `_OnClicked → TryFinish` 两段式点击语义一致。

### 2. 点击路径的 auto 等待长度失真(P3,随 #1 一并修复)

- **native 行为**:`RaiseAutoClick(typeWriter.messageLength)` 用**字幕自身**长度。
- **前端行为**:`currentMessageLength` 只在 dialog 路径更新,字幕期间停留为上一条 dialog 的长度(或 0)。
- **修复**:subtitle 执行时 `cancelTyping()` 后同步 `currentMessageLength = parseRichChars(text).length`(与 dialog 路径同口径的可见字符计数)。

### 3. `skipNode()` 不清 subtitle(P2)

- **native 行为**:skip → `ShouldResetOnSkip()=true` → `OnReset`:`alpha=0` 立即(无 tween)+ `typeWriter.OnReset()` + 解绑点击。
- **前端行为**:`skipNode` 只清 interlude/spellsticker,字幕残影留到下一条 subtitle 或播放结束。
- **修复**:`skipNode` 中补 `await this.renderer.clearSubtitle(0)`(立即清,非渐隐)。

### 4. 连续字幕重复淡入(闪烁)(P2)

- **native 行为**:面板已可见时 `set_isHidden(false)` 为 no-op(`m_hidden == value`),连续 `[Subtitle]` 无缝换字。
- **前端行为**:`setSubtitle` 每次都 `alpha=0` → 150ms 淡入,每句闪一次。
- **修复**:渲染器引入 `subtitleHidden` 标志(移植 `m_hidden` 语义,`set_isHidden` 即翻转、alpha tween 异步追赶):已可见时跳过 alpha 重置仅换字重启打字;隐藏面板才淡入,且从当前 alpha 起算(覆盖打断淡出途中再显示的场景,等价 DOKill+DOFade)。

### 5. 打字过程换行重排(布局抖动)(P2)

- **native 行为**:`BeginText` 用隐藏尾串按全文一次性布局,换行从 t0 固定。
- **前端行为**:逐字 `set_text(前缀子串)`;受限宽换行时已上屏行随打字进度反复重排。
- **修复**:移植隐藏尾串技巧 —— 打字期间文本 = 可见前缀 + `<color=#00000000>` 透明尾串(tag 注册进 `style.tagStyles`),t0 即按全文换行与定位,逐字仅"挪出"透明区。

### 6. 多行字幕的逐行水平对齐缺失(P2)

- **native 行为**:`TextAnchor.UpperCenter/UpperRight` 对每一行做水平对齐。
- **前端行为**:PIXI style 未设 `align`(默认 left),`layoutSubtitle` 只平移整块;center/right 且换行时短行相对长行左对齐。
- **修复**:`setSubtitle` 里 `style.align = alignment`(整块偏移 `layoutSubtitle` 保留,二者叠加与 native 锚点语义等价)。

**未修条目**(review 建议维持现状):alignment 大小写不敏感(P3,现网语料无大写混用)、溢出告警日志(P3,非致命调试日志)、Playback/阅读模式 executor(P3,有意省略,注释已声明)。

## 验证用剧情文件

生产剧情文件位于本地 `torappu/storage/asset/gamedata/latest/story`:

- **修复 1+2(自动推进 + 等待时长)**:任意含 `[Subtitle]` 的文件(全语料 525 个文件、1839 处),如 `obt/main/level_main_10-12_end.txt:203-206` —— 开启自动播放,确认每条字幕打完字后按 1.5s + 字数×0.03s 自动点进,不再停死。
- **修复 3(skip 清场)**:`obt/main/level_main_17-17_end.txt` —— 主线中唯一同时含 `[subtitle]`(999、1016、1027 行)与 `[skipnode]`(1181、1216 行)的文件;字幕显示中点 skip,确认字幕立即消失(非渐隐、无残影)。
- **修复 4(连续字幕不闪烁)**:`obt/main/level_main_10-12_end.txt:203-206`(4 连句)、`activities/act25side/level_act25side_06_beg.txt:374-376`(3 连句)—— 连续字幕间无黑闪,直接换字重启打字。
- **修复 5(换行不重排)**:`activities/act21side/level_act21side_st04.txt:254`(`width=400` 配 30 字长文本,折行 3 行)、`activities/act25side/level_act25side_06_beg.txt:375`(`width=700` + `\n` 双行)—— 打字全程已上屏行不再来回重排。
- **修复 6(逐行对齐)**:`obt/main/level_main_11-04_end.txt:360`(`第四幕\n——————\n第三场` center 对齐,短行必须逐行居中)、`activities/act25side/level_act25side_06_beg.txt:374-376`(right 对齐折行)。

## 测试

- `pnpm test`:20 个文件 227 个用例全部通过(基线 222,新增 5 个:`tests/runtime.spec.ts` 的 "auto mode advances a subtitle once its typewriter ends naturally"、"clears the subtitle immediately when skipping the story";`tests/renderer.spec.ts` 的 "fades a hidden subtitle in but never replays the fade for consecutive ones"、"types against a transparent tail so the full-text layout is fixed from t0"、"reports instant subtitles as finished and applies per-line alignment")。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint <改动文件>`:通过。
- `STORY_CORPUS_ROOT=… pnpm test:story-log`:全语料(2 用例)通过,Log All 语义无回归。
