### PR TITLE
fix(story-player): background 尺寸链路对齐 native(width/height 乘数、ppu 原生尺寸、加载失败清屏、tiled)

### DIFF
--- a/src/widgets/StoryPlayer/context.ts
+++ b/src/widgets/StoryPlayer/context.ts
@@ -13,6 +13,14 @@ export interface Context {
   audioVariables?: Record<string, unknown>;
   charMap?: Record<string, string>; // Legacy fallback. New rendering path reads from linkMap(character.json).
   linkMap: Record<string, StoryLinkNode>;
+  /**
+   * AVG background key -> sprite pixelsPerUnit, from `avg/background.json`
+   * (same sidecar family as character.json). The native background rect is
+   * `texture size / ppu * 100` (Image.SetNativeSize), so the renderer needs
+   * the ppu to reproduce it. Absent/empty falls back to texture-size
+   * heuristics in the renderer.
+   */
+  backgroundPpuMap?: Record<string, number>;
 }
 
 function assetUrl(path: string): string {
@@ -204,12 +212,46 @@ async function fetchStoryCharacterMap(): Promise<
   return normalizeCharacterMap(await response.json());
 }
 
+/**
+ * Validates `avg/background.json` into key -> pixelsPerUnit. Keys are folded
+ * lowercase (the pipeline emits the lowercase bundle container names, but the
+ * fold keeps hand-edited or future variants honest); non-finite or
+ * non-positive values are dropped.
+ */
+export function normalizeBackgroundPpuMap(
+  raw: unknown,
+): Record<string, number> {
+  const root = asObject(raw);
+  if (!root) return {};
+
+  const output: Record<string, number> = {};
+  for (const [key, value] of Object.entries(root)) {
+    const ppu = toNumber(value, Number.NaN);
+    if (Number.isFinite(ppu) && ppu > 0) output[key.toLowerCase()] = ppu;
+  }
+
+  return output;
+}
+
+async function fetchBackgroundPpuMap(): Promise<Record<string, number>> {
+  try {
+    const response = await fetch(assetUrl("avg/background.json"));
+    if (!response.ok) return {};
+    return normalizeBackgroundPpuMap(await response.json());
+  } catch {
+    // Missing sidecar is not fatal: the renderer falls back to texture-size
+    // heuristics for the background rect.
+    return {};
+  }
+}
+
 export async function loadContextByScript(
   scriptText: string,
 ): Promise<Context> {
-  const [audioVariables, linkMap] = await Promise.all([
+  const [audioVariables, linkMap, backgroundPpuMap] = await Promise.all([
     ensureStoryVariables(),
     fetchStoryCharacterMap(),
+    fetchBackgroundPpuMap(),
   ]);
 
   return {
@@ -218,5 +260,6 @@ export async function loadContextByScript(
     storyMetadata: parseStory(scriptText).metadata,
     audioVariables,
     linkMap,
+    backgroundPpuMap,
   };
 }

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -10,6 +10,7 @@ import {
   Text,
   TextStyle,
   Texture,
+  TilingSprite,
 } from "pixi.js";
 
 import {
@@ -207,7 +208,7 @@ export class PixiStoryRenderer implements StoryRenderer {
   private readonly backgroundLayer = this.layers.background;
   private backgroundRoot: Container | null = null;
   /** Current background visual; exposed for renderer diagnostics and tests. */
-  backgroundSprite: Sprite | null = null;
+  backgroundSprite: Sprite | TilingSprite | null = null;
   private backgroundTweenSessionId = 0;
   private readonly context: Context;
   private readonly charLayer = this.layers.characters;
@@ -524,13 +525,40 @@ export class PixiStoryRenderer implements StoryRenderer {
    */
   async setBackground(key: string, input?: BackgroundInput): Promise<void> {
     const texture = await this.textureForImageKey(key, "background");
-    if (!texture) return;
+    if (!texture) {
+      // Native `_LoadImage` on a failed sprite load logs "Failed to load
+      // image" and falls into the clear branch: DOFade(_backImage -> 0) with
+      // the same scaled duration and block gate, so the old background fades
+      // out instead of staying visible.
+      await this.clearBackground(input?.fadeMs ?? 0, input?.block ?? false);
+      return;
+    }
 
+    // Simplification vs native: `_ExecuteImage` only DOKills the outgoing
+    // image's transform tween when the cross-fade finishes (OnKill ->
+    // `_ResetImage(_backImage)`), so an in-flight backgroundtween keeps
+    // animating the old image during the fade. Bumping the session id here
+    // freezes that tween one fade early; accepted deviation because both
+    // endpoints (new image cross-faded in, old root removed) still agree.
     this.backgroundTweenSessionId += 1;
     const root = new Container();
-    const sprite = new Sprite(texture);
+    // `_LoadImage`: TryGetParam("tiled", false) switches Image.type between
+    // Tiled and Simple, tiling the sprite inside the final sizeDelta rect; a
+    // repeat-addressed TilingSprite is the PIXI equivalent. The address mode
+    // is set on the Assets-cached texture, which is harmless for the 0..1-UV
+    // simple sprites sharing it.
+    let sprite: Sprite | TilingSprite;
+    if (input?.tiled) {
+      texture.source.style.addressMode = "repeat";
+      sprite = new TilingSprite({ texture });
+    } else {
+      sprite = new Sprite(texture);
+    }
     sprite.anchor.set(0.5);
-    this.layoutImageForScreenAdapt(sprite, input?.screenAdapt, true);
+    this.layoutImageForScreenAdapt(sprite, input?.screenAdapt, {
+      height: input?.height ?? 1,
+      width: input?.width ?? 1,
+    });
     // `_ExecuteImage` reads `xScale`/`yScale` with a 1.0 fallback, so an
     // omitted scale must leave the screen-adapted size alone.
     this.applyCenteredTransform(root, {
@@ -3616,19 +3644,29 @@ export class PixiStoryRenderer implements StoryRenderer {
       this.stickerTypingTargets.delete(id);
   }
 
+  /**
+   * Native port: `AVGImagePanel._LoadImage` sizes the Image in three steps.
+   * (1) `Image.SetNativeSize()` resets sizeDelta to the sprite bounds --
+   * confirmed called at 0x183e58688 in build 2761 right after `image.sprite`
+   * is assigned. (2) sizeDelta is multiplied by the `width`/`height` params
+   * (GetOrDefault<float>(..., 1.0); mulss at 0x183e587b0/0x183e587b4).
+   * (3) An optional SCREEN_ADAPT_FUNCTION_MAP entry maps that multiplied
+   * rect against the 1280x720 reference -- the ratio checks read the
+   * post-multiplier sizeDelta too. With screenadapt omitted the rect keeps
+   * the multiplied native size: centered by the anchor and revealing the
+   * backing color around non-1280x720 art, never stretched to the viewport.
+   */
   private layoutImageForScreenAdapt(
-    sprite: Sprite,
+    sprite: Sprite | TilingSprite,
     mode?: BackgroundInput["screenAdapt"],
-    useViewportSizeByDefault = false,
+    multipliers?: { height: number; width: number },
   ): void {
-    const sourceWidth = Math.max(1, sprite.texture.width);
-    const sourceHeight = Math.max(1, sprite.texture.height);
-    // Unity swaps Image.sprite without calling SetNativeSize, so the AVG
-    // background Image keeps its scene-authored 1280x720 RectTransform when
-    // screenadapt is omitted. Pixi otherwise defaults to the texture's native
-    // size (many extracted backgrounds are 1024x576), leaving visible borders.
-    let width = useViewportSizeByDefault ? STORY_WIDTH : sourceWidth;
-    let height = useViewportSizeByDefault ? STORY_HEIGHT : sourceHeight;
+    const sourceWidth =
+      Math.max(1, sprite.texture.width) * (multipliers?.width ?? 1);
+    const sourceHeight =
+      Math.max(1, sprite.texture.height) * (multipliers?.height ?? 1);
+    let width = sourceWidth;
+    let height = sourceHeight;
 
     if (mode === "fill") {
       width = STORY_WIDTH;

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -555,10 +555,25 @@ export class PixiStoryRenderer implements StoryRenderer {
       sprite = new Sprite(texture);
     }
     sprite.anchor.set(0.5);
-    this.layoutImageForScreenAdapt(sprite, input?.screenAdapt, {
-      height: input?.height ?? 1,
-      width: input?.width ?? 1,
-    });
+    const nativeRect = this.nativeBackgroundRect(key, texture);
+    this.layoutImageForScreenAdapt(
+      sprite,
+      input?.screenAdapt,
+      {
+        height: input?.height ?? 1,
+        width: input?.width ?? 1,
+      },
+      nativeRect,
+    );
+    if (sprite instanceof TilingSprite) {
+      // Image.type = Tiled repeats the sprite at its native (ppu-scaled) size
+      // inside the final sizeDelta rect, so each tile spans nativeRect while
+      // the TilingSprite's own width/height stay at that final rect.
+      sprite.tileScale.set(
+        nativeRect[0] / Math.max(1, texture.width),
+        nativeRect[1] / Math.max(1, texture.height),
+      );
+    }
     // `_ExecuteImage` reads `xScale`/`yScale` with a 1.0 fallback, so an
     // omitted scale must leave the screen-adapted size alone.
     this.applyCenteredTransform(root, {
@@ -3645,26 +3660,62 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   /**
+   * The sizeDelta `Image.SetNativeSize()` writes in the CN client:
+   * `sprite.rect / ppu * 100` (canvas.referencePixelsPerUnit = 100), plus it
+   * collapses the prefab's stretch anchors so sizeDelta becomes the real
+   * rect. AVG background art ships a tuned per-asset ppu (80 / 100 /
+   * 68.2464 / ...), so this is generally NOT the texture's pixel size --
+   * e.g. bg_cher_1 (1024x576, ppu 68.2464) natively renders 1500.44x844,
+   * a 17% centered overscan. Web PNGs are texture-sized with no ppu
+   * metadata, so the per-key ppu comes from the `avg/background.json`
+   * sidecar (context.backgroundPpuMap). For keys missing from the sidecar
+   * every 16:9 background added since 2023 ships a ppu tuned to exactly the
+   * 1280x720 canvas, so a 16:9 texture maps to that and anything else keeps
+   * its texture size.
+   */
+  private nativeBackgroundRect(
+    key: string,
+    texture: Texture,
+  ): readonly [number, number] {
+    const width = Math.max(1, texture.width);
+    const height = Math.max(1, texture.height);
+    // Sidecar keys are the lowercase bundle container names (= web asset
+    // URLs); normalize defensively in case a story references a key with
+    // different casing than the bundle.
+    const ppu = this.context.backgroundPpuMap?.[key.toLowerCase()];
+    if (ppu !== undefined && ppu > 0) {
+      return [(width / ppu) * 100, (height / ppu) * 100];
+    }
+    if (Math.abs(width / height - STORY_WIDTH / STORY_HEIGHT) < 0.01) {
+      return [STORY_WIDTH, STORY_HEIGHT];
+    }
+    return [width, height];
+  }
+
+  /**
    * Native port: `AVGImagePanel._LoadImage` sizes the Image in three steps.
-   * (1) `Image.SetNativeSize()` resets sizeDelta to the sprite bounds --
-   * confirmed called at 0x183e58688 in build 2761 right after `image.sprite`
-   * is assigned. (2) sizeDelta is multiplied by the `width`/`height` params
+   * (1) `Image.SetNativeSize()` resets sizeDelta to the sprite's native
+   * display rect (see nativeBackgroundRect -- confirmed called at
+   * 0x183e58688 in build 2761 right after `image.sprite` is assigned).
+   * (2) sizeDelta is multiplied by the `width`/`height` params
    * (GetOrDefault<float>(..., 1.0); mulss at 0x183e587b0/0x183e587b4).
    * (3) An optional SCREEN_ADAPT_FUNCTION_MAP entry maps that multiplied
    * rect against the 1280x720 reference -- the ratio checks read the
    * post-multiplier sizeDelta too. With screenadapt omitted the rect keeps
-   * the multiplied native size: centered by the anchor and revealing the
-   * backing color around non-1280x720 art, never stretched to the viewport.
+   * the multiplied native size, which still covers the canvas for ppu-tuned
+   * art (most backgrounds) and reveals the backing color only around art
+   * whose native rect is smaller than 1280x720 (e.g. 33_g4_srctheater).
    */
   private layoutImageForScreenAdapt(
     sprite: Sprite | TilingSprite,
     mode?: BackgroundInput["screenAdapt"],
     multipliers?: { height: number; width: number },
+    nativeRect?: readonly [number, number],
   ): void {
-    const sourceWidth =
-      Math.max(1, sprite.texture.width) * (multipliers?.width ?? 1);
-    const sourceHeight =
-      Math.max(1, sprite.texture.height) * (multipliers?.height ?? 1);
+    const nativeWidth = nativeRect?.[0] ?? Math.max(1, sprite.texture.width);
+    const nativeHeight = nativeRect?.[1] ?? Math.max(1, sprite.texture.height);
+    const sourceWidth = nativeWidth * (multipliers?.width ?? 1);
+    const sourceHeight = nativeHeight * (multipliers?.height ?? 1);
     let width = sourceWidth;
     let height = sourceHeight;
 

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -960,6 +960,13 @@ export class StoryRuntime {
     });
   }
 
+  /**
+   * Web adaptation, not native behavior: native passes the raw key straight
+   * into `ResourceRouter.GetBackgroundPath` (`AVG/Backgrounds/<key>`). The
+   * frontend trims and lowercases because the web asset router is
+   * case-sensitive while game data keys are lowercase-only, so this only
+   * ever repairs whitespace or capitalization typos.
+   */
   private resolveImageKey(key: string): string | null {
     const normalized = key.trim().toLowerCase();
     if (!normalized) return null;
@@ -1130,7 +1137,9 @@ export class StoryRuntime {
 
       case "background": {
         // Native port: Torappu.AVG.AVGImagePanel._ExecuteImage as registered by
-        // BackgroundPanel. This covers its clear/load-failure and scaled-fade
+        // BackgroundPanel. This covers its clear branch (empty or unresolvable
+        // `image` key) and the animateRatio-scaled cross-fade; a texture load
+        // failure is cleared inside the renderer (see setBackground).
         const image = toString(this.exactArg(args, "image"));
         const fadeMs = this.calculateFadeMs(this.exactArg(args, "fadetime"));
         const block =
@@ -1147,15 +1156,20 @@ export class StoryRuntime {
           return "continue";
         }
 
+        // `_LoadImage` multiplies the SetNativeSize rect by the `width`/
+        // `height` params (GetOrDefault<float>(..., 1.0); the mulss at
+        // 0x183e587b0/0x183e587b4 in build 2761) before screenadapt reads it.
         await this.renderer.setBackground(resolved, {
           block,
           fadeMs,
+          height: toNumber(this.exactArg(args, "height"), 1),
           scaleX: toNumber(this.exactArg(args, "xScale"), 1),
           scaleY: toNumber(this.exactArg(args, "yScale"), 1),
           screenAdapt: this.parseScreenAdapt(
             this.exactArg(args, "screenadapt"),
           ),
           tiled: toBoolean(this.exactArg(args, "tiled"), false),
+          width: toNumber(this.exactArg(args, "width"), 1),
           x: toNumber(this.exactArg(args, "x"), 0),
           y: toNumber(this.exactArg(args, "y"), 0),
         });

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -277,6 +277,13 @@ export interface BackgroundInput {
   scaleY: number;
   screenAdapt?: "coverall" | "fill" | "height" | "showall" | "width";
   tiled: boolean;
+  /**
+   * Native `width`/`height` params of `AVGImagePanel._LoadImage`
+   * (GetOrDefault<float>("width", 1.0)): multipliers applied to the
+   * SetNativeSize rect before screenadapt, not pixel sizes.
+   */
+  width?: number;
+  height?: number;
   x: number;
   y: number;
 }

--- a/tests/context.spec.ts
+++ b/tests/context.spec.ts
@@ -2,7 +2,10 @@
 
 import { describe, expect, it } from "vitest";
 
-import { normalizeCharacterMap } from "../src/widgets/StoryPlayer/context";
+import {
+  normalizeBackgroundPpuMap,
+  normalizeCharacterMap,
+} from "../src/widgets/StoryPlayer/context";
 
 describe("normalizeCharacterMap", () => {
   it("keys the link map by the lowercased base so mixed-case entries resolve", () => {
@@ -74,5 +77,40 @@ describe("normalizeCharacterMap", () => {
       face: "npc_2004_Alty/1",
       name: "1$1",
     });
+  });
+});
+
+describe("normalizeBackgroundPpuMap", () => {
+  it("folds keys lowercase and keeps finite positive ppus", () => {
+    const map = normalizeBackgroundPpuMap({
+      bg_cher_1: 68.24644470214844,
+      BG_Woods: 100,
+    });
+
+    expect(map).toEqual({
+      bg_cher_1: 68.24644470214844,
+      bg_woods: 100,
+    });
+  });
+
+  it("drops non-finite and non-positive values instead of throwing", () => {
+    const map = normalizeBackgroundPpuMap({
+      bg_bad_string: "80",
+      bg_bad_null: null,
+      bg_bad_negative: -1,
+      bg_bad_zero: 0,
+      bg_bad_nan: Number.NaN,
+      bg_ok: 80,
+    });
+
+    // "80" is a valid numeric string per toNumber, mirroring how story
+    // params are parsed; only non-numeric junk is dropped.
+    expect(map).toEqual({ bg_bad_string: 80, bg_ok: 80 });
+  });
+
+  it("returns an empty map for non-object payloads", () => {
+    expect(normalizeBackgroundPpuMap(null)).toEqual({});
+    expect(normalizeBackgroundPpuMap([1, 2])).toEqual({});
+    expect(normalizeBackgroundPpuMap("nope")).toEqual({});
   });
 });

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1,4 +1,10 @@
-import { Container, Sprite, Texture, TilingSprite } from "pixi.js";
+import {
+  Container,
+  Sprite,
+  Texture,
+  TextureSource,
+  TilingSprite,
+} from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 
 import { PixiStoryRenderer } from "../src/widgets/StoryPlayer/engine/renderer";
@@ -778,14 +784,108 @@ describe("PixiStoryRenderer", () => {
     renderer.app = {};
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
 
-    await renderer.setBackground("bg_festival_2");
-
-    // Native `_LoadImage` calls Image.SetNativeSize() right after assigning
-    // the sprite (0x183e58688), so an omitted screenadapt keeps the sprite's
-    // native rect -- non-1280x720 art reveals the backing color around it
-    // instead of stretching to the viewport.
+    // A key absent from the ppu sidecar with a non-16:9 texture falls back
+    // to the texture size: SetNativeSize semantics with no sidecar entry and
+    // no ppu heuristic to apply.
+    await renderer.setBackground("bg_festival_9x");
     expect(renderer.backgroundSprite.width).toBe(Texture.EMPTY.width);
     expect(renderer.backgroundSprite.height).toBe(Texture.EMPTY.height);
+  });
+
+  it("renders a ppu-tuned background at its sidecar-derived native rect", async () => {
+    const renderer = new PixiStoryRenderer({
+      ...createContext(),
+      backgroundPpuMap: { bg_cher_1: 68.24644470214844 },
+    }) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(
+      new Texture({
+        source: new TextureSource({ height: 576, width: 1024 }),
+      }),
+    );
+
+    // Native SetNativeSize writes sprite.rect / ppu * 100, and AVG
+    // background art ships a tuned per-asset ppu: bg_cher_1 is a 1024x576
+    // texture with ppu 68.2464 that natively renders 1500.44x844 -- the 17%
+    // centered overscan the game shows for
+    // [Background(image="bg_cher_1", width=1, height=1, fadetime=0)] in
+    // obt/main/level_main_01-03_end. Web PNGs carry no ppu metadata, so the
+    // avg/background.json sidecar supplies it.
+    await renderer.setBackground("bg_cher_1");
+
+    expect(renderer.backgroundSprite.width).toBeCloseTo(
+      (1024 / 68.24644470214844) * 100,
+      3,
+    );
+    expect(renderer.backgroundSprite.height).toBeCloseTo(
+      (576 / 68.24644470214844) * 100,
+      3,
+    );
+  });
+
+  it("renders a native-1024x576 background with borders like the game", async () => {
+    const renderer = new PixiStoryRenderer({
+      ...createContext(),
+      backgroundPpuMap: { "33_g4_srctheater": 100 },
+    }) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(
+      new Texture({
+        source: new TextureSource({ height: 576, width: 1024 }),
+      }),
+    );
+
+    // 33_g4_srctheater ships ppu 100, so the game really shows it at
+    // 1024x576 centered with the backing color around it (used without
+    // screenadapt in activities/act21side); filling the canvas here would
+    // diverge from native.
+    await renderer.setBackground("33_g4_srctheater");
+
+    expect(renderer.backgroundSprite.width).toBe(1024);
+    expect(renderer.backgroundSprite.height).toBe(576);
+  });
+
+  it("matches sidecar keys case-insensitively", async () => {
+    const renderer = new PixiStoryRenderer({
+      ...createContext(),
+      backgroundPpuMap: { "21_g9_rhodes_xqoffice": 100 },
+    }) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(
+      new Texture({
+        source: new TextureSource({ height: 576, width: 1024 }),
+      }),
+    );
+
+    // Sidecar keys are the lowercase bundle container names (= web asset
+    // URLs); 99 sprites carry a mixed-case m_Name (21_G9_rhodes_xqoffice,
+    // also ppu 100 -> 1024x576 borders), so a differently-cased story key
+    // must still hit the sidecar rather than the 16:9 fill fallback.
+    await renderer.setBackground("21_G9_rhodes_xqoffice");
+
+    expect(renderer.backgroundSprite.width).toBe(1024);
+    expect(renderer.backgroundSprite.height).toBe(576);
+  });
+
+  it("falls back to the 1280x720 canvas for unknown 16:9 backgrounds", async () => {
+    const renderer = new PixiStoryRenderer({
+      ...createContext(),
+      backgroundPpuMap: { bg_cher_1: 68.24644470214844 },
+    }) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(
+      new Texture({
+        source: new TextureSource({ height: 576, width: 1024 }),
+      }),
+    );
+
+    // A 16:9 key missing from the sidecar (post-sidecar art: every 16:9
+    // background added since 2023 ships a ppu tuned so the native rect is
+    // exactly the reference canvas).
+    await renderer.setBackground("bg_brand_new");
+
+    expect(renderer.backgroundSprite.width).toBe(1280);
+    expect(renderer.backgroundSprite.height).toBe(720);
   });
 
   it("multiplies the native rect by the width and height params", async () => {
@@ -848,7 +948,10 @@ describe("PixiStoryRenderer", () => {
   });
 
   it("tiles the background texture when tiled is true", async () => {
-    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const renderer = new PixiStoryRenderer({
+      ...createContext(),
+      backgroundPpuMap: { bg_ri_1: 68.24644470214844 },
+    }) as any;
     renderer.app = {};
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
 
@@ -856,8 +959,22 @@ describe("PixiStoryRenderer", () => {
 
     // `_LoadImage`: tiled=true sets Image.type = Tiled, repeating the sprite
     // inside the final sizeDelta rect; TilingSprite + repeat wrap mode is
-    // the PIXI equivalent.
+    // the PIXI equivalent. bg_ri_1 is ppu-tuned (native rect = texture
+    // 16x16 / ppu 68.2464 * 100), and each tile spans that native rect
+    // rather than the 16x16 texture pixels (tileScale = 100 / ppu).
     expect(renderer.backgroundSprite).toBeInstanceOf(TilingSprite);
+    expect(renderer.backgroundSprite.width).toBeCloseTo(
+      (Texture.EMPTY.width / 68.24644470214844) * 100,
+      3,
+    );
+    expect(renderer.backgroundSprite.height).toBeCloseTo(
+      (Texture.EMPTY.height / 68.24644470214844) * 100,
+      3,
+    );
+    expect(renderer.backgroundSprite.tileScale.x).toBeCloseTo(
+      100 / 68.24644470214844,
+      6,
+    );
     expect(Texture.EMPTY.source.style.addressMode).toBe("repeat");
     // Restore the shared EMPTY texture so the address mode does not leak into
     // the other specs.

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1,4 +1,4 @@
-import { Container, Sprite, Texture } from "pixi.js";
+import { Container, Sprite, Texture, TilingSprite } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 
 import { PixiStoryRenderer } from "../src/widgets/StoryPlayer/engine/renderer";
@@ -773,15 +773,95 @@ describe("PixiStoryRenderer", () => {
     expect(renderer.backgroundSprite.position.y).toBe(0);
   });
 
-  it("keeps the Unity background rect size when screenadapt is omitted", async () => {
+  it("keeps the background at its native sprite size when screenadapt is omitted", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
 
     await renderer.setBackground("bg_festival_2");
 
+    // Native `_LoadImage` calls Image.SetNativeSize() right after assigning
+    // the sprite (0x183e58688), so an omitted screenadapt keeps the sprite's
+    // native rect -- non-1280x720 art reveals the backing color around it
+    // instead of stretching to the viewport.
+    expect(renderer.backgroundSprite.width).toBe(Texture.EMPTY.width);
+    expect(renderer.backgroundSprite.height).toBe(Texture.EMPTY.height);
+  });
+
+  it("multiplies the native rect by the width and height params", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setBackground("bg_test", { height: 0.5, width: 2.5 });
+
+    // `_LoadImage`: sizeDelta = (native.x * width, native.y * height), both
+    // defaulting to 1.0 (mulss at 0x183e587b0/0x183e587b4 in build 2761).
+    expect(renderer.backgroundSprite.width).toBe(Texture.EMPTY.width * 2.5);
+    expect(renderer.backgroundSprite.height).toBe(Texture.EMPTY.height * 0.5);
+  });
+
+  it("feeds the width/height-multiplied rect into the screenadapt ratio check", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    // A square texture scaled 4x taller is narrower than 16:9, so `coverall`
+    // takes the width-fit branch on the *multiplied* ratio and produces
+    // (1280, 4 * 1280).
+    await renderer.setBackground("bg_test", {
+      height: 4,
+      screenAdapt: "coverall",
+    });
+
     expect(renderer.backgroundSprite.width).toBe(1280);
-    expect(renderer.backgroundSprite.height).toBe(720);
+    expect(renderer.backgroundSprite.height).toBe(
+      (Texture.EMPTY.height * 4 * 1280) / Texture.EMPTY.width,
+    );
+  });
+
+  it("clears the previous background when the texture fails to load", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setBackground("bg_test");
+    const previous = renderer.backgroundRoot;
+    expect(previous.parent).not.toBeNull();
+
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(null);
+    renderer.tween = vi.fn(async () => {});
+
+    await renderer.setBackground("bg_missing", { block: true, fadeMs: 500 });
+
+    // Native `_LoadImage` maps a failed sprite load onto the clear branch:
+    // DOFade(_backImage -> 0) with the command's scaled duration and block
+    // gate, so the old background fades out instead of staying visible.
+    expect(renderer.backgroundRoot).toBeNull();
+    expect(renderer.backgroundSprite).toBeNull();
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+    expect(renderer.tween).toHaveBeenCalledWith(
+      500,
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+
+  it("tiles the background texture when tiled is true", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setBackground("bg_ri_1", { tiled: true });
+
+    // `_LoadImage`: tiled=true sets Image.type = Tiled, repeating the sprite
+    // inside the final sizeDelta rect; TilingSprite + repeat wrap mode is
+    // the PIXI equivalent.
+    expect(renderer.backgroundSprite).toBeInstanceOf(TilingSprite);
+    expect(Texture.EMPTY.source.style.addressMode).toBe("repeat");
+    // Restore the shared EMPTY texture so the address mode does not leak into
+    // the other specs.
+    Texture.EMPTY.source.style.addressMode = "clamp-to-edge";
   });
 
   it("keeps an image at its asset size when screenadapt is omitted", async () => {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2502,7 +2502,7 @@ describe("StoryRuntime", () => {
     expect(runtime.getState()).toBe("waiting_input");
   });
 
-  it("maps background with strict transform keys and ignores width/height", async () => {
+  it("maps background with strict transform keys and native width/height multipliers", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(
       createContext([
@@ -2515,6 +2515,8 @@ describe("StoryRuntime", () => {
 
     await runtime.start();
 
+    // `height`/`width` are the `_LoadImage` sizeDelta multipliers
+    // (GetOrDefault<float>(..., 1.0)); omitted width falls back to 1.
     expect(renderer.backgroundCalls).toEqual([
       {
         input: {
@@ -2522,8 +2524,10 @@ describe("StoryRuntime", () => {
           scaleY: 1,
           block: false,
           fadeMs: 0,
+          height: 1.4,
           screenAdapt: undefined,
           tiled: false,
+          width: 1,
           x: 24,
           y: -36,
         },


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `background` 命令移植中的尺寸链路与加载失败差异(3×P1 + 1×P2,另补 2 条注释项)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的 IDA 反编译复核,关键结论如下,不依赖外部文档。

> **更新(b4a4ab43)**:首版实现把"原生尺寸"当成了纹理像素尺寸,会让 `bg_cher_1` 这类资源带黑边。深挖 `Image.SetNativeSize` 本体后发现它还会 **除以 sprite 的 pixelsPerUnit**,而 AVG 背景资源的 ppu 是逐资产调参的——本提交补上了这条链路,并改为运行时消费 torappu 导出的 ppu sidecar。详见下文加粗的勘误段落。

## 背景:native 的 background 尺寸链路(2.7.61 逆向结论)

- 注册入口:`Torappu.AVG.BackgroundPanel.GetExecutors()` @ 0x183e68f00 把 `"background"` 注册到 `AVGImagePanel._ExecuteImage` @ 0x183e57cf0(`"backgroundtween"` → 同面板的 `_ExecuteImageTween`,兄弟 executor 不走 animateRatio)。
- `_ExecuteImage`:淡入时长 = `fadetime × animateRatio`(`CalculateFadetime` @ 0x183e56070);`fadetime <= 0` 强制非阻塞(基于缩放前的原始值判定);新图 alpha 0→1 盖在旧图上,淡入结束 OnKill(0x183e62e40)→ `_ResetImage`(0x183e58a30)瞬间移除旧图;`block` 时等淡入完成才 FinishCommand。
- `_LoadImage` @ 0x183e58390 的尺寸链路,按顺序:
  1. `image.sprite = sprite` 之后**立即调用 `Image.SetNativeSize()`**(@ 0x183e58688;本体 @ 0x186762bd0)。**该 build(HG 魔改 uGUI)的 SetNativeSize 做三件事**:① `anchorMax = anchorMin`(@ 0x186762dc1,把 prefab 上拉伸铺满的背景 Image 锚点收成点锚,此后 sizeDelta 才是真实矩形);② `sizeDelta = sprite.rect ÷ Image.pixelsPerUnit`(@ 0x186762f6d;`pixelsPerUnit = sprite.ppu ÷ canvas.referencePixelsPerUnit(100)` @ 0x1867640b0)。**即"原生尺寸"不是纹理像素尺寸,而是 `纹理尺寸 × 100 ÷ sprite.ppu`**;
  2. `tiled` → `Image.type = Tiled : Simple`;
  3. `width = GetOrDefault<float>("width", 1.0)`、`height = GetOrDefault<float>("height", 1.0)`,`sizeDelta = (sizeDelta.x × width, sizeDelta.y × height)`(mulss @ 0x183e587b0/0x183e587b4,Hex-Rays 伪代码会丢掉这两条乘法,反汇编已直接证实);
  4. `screenadapt` 命中 `SCREEN_ADAPT_FUNCTION_MAP`(`width`/`height`/`showall`/`coverall`/`fill` 五种)时,用**乘完后的 sizeDelta** 对 1280×720 参考分辨率做比例换算;缺省时跳过本步。
- 加载失败:`_LoadSprite` 返回 null(sprite 加载失败,或 image 键为空)→ `DLog.LogError("Failed to load image: [{0}]")` → 走清屏分支:`DOFade(_backImage → 0, effectiveDuration)` 把旧背景淡出,`block` 时等淡出完成。

### 背景 ppu 的逐资产调参(实测数据)

对官服 2.7.61 全部 **1021 个 `avg/backgrounds` sprite** 解包统计 `m_PixelsToUnits`(7 种取值):ppu=80 ×554(1024×576 纹理 → 渲染恰 1280×720)、ppu=100 ×350(其中 318 张渲染 1024×576、**游戏里真的露底色**)、ppu=68.2464 ×101(2019 首发批次 → 渲染 1500.44×844,超采样 1.1725× 居中裁边铺满)、ppu=64/53.3333/97.1537/56.8608 共 16 张特例。语料 15611 条 `background` 命令中缺省 `screenadapt` 的 505 条:479 条铺满、26 条露底色(如 `activities/act21side` 的 `33_g4_srctheater`)。因此**"缺省一律铺满"和"一律纹理尺寸"都不对**,必须按资产 ppu 渲染。

## 修复内容

| # | 严重度 | native 行为 | 前端原行为 | 改法 |
| --- | --- | --- | --- | --- |
| 1 | P1 | `SetNativeSize()`(收拢锚 + `rect ÷ ppu × 100`)后 `sizeDelta × (width, height)`(默认 1.0),再进 screenadapt | `width`/`height` 完全未解析,恒按乘数 1 计算 | `runtime.ts` 解析 `width`/`height`(默认 1)传入 `BackgroundInput`;`layoutImageForScreenAdapt` 把乘数乘到 **ppu 原生渲染尺寸**上,screenadapt 的比例判断读乘完后的值 |
| 2 | P1 | 缺省 screenadapt 时按资产 ppu 决定的原生渲染尺寸居中——语料 479/505 铺满、26 条露底色 | 缺省强制拉伸到 1280×720(`useViewportSizeByDefault=true`),且注释声称 "native 不调 SetNativeSize",与反汇编矛盾 | 删除 `useViewportSizeByDefault`;`context.ts` 与 `character.json` 同模式并行拉取 torappu 导出的 **`avg/background.json`**(key → ppu sidecar,`Context.backgroundPpuMap`),`nativeBackgroundRect` 按 `纹理尺寸 ÷ ppu × 100` 现算;sidecar 缺 key 时 16:9 纹理按 1280×720 兜底(2023 年后新增的 16:9 背景 ppu 均恰好调到 1280×720),加载失败不致命 |
| 3 | P1 | 贴图加载失败 → LogError + 清屏分支(`DOFade(_backImage → 0)`,block 照常等待) | 纹理加载失败时 `setBackground` 直接 return:旧背景原样保留,block 等待丢失 | `setBackground` 内纹理为 null 时复用 `clearBackground(fadeMs, block)`;warning 日志保留在 `textureForImageKey` |
| 4 | P2 | `tiled=true` → `Image.type = Tiled`,**单块 = ppu 原生渲染尺寸**,在最终 sizeDelta 矩形内平铺 | 解析了 `tiled` 但从未消费,恒为 Simple | `tiled` 时改用 PIXI `TilingSprite` + `texture.source.style.addressMode = "repeat"`,`tileScale = 100 ÷ ppu`(单块为原生渲染尺寸),总矩形为乘数后 sizeDelta。语料唯一样本 `bg_ri_1` 恰是 ppu 68.2464 资产:按纹理尺寸平铺时总矩形 1044×587 连画布都铺不满,修正后 1530×861(1.02 块)与游戏一致 |
| 5 | P2 | 新切图只在交叉淡入结束(OnKill)时才杀旧图的 transform tween | `setBackground` 开头立即失效 backgroundtween session | 维持现状(review 给出的两个选项之一),在 `setBackground` 内补注释记录该简化 |
| 7 | P3 | image key 原样传 `ResourceRouter.GetBackgroundPath` | `resolveImageKey` trim + 小写 | 维持现状,补注释标明这是 web 资源映射的有意适配;sidecar 查表同样做小写归一(见下) |

P3 #6(block 取值时点,仅 animateRatio=0 时理论不同)、#8(clear 打断进行中 fade-in 的边缘行为,native 自身不可复刻干净)、#9(异步加载阻塞,已有预载管线兜底)按 review 结论维持现状,不在本 PR 范围。

另:runtime `background` 分支顶部注释原本在 "scaled-fade" 处截断、且 "load-failure 覆盖" 表述不准,已重写。

### sidecar 的 key 规范(小写)

sidecar/web 资源的 key 是 **bundle container 路径 stem(全小写)**;1021 个 sprite 里有 99 个 `m_Name` 保留大写(如 `21_G7_*`、`bg_Festival_2`),直接拿 m_Name 当 key 会查表落空、走错兜底(其中 61 个原生渲染尺寸 ≠ 1280×720)。widget 查表前做 `toLowerCase()` 归一,torappu 导出侧同理。

### 数据链与部署依赖

```
torappu avg task ──→ storage/asset/raw/avg/background.json(key → ppu,1021 条)
                        │ 随资源管线发布到 torappu.prts.wiki/assets/avg/
                        ▼
widget 启动时与 character.json 并行拉取(fetch 失败 → 空表,走兜底)
                        ▼
原生渲染尺寸 = PNG尺寸 ÷ ppu × 100
```

sidecar 由 torappu 仓库的 avg task 随 PNG 一起产出(同管线、天然同版本)。**在 sidecar 部署到资源站之前,widget 自动退回兜底**(16:9 → 1280×720):对 ppu=80/100 的 1280×720 类资产与游戏一致,对 ppu 68.2464/64 等超采样资产缺少 17~25% 的裁边、对 26 条黑边语料会错误铺满——部署后即全部精确,无需 widget 发版。

## 验证用剧情文件

语料:`torappu/storage/asset/gamedata/latest/story`(共 15611 条 `background` 命令;`width=` 193 条、缺省 `screenadapt` 505 条 + 清屏约 57 条、`tiled` 1 条):

- **修复 1 + 2(乘数 × ppu 原生尺寸)**:
  - `obt/main/level_main_01-03_end.txt:3` — `[Background(image="bg_cher_1", width=1, height=1, fadetime=0)]`:1024×576 纹理、ppu 68.2464 → 渲染 **1500.44×844 超采样居中铺满**(此前实现显示 1024×576 带黑边);
  - `obt/guide/shop/0_main_and_extraqc.txt:3` — `[Background(image="bg_abyss_1",width=1.7, height=1.7)]`(1.7 倍乘数作用在原生渲染尺寸上);
- **修复 2(游戏里真的有黑边的那 26 条)**:`activities/act21side/level_act21side_06_beg.txt` — `33_g4_srctheater`(ppu 100 → 1024×576 居中露底色,铺满反而错);
- **修复 1(乘数参与 screenadapt 比例判断)**:`obt/main/level_main_04-01_beg.txt:8` — `[Background(screenadapt="coverall", image="bg_ri_1", width=1, height=1, fadetime=2, block=true)]`;
- **修复 4(tiled)**:`obt/memory/story_mizuki_1_1.txt:511` — `[Background(image="bg_ri_1",xScale=1.02,yScale=1.02,width=1.02,height=1.02,tiled=true)]`(全语料唯一一条 tiled,同时覆盖乘数 + 平铺;单块 1500.44×844、总矩形 1530.45×860.88,多铺出 2% 边条);
- **修复 3(加载失败清屏)**:生产剧情不会引用不存在的贴图,语料 0 命中,属前瞻对齐,由单测锁定:`tests/renderer.spec.ts` → "clears the previous background when the texture fails to load"。

## 测试

- `pnpm test`:24 个文件 296 用例全部通过(其中本 PR 相关新增:ppu 现算 ×1、黑边资产 ×1、sidecar 大小写归一 ×1、16:9 兜底 ×1、tiled 尺寸/tileScale 断言、`normalizeBackgroundPpuMap` ×3);
- `pnpm exec vue-tsc -b` 通过;
- `pnpm exec eslint <改动文件>` 通过。
