### PR TITLE
fix(story-player): decision 等待期 skip 挂死与 & 选项禁用前缀

### DIFF
--- a/src/widgets/StoryPlayer/engine/log/semantics.ts
+++ b/src/widgets/StoryPlayer/engine/log/semantics.ts
@@ -68,6 +68,13 @@ export function passesGate(
  * story_ghost_2_1 的 4 选项 / 3 values）在原生里照常播下去。
  * 标签与 runtime 的 translateText 同源展开（如 `{@nickname}`），
  * 否则 Log All 会显示播放时不可见的字面占位符。
+ *
+ * `&` 禁用前缀（2.7.61 起）：原生 `DecisionPanel._SetupOptionText`
+ * （0x183e718a0）对 `StartsWith("&")` 的选项 `Substring(1)` 剥前缀并置
+ * `interactable=false`，剥完才进 `AVGTextManager.Translate`。这里在共享
+ * 语义层同序处理（先剥 `&` 再 expandStoryText），使 runtime 面板与
+ * Log All 显示同一份玩家可见文本。禁用项仍保留 optionIndex/value：
+ * 原生 predicator 不感知禁用，Log All 的分支枚举也不排除它。
  */
 export function parseDecision(
   line: ParsedCommandLine,
@@ -79,11 +86,15 @@ export function parseDecision(
   const labels = toStringValue(optionsValue).split(";");
   const values = toIntList(line.args.values);
   return {
-    options: labels.map((label, optionIndex) => ({
-      label: expandStoryText(label, variables),
-      optionIndex,
-      value: values[optionIndex] ?? 0,
-    })),
+    options: labels.map((label, optionIndex) => {
+      const disabled = label.startsWith("&");
+      return {
+        disabled,
+        label: expandStoryText(disabled ? label.slice(1) : label, variables),
+        optionIndex,
+        value: values[optionIndex] ?? 0,
+      };
+    }),
   };
 }
 

--- a/src/widgets/StoryPlayer/engine/log/types.ts
+++ b/src/widgets/StoryPlayer/engine/log/types.ts
@@ -19,6 +19,13 @@ export type OptionIndex = number;
 
 /** decision 的一个选项 */
 export interface ChoiceOption {
+  /**
+   * 是否为 `&` 禁用前缀选项（native `_SetupOptionText`：`StartsWith("&")` →
+   * 剥前缀 + `interactable=false`）。禁用只作用于渲染层：选项仍占一个
+   * optionIndex/value，Log All 的分支枚举不排除它（宁可多列也不丢行）。
+   */
+  disabled: boolean;
+  /** 已剥掉 `&` 禁用前缀、展开变量后的显示文本 */
   label: string;
   optionIndex: OptionIndex;
   /** runtime 中玩家选择该选项后写入 decisionSelectValue 的值 */

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -500,8 +500,18 @@ export class PixiStoryRenderer implements StoryRenderer {
   async showDecision(
     options: string[],
     values: number[],
+    disabled?: boolean[],
   ): Promise<DecisionSelection> {
-    return this.decisionPanel.show(options, values);
+    return this.decisionPanel.show(options, values, disabled);
+  }
+
+  /**
+   * Native provenance: skip 路径的 `DecisionPanel.ForceCommandEnd`
+   * （0x183e706b0）——按「未点击」结算挂起中的 decision，让
+   * runtime 挂在 showDecision 上的命令循环得以继续。
+   */
+  settleDecision(): void {
+    this.decisionPanel.clear();
   }
 
   /**

--- a/src/widgets/StoryPlayer/engine/rendering/panels/DecisionPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/DecisionPanel.ts
@@ -39,7 +39,11 @@ export class DecisionPanel {
 
   constructor(private readonly layer: ContainerType) {}
 
-  show(options: string[], values: number[]): Promise<DecisionSelection> {
+  show(
+    options: string[],
+    values: number[],
+    disabledOptions: boolean[] = [],
+  ): Promise<DecisionSelection> {
     // Settle any decision this one replaces: `_ExecuteDecision` awaits the
     // selected value, so dropping the pending resolver would strand the
     // command loop in `waiting_decision` forever.
@@ -58,16 +62,24 @@ export class DecisionPanel {
     const startX = (STORY_WIDTH - buttonWidth) / 2;
 
     for (const [index, option] of options.entries()) {
+      // Native `_SetupOptionText`（0x183e718a0）：`&` 前缀项剥前缀后
+      // `interactable = false`。前缀已在 log/semantics.parseDecision 剥掉，
+      // 这里只负责禁用的呈现：灰底灰字、无手型、不注册指针事件
+      // （按钮保持 passive，点击穿透到遮罩，不会误结算）。
+      const disabled = disabledOptions[index] ?? false;
       const button = new Container();
       button.position.set(startX, startY + index * stride);
-      button.eventMode = "static";
-      button.cursor = "pointer";
       const background = new Graphics();
-      paintButton(background, 0x30_30_30, buttonWidth, buttonHeight);
+      paintButton(
+        background,
+        disabled ? 0x1c_1c_1c : 0x30_30_30,
+        buttonWidth,
+        buttonHeight,
+      );
       const label = new Text({
         style: new TextStyle({
           align: "center",
-          fill: "#ffffff",
+          fill: disabled ? "#8c8c8c" : "#ffffff",
           fontFamily: [DIALOG_FONT_FAMILY, "sans-serif"],
           fontSize: 20,
         }),
@@ -76,19 +88,23 @@ export class DecisionPanel {
       label.anchor.set(0.5);
       label.position.set(buttonWidth / 2, buttonHeight / 2);
       button.addChild(background, label);
-      button.on("pointerover", () =>
-        paintButton(background, 0x50_50_50, buttonWidth, buttonHeight),
-      );
-      button.on("pointerout", () =>
-        paintButton(background, 0x30_30_30, buttonWidth, buttonHeight),
-      );
-      button.on("pointertap", () => {
-        // 下标在点击点就是唯一的；value 可能在 options 间重复，只能由
-        // runtime 写闸门，不能反查回下标（Log All 高亮依赖下标）。
-        // values 由 runtime 的 parseDecision 逐项解析好传进来，这里的 0
-        // 只是兜底；0 与原生 `_GetOptionValue` 的越界返回值一致。
-        this.clear({ optionIndex: index, value: values[index] ?? 0 });
-      });
+      if (!disabled) {
+        button.eventMode = "static";
+        button.cursor = "pointer";
+        button.on("pointerover", () =>
+          paintButton(background, 0x50_50_50, buttonWidth, buttonHeight),
+        );
+        button.on("pointerout", () =>
+          paintButton(background, 0x30_30_30, buttonWidth, buttonHeight),
+        );
+        button.on("pointertap", () => {
+          // 下标在点击点就是唯一的；value 可能在 options 间重复，只能由
+          // runtime 写闸门，不能反查回下标（Log All 高亮依赖下标）。
+          // values 由 runtime 的 parseDecision 逐项解析好传进来，这里的 0
+          // 只是兜底；0 与原生 `_GetOptionValue` 的越界返回值一致。
+          this.clear({ optionIndex: index, value: values[index] ?? 0 });
+        });
+      }
       container.addChild(button);
     }
     this.layer.addChild(container);

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -304,6 +304,16 @@ function preprocessSkipToIndex(lines: ReturnType<typeof parseScript>): number {
   );
 }
 
+/**
+ * Native 的选项渲染上限是 DecisionPanel 预制体上 `_optionRoots` /
+ * `m_optionTexts` 数组的长度（由 prefab 配置，代码里读不出具体值；
+ * 2.7.61 现网语料单条 decision 最多 4 个选项）。超出时原生打
+ * `[AVG] Too many decision options. Some will be ignored!` 并隐藏多余
+ * 按钮；web 侧只降级为 warning、仍全量渲染（与 options 缺失路径同样
+ * 的容错取向）。
+ */
+const DECISION_OPTION_CAPACITY = 4;
+
 export class StoryRuntime {
   private readonly audio: StoryAudio;
   private readonly defaultSpeed: AutoSpeed;
@@ -522,6 +532,9 @@ export class StoryRuntime {
 
     const hadActiveProcessLoop = this.processing;
     const activeProcessCompletion = this.processingCompletion;
+    // 必须在改写 state 之前取样：waiting_decision 时命令循环正挂在
+    // renderer.showDecision 上，skip 要负责替它结算（见下方 settleDecision）。
+    const waitingDecision = this.state === "waiting_decision";
     let shouldResume = false;
 
     // m_executeIndex points at the command currently being waited on while our
@@ -570,6 +583,13 @@ export class StoryRuntime {
     // Its existing processLoop owns continuation; starting another loop would
     // race it and can leave state="running" with no loop alive.
     this.interruptPendingWait();
+    // Native provenance: 2.7.61 的 skip 不再走 DecisionPanel.ShouldResetOnSkip
+    // （该函数恒返回 false），而是对阻塞中的 executor 调
+    // DecisionPanel.ForceCommandEnd（0x183e706b0）收尾。这里等价地按
+    // 「未点击」结算挂起的 decision（{optionIndex:-1, value:0}，闸门对 0
+    // 全开），命令循环随即从被移动的 cursor 继续；不结算的话 processLoop
+    // 永远吊在 showDecision 上，state=running 却无人推进（点选项才能解围）。
+    if (waitingDecision) this.renderer.settleDecision();
     if (hadActiveProcessLoop) await activeProcessCompletion;
     else if (shouldResume) await this.processLoop();
   }
@@ -2460,16 +2480,28 @@ export class StoryRuntime {
       }
 
       case "decision": {
-        // Native port: Torappu.AVG.DecisionPanel._ExecuteDecision. Selection writes
-        // a value for the command-loop predicate gate; it is not a label jump.
+        // Native port: Torappu.AVG.DecisionPanel._ExecuteDecision. Selection
+        // writes a value for the command-loop predicate gate; it is not a
+        // label jump.
+        // 有意省略：native 在 autoPlayMode==QUICK_PLAY 且设置项
+        // AVG_SKIP_DECISION 开启时会 _SetOptionButtonSelect(0) 自动选第
+        // 0 项、不阻塞（0x183e70f9d-0x183e71013）；web 没有游戏内设置
+        // 项，按 AVG_SKIP_DECISION 恒为关处理，总是阻塞等点击。等待期间
+        // 把 autoPlayMode 降级为 default、选择后恢复，也是 web 适配
+        // （native 不降级）。
         const autoPlayCache = this.autoPlayMode;
         this.setAutoPlayMode("default");
         this.decisionSelectValue = 0;
         this.decisionReferences = null;
         // options/values 的解析与 Log All 共用 log/semantics.parseDecision，
-        // 缺项 value 按原生 `_GetOptionValue` 取 0（闸门对 0 恒放行）
+        // 缺项 value 按原生 `_GetOptionValue` 取 0（闸门对 0 恒放行）；
+        // `&` 禁用前缀同样在 parseDecision 剥离并标记 disabled。
         const parsed = parseDecision(line, this.context.audioVariables);
         if (!parsed) {
+          // native 对缺 options 是阻塞语义：LogError "[AVG] No options
+          // parameter for Decision command" 后 return true（面板已激活，
+          // 主播放路径实际卡死，现网脚本不会出现）。web 取容错放行：
+          // 上面的重置已清空分支状态，warn 后继续播。
           this.warn(
             "invalid_parameter",
             "decision options parameter is missing",
@@ -2479,9 +2511,22 @@ export class StoryRuntime {
 
         const options = parsed.options.map((option) => option.label);
         const values = parsed.options.map((option) => option.value);
+        const disabled = parsed.options.map((option) => option.disabled);
+        if (options.length > DECISION_OPTION_CAPACITY) {
+          this.warn(
+            "invalid_parameter",
+            `too many decision options: ${options.length} > native capacity ${DECISION_OPTION_CAPACITY}`,
+            line.lineNumber,
+            "decision",
+          );
+        }
 
         this.state = "waiting_decision";
-        const selection = await this.renderer.showDecision(options, values);
+        const selection = await this.renderer.showDecision(
+          options,
+          values,
+          disabled,
+        );
         this.decisionSelectValue = selection.value;
         // 点击下标由 renderer 直接返回：value 可能在 options 间重复
         // （显式值相同，或与缺省值 0 碰撞），反查会记错选项，

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -108,9 +108,9 @@ export interface RuntimeChoiceSelection {
 
 /** showDecision 的结果：点击的选项下标 + 写入闸门的值（value 会跨 decision 复用，不能反查下标） */
 export interface DecisionSelection {
-  /** 玩家点击的选项下标；-1 表示面板未经点击被清除（跳过/销毁） */
+  /** 点击的选项下标；-1 表示面板未经点击被清除（跳过/销毁） */
   optionIndex: number;
-  /** `values[optionIndex] ?? optionIndex + 1`，写入 decisionSelectValue */
+  /** 点击项的 value（`values[optionIndex] ?? 0`，缺项取 0 与原生 `_GetOptionValue` 越界分支一致），写入 decisionSelectValue */
   value: number;
 }
 
@@ -568,7 +568,17 @@ export interface StoryRenderer {
   showDecision: (
     options: string[],
     values: number[],
+    /** 与 options 同长的禁用标记（native `_SetupOptionText` 的 `&` 前缀项 interactable=false） */
+    disabled?: boolean[],
   ) => Promise<DecisionSelection>;
+  /**
+   * 按「未点击」结算挂起中的 decision（`{optionIndex: -1, value: 0}`）。
+   * Native provenance: 2.7.61 的 skip 不走 `DecisionPanel.ShouldResetOnSkip`
+   * （该函数已固定返回 false），而是对阻塞中的 executor 调
+   * `DecisionPanel.ForceCommandEnd`（0x183e706b0）收尾；runtime.skipNode
+   * 用它解开挂在 showDecision 上的命令循环。
+   */
+  settleDecision: () => void;
   stopVideo: () => void;
 }
 

--- a/tests/decisionPanel.spec.ts
+++ b/tests/decisionPanel.spec.ts
@@ -1,4 +1,4 @@
-import { Container, type FederatedPointerEvent } from "pixi.js";
+import { Container, type FederatedPointerEvent, type Text } from "pixi.js";
 import { describe, expect, it } from "vitest";
 
 import { DecisionPanel } from "../src/widgets/StoryPlayer/engine/rendering/panels/DecisionPanel";
@@ -18,5 +18,26 @@ describe("DecisionPanel", () => {
 
     await expect(selection).resolves.toEqual({ optionIndex: 0, value: 1 });
     expect(layer.children).toHaveLength(0);
+  });
+
+  it("renders ampersand options disabled without settling on tap", async () => {
+    const layer = new Container();
+    const panel = new DecisionPanel(layer);
+    // 原生 _SetupOptionText：`&` 前缀项剥前缀 + interactable=false。
+    // 前缀由 log/semantics.parseDecision 剥掉，面板只收 disabled 标记。
+    const selection = panel.show(["可选", "不可选"], [1, 2], [false, true]);
+
+    const root = layer.children[0] as Container;
+    const disabledOption = root.children[2] as Container;
+    const disabledLabel = disabledOption.children[1] as Text;
+    expect(disabledLabel.text).toBe("不可选");
+
+    // 禁用按钮不注册指针事件，tap 不结算
+    disabledOption.emit("pointertap", {} as FederatedPointerEvent);
+    await Promise.resolve();
+
+    const enabledOption = root.children[1] as Container;
+    enabledOption.emit("pointertap", {} as FederatedPointerEvent);
+    await expect(selection).resolves.toEqual({ optionIndex: 0, value: 1 });
   });
 });

--- a/tests/helpers/storyOracle.ts
+++ b/tests/helpers/storyOracle.ts
@@ -19,7 +19,10 @@ import type { ParsedLine } from "../../src/widgets/StoryPlayer/engine/types";
  * - multiline 空片段不动累积；sticker/subtitle 的 hidelog/multi 是
  *   web 日志侧规则，但两种累积不共用缓冲（原生在 sticker/subtitle 处
  *   会 _TryEndMultilineMode）；
- * - decision 的 values 缺项取 0（原生 _GetOptionValue 越界返回 0）。
+ * - decision 的 values 缺项取 0（原生 _GetOptionValue 越界返回 0）；
+ * - 选项文本的 `&` 禁用前缀（原生 _SetupOptionText 剥前缀 +
+ *   interactable=false）只作用于渲染层，不影响分支枚举/取值，oracle
+ *   不解析它。
  */
 
 export interface OracleChoice {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -95,7 +95,14 @@ class FakeRenderer implements StoryRenderer {
   videoWaiter: Promise<void> = Promise.resolve();
   decisionValue = 0;
   decisionIndex = -1;
-  decisionCalls: { options: string[]; values: number[] }[] = [];
+  decisionCalls: {
+    disabled: boolean[];
+    options: string[];
+    values: number[];
+  }[] = [];
+  /** 为 true 时 showDecision 挂起等 settleDecision（模拟玩家尚未点击） */
+  holdDecisions = false;
+  private decisionWaiters: Array<(selection: DecisionSelection) => void> = [];
   private resolveVideoWaiter: (() => void) | null = null;
 
   setCameraEffect(
@@ -309,9 +316,24 @@ class FakeRenderer implements StoryRenderer {
   async showDecision(
     options: string[],
     values: number[],
+    disabled?: boolean[],
   ): Promise<DecisionSelection> {
-    this.decisionCalls.push({ options, values });
-    return { optionIndex: this.decisionIndex, value: this.decisionValue };
+    this.decisionCalls.push({ disabled: disabled ?? [], options, values });
+    if (!this.holdDecisions) {
+      return { optionIndex: this.decisionIndex, value: this.decisionValue };
+    }
+    return new Promise<DecisionSelection>((resolve) => {
+      this.decisionWaiters.push(resolve);
+    });
+  }
+
+  /** 按「未点击」结算挂起中的 decision，对应 PixiStoryRenderer.settleDecision */
+  settleDecision(): void {
+    const waiters = this.decisionWaiters;
+    this.decisionWaiters = [];
+    for (const resolve of waiters) {
+      resolve({ optionIndex: -1, value: 0 });
+    }
   }
 
   stopVideo(): void {
@@ -1104,6 +1126,7 @@ describe("StoryRuntime", () => {
     // 面板拿到的是 log/semantics.parseDecision 逐项解析好的 values；
     // 缺项取 0，与原生 DecisionPanel._GetOptionValue 越界分支一致
     expect(renderer.decisionCalls[0]).toEqual({
+      disabled: [false, false, false],
       options: ["A", "B", "C"],
       values: [7, 0, 0],
     });
@@ -1126,6 +1149,115 @@ describe("StoryRuntime", () => {
     await runtime.start();
 
     expect(runtime.getLogPosition().selections).toEqual([]);
+  });
+
+  it("settles a pending decision when skipping so the command loop resumes", async () => {
+    const renderer = new FakeRenderer();
+    renderer.holdDecisions = true;
+    const runtime = new StoryRuntime(
+      createContext([
+        '[decision(options="A;B", values="1;2")]', // line 1，挂起等点击
+        '[skipnode(mode="nofirstskip")]', // line 2，首读保护锚点
+        '[name="A"]after', // line 3
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    const startPromise = runtime.start();
+    await Promise.resolve();
+
+    expect(runtime.getState()).toBe("waiting_decision");
+    expect(runtime.canSkipNode()).toBe(true);
+
+    // 不结算挂起 decision 的话这一步永不返回：processLoop 吊在
+    // showDecision 上，cursor 移动了也无人消费（native 走 ForceCommandEnd）
+    await runtime.skipNode();
+    await startPromise;
+
+    // 未点击结算：value=0（闸门全开）、不记选择历史
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
+    expect(runtime.getDecisionSelectValue()).toBe(0);
+    expect(runtime.getLogPosition().selections).toEqual([]);
+  });
+
+  it("finishes the story when skipping past a pending decision to the end", async () => {
+    const renderer = new FakeRenderer();
+    renderer.holdDecisions = true;
+    const runtime = new StoryRuntime(
+      createContext([
+        '[skipnode(mode="skip")]',
+        '[decision(options="A;B", values="1;2")]',
+        '[name="A"]tail',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    const startPromise = runtime.start();
+    await Promise.resolve();
+
+    expect(runtime.getState()).toBe("waiting_decision");
+
+    await runtime.skipNode();
+    await startPromise;
+
+    expect(runtime.getState()).toBe("finished");
+    expect(runtime.canSkipNode()).toBe(false);
+  });
+
+  it("marks ampersand-prefixed options as disabled and strips the prefix", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[decision(options="&不可选;可选", values="1;2")]', // line 1
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // `&` 前缀在 log/semantics.parseDecision 剥离（原生 _SetupOptionText），
+    // 面板拿到的是玩家可见文本 + 禁用标记
+    expect(renderer.decisionCalls[0]).toEqual({
+      disabled: [true, false],
+      options: ["不可选", "可选"],
+      values: [1, 2],
+    });
+  });
+
+  it("warns when a decision exceeds the native option capacity", async () => {
+    const warnings: RuntimeWarning[] = [];
+    const onWarning = (warning: RuntimeWarning) => warnings.push(warning);
+    const runtime = new StoryRuntime(
+      createContext(['[decision(options="1;2;3;4;5", values="1;2;3;4;5")]']),
+      new FakeRenderer(),
+      new FakeAudio(),
+      { onWarning },
+    );
+
+    await runtime.start();
+
+    // 原生上限为 DecisionPanel 预制体按钮数，超出打
+    // "[AVG] Too many decision options. Some will be ignored!"
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        command: "decision",
+        type: "invalid_parameter",
+      }),
+    ]);
+
+    const boundaryWarnings: RuntimeWarning[] = [];
+    const boundaryRuntime = new StoryRuntime(
+      createContext(['[decision(options="1;2;3;4", values="1;2;3;4")]']),
+      new FakeRenderer(),
+      new FakeAudio(),
+      { onWarning: (warning) => boundaryWarnings.push(warning) },
+    );
+    await boundaryRuntime.start();
+    expect(boundaryWarnings).toEqual([]);
   });
 
   it("shows and hides story items with legacy defaults", async () => {


### PR DESCRIPTION
fix(story-player): decision 等待期 skip 挂死与 & 选项禁用前缀
本 PR 修复 StoryPlayer 对 AVG `decision` 命令移植中的可修复行为差异(P1×1 + P2×2 + 注释/告警小项)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的逆向分析,关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 decision 机制(2.7.61 / build 2761 IDA 反编译复核)

- `Torappu.AVG.DecisionPanel._ExecuteDecision`(0x183e70d70):先重置 predicator(`decisionValue=0` / `referenceValues=null`)再校验 `options`;缺 `options` 时 `LogError("[AVG] No options parameter for Decision command")` 后 `return true`(**阻塞**)。`autoPlayMode==QUICK_PLAY` **且**设置项 `AVG_SKIP_DECISION` 开启时 `_SetOptionButtonSelect(0)` 自动选第 0 项、不阻塞(0x183e70f9d-0x183e71013)。
- `Torappu.AVG.DecisionPanel._SetupOptionText`(0x183e718a0):选项文字 `StartsWith("&")` → `Substring(1)` 剥前缀 + `interactable=false`(2.7.51 的 `"\t"` 前缀已过时),剥完才进 `AVGTextManager.Translate`。渲染上限为预制体 `_optionRoots`/`m_optionTexts` 数组长度,超出打 `"[AVG] Too many decision options. Some will be ignored!"` 并隐藏多余按钮(不截断数组)。
- `Torappu.AVG.DecisionPanel.ShouldResetOnSkip`(0x183e70c50):**恒返回 false**(`xor al,al; retn`)——2.7.61 的 skip 不再靠该钩子清面板,阻塞中的 executor 由 skip 路径调 `DecisionPanel.ForceCommandEnd`(0x183e706b0)收尾,命令循环不会吊死。
- `Torappu.AVG.DecisionPanel._GetOptionValue`(0x183e712f0):`Split(';')` + `Int32.TryParse`,越界/解析失败返回 0。
- `AVGController.OnDecisionSelected`(0x183e15b90):`(value, index)` 双参,下标与值分离传递。
- 值谓词分支模型(非 label 跳转)、闸门三规则、`IsDecisionCommand` OrdinalIgnoreCase 等核心语义此前已正确移植,本 PR 不动。

## 修复内容

### 1. waiting_decision 期间点「跳过段」挂死播放器(P1)

- **native 行为**:skip 路径对阻塞 executor 走 `ForceCommandEnd`(0x183e706b0)等收尾,循环不会吊死。
- **前端行为**:`index.vue` 的 skip 按钮在 `waiting_decision` 时仍可点(`canSkipNode` 只排除 idle/error/finished);`skipNode`(runtime.ts)移动 cursor 后 `await activeProcessCompletion`,而 processLoop 正挂起在 `await renderer.showDecision(...)` 上永不 resolve——state 被置回 running 却无循环推进,只能靠再点一次选项解围。
- **修复**:`skipNode` 入口先取样 `state === "waiting_decision"`,在 `interruptPendingWait()` 旁按「未点击」结算挂起的 decision(`{optionIndex:-1, value:0}`,闸门对 0 全开、不记 choiceHistory),命令循环随即从被移动的 cursor 继续。`StoryRenderer` 接口新增 `settleDecision()`(`PixiStoryRenderer` 转发 `DecisionPanel.clear()`),与 destroy/顶替时的未点击结算同一条路径。不动 `canSkipNode`(skip 在 decision 等待期仍是可用操作)。

### 2. `&` 选项禁用前缀未实现(P2)

- **native 行为**:2.7.61 `_SetupOptionText`:`StartsWith("&")` → 剥前缀 + `interactable=false` 灰显。
- **前端行为**:`&xxx` 原样渲染且可点击。
- **修复**:剥离放在 runtime 与 Log All 共享的 `log/semantics.parseDecision`(单一真相):先剥 `&` 再 `expandStoryText`,与 native「先剥前缀再 Translate」同序;`ChoiceOption` 新增 `disabled` 字段,经 `runtime` → `showDecision(options, values, disabled)` 传到面板。`DecisionPanel` 对禁用项灰底灰字、无手型光标、不注册指针事件(按钮保持 passive,点击穿透到遮罩不会误结算)。禁用项仍保留 optionIndex/value:native predicator 不感知禁用,Log All 的分支枚举也不排除它(宁多列不丢行)。`tests/helpers/storyOracle.ts`(独立第二解释器)注释同步标注该前缀只作用于渲染层。

### 3. QUICK_PLAY 自动选 0 未实现(P2,注释说明,不改行为)

- **native 行为**:`QUICK_PLAY` 且设置项 `AVG_SKIP_DECISION` 开 → 自动选 0 不阻塞。
- **前端行为**:总是阻塞等点击(等待期间降级 autoPlayMode 为 default、选择后恢复,web 适配)。
- **改法**:web 无游戏内设置项,按 `AVG_SKIP_DECISION` 恒为关处理,属有意省略;在 `case "decision"` 注释中写明 native 双条件与有意省略理由,避免误当对齐缺口。

### 4. `options` 缺失路径不阻塞(P2,注释说明,不改行为)

- **native 行为**:`LogError` + `return true` 阻塞(面板已激活;现网脚本不会出现)。
- **前端行为**:`warn("invalid_parameter")` + 放行(web 容错取向)。
- **改法**:保留放行,在 `!parsed` 分支注释写明 native 是阻塞语义。

### 5. 选项数超上限无提示(P3,顺手)

- **改法**:`options.length > 4` 时补 `invalid_parameter` warning(对应 native 的 "Too many decision options" LogError;上限取预制体按钮容量,2.7.61 现网语料单条 decision 最多 4 项)。行为仍为全量渲染,不截断(容错取向)。

### 6. `DecisionSelection.value` 注释过时(P3,顺手)

- 注释写 `values[optionIndex] ?? optionIndex + 1`,实现与 native 均为 `?? 0`;已更正。

## 验证用剧情文件

生产剧情文件位于本地 `torappu/storage/asset/gamedata/latest/story`:

- **修复 1(skip 挂死)**:`obt/main/level_main_17-17_end.txt` —— 语料中唯一同时含 `[Decision]`(第 13 行起共 12 处)与 `[skipnode]`(第 1181、1216 行)的主线文件:播放至任一 decision 显示(如第 13 行)时点「跳过段」,修复前播放器挂死(state=running 但点推进无效),修复后跳过正常完成(首读时落在 nofirstskip 锚点后继续播;若已读过则直接完结)。
- **修复 2(& 前缀)**:2.7.61 现网语料 0 命中(`options="` 内无 `&` 前缀样本)——**前瞻对齐,由单测锁定**:`tests/runtime.spec.ts` 的 "marks ampersand-prefixed options as disabled and strips the prefix" 与 `tests/decisionPanel.spec.ts` 的 "renders ampersand options disabled without settling on tap"。
- **修复 5(超限 warning)**:语料单条 decision 最多 4 项(`obt/memory/story_ghost_2_1.txt` 第 643 行,4 选项/3 values),恰好等于容量边界、不触发;超限分支**由单测锁定**:`tests/runtime.spec.ts` 的 "warns when a decision exceeds the native option capacity"(含 4 项不告警的边界断言)。
- **修复 3/4/6**:注释类修正,无行为变化,由既有 227 用例回归覆盖。

## 测试

- `pnpm test`:20 个文件 **227** 用例全部通过(基线 222 + 新增 5)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint <改动文件>`:通过。
- `STORY_CORPUS_ROOT=... pnpm test:story-log`(全语料 Log All 与独立 oracle 对拍):2/2 通过。
