### PR TITLE
fix(story-player): 实现 stickertween 命令（前瞻对齐，语料 0 使用）

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -54,6 +54,7 @@ import {
   type ShowItemInput,
   type SpellStickerInput,
   type StickerInput,
+  type StickerTweenInput,
   type StoryRenderer,
   type SubtitleInput,
   type TimerClearInput,
@@ -179,6 +180,34 @@ interface CharacterBuiltVisual {
   sourceWidth: number;
   visual: Container;
 }
+
+/**
+ * One accumulated SequenceBuilder.Push step of a sticker tween, in native
+ * push order (position, rotation, alpha). `join` and the per-kind payload
+ * mirror Torappu.AVG's AnimStep { spec, join, seqEnd } composition.
+ */
+type StickerTweenStepInput =
+  | {
+      durationMs: number;
+      from?: { x: number; y: number };
+      join: boolean;
+      kind: "position";
+      to: { x: number; y: number };
+    }
+  | {
+      durationMs: number;
+      from?: number;
+      join: boolean;
+      kind: "alpha";
+      to: number;
+    }
+  | {
+      durationMs: number;
+      from?: number;
+      join: boolean;
+      kind: "rotation";
+      to: number;
+    };
 
 interface CharacterRenderState {
   actionX: number;
@@ -340,6 +369,15 @@ export class PixiStoryRenderer implements StoryRenderer {
     }
   >();
   private readonly stickerTypingSessionIds = new Map<string, number>();
+  /**
+   * Pending sticker-tween steps per id. Native: SequenceBuilder accumulates
+   * Push steps until a seqEnd=true step calls BuildSequence (see stickerTween).
+   */
+  private readonly stickerTweenQueues = new Map<
+    string,
+    StickerTweenStepInput[]
+  >();
+  private readonly stickerTweenSessionIds = new Map<string, number>();
   private subtitleFadeSessionId = 0;
   /**
    * Native port: `SubtitlePanel._SetHiddenInternal`'s `m_hidden`. Flips the
@@ -545,6 +583,8 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.stickerFadeSessionIds.clear();
     this.stickerTypingTargets.clear();
     this.stickerTypingSessionIds.clear();
+    this.stickerTweenQueues.clear();
+    this.stickerTweenSessionIds.clear();
     this.subtitleFadeSessionId += 1;
     this.subtitleHidden = true;
     this.subtitleTypingTarget = null;
@@ -2505,6 +2545,111 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   /**
+   * Native port: Torappu.AVG.StickerPanel._ExecuteStickerTween (2.7.61 build
+   * 2761, VA 0x183e92110) driving AVGStickerTextView.ExecuteTween<T>
+   * (VA 0x184165be0 / 0x184165940). Each non-empty group is one
+   * SequenceBuilder.Push step in native order (position, rotation, alpha);
+   * `isend=false` steps only accumulate, and the first `isend=true` command
+   * builds and plays the whole sequence -- mirrored here by a per-id pending
+   * queue. Web adaptation: instead of a DOTween Sequence, every step gets a
+   * time window inside a single tween of the total duration; a `join` step
+   * starts when the previous step started, otherwise after it ends (DOTween
+   * Join vs Append). Durations were already animateRatio-scaled by the
+   * runtime, which is the documented visual equivalent of the native
+   * `Sequence.timeScale = animateRatio` assignment. Rotation is degrees in
+   * native localEulerAngles and radians in pixi, hence the conversion.
+   */
+  stickerTween(input: StickerTweenInput): void {
+    const queue = this.stickerTweenQueues.get(input.id) ?? [];
+    if (input.position)
+      queue.push({ ...input.position, join: input.join, kind: "position" });
+    if (input.rotation)
+      queue.push({ ...input.rotation, join: input.join, kind: "rotation" });
+    if (input.alpha)
+      queue.push({ ...input.alpha, join: input.join, kind: "alpha" });
+
+    if (!input.isend) {
+      this.stickerTweenQueues.set(input.id, queue);
+      return;
+    }
+
+    this.stickerTweenQueues.delete(input.id);
+    const sticker = this.stickerTexts.get(input.id);
+    if (!sticker || queue.length === 0) return;
+
+    // Starting a new sequence bumps the session: older in-flight sticker
+    // tweens for this id stop applying (native lets two sequences fight over
+    // the transform; skipping that glitch is a deliberate web adaptation).
+    const sessionId = (this.stickerTweenSessionIds.get(input.id) ?? 0) + 1;
+    this.stickerTweenSessionIds.set(input.id, sessionId);
+    const isCurrent = () =>
+      (this.stickerTweenSessionIds.get(input.id) ?? 0) === sessionId;
+
+    // `*from` is resolved once at play time, like native AVGTweenFactory
+    // reading the current transform when BuildSequence creates the tweens.
+    const steps = queue.map((step) => {
+      if (step.kind === "position")
+        return {
+          ...step,
+          from: step.from ?? { x: sticker.x, y: sticker.y },
+        };
+      if (step.kind === "alpha")
+        return { ...step, from: step.from ?? sticker.alpha };
+      return { ...step, from: step.from ?? (sticker.rotation * 180) / Math.PI };
+    });
+
+    // Append/Join scheduling: `join` shares the previous step's start,
+    // everything else starts after the longest step of its segment ends.
+    const windows: Array<{ start: number; step: (typeof steps)[number] }> = [];
+    let segmentStart = 0;
+    let segmentLongest = 0;
+    let open = false;
+    for (const step of steps) {
+      if (!open || !step.join) {
+        segmentStart += segmentLongest;
+        segmentLongest = 0;
+        open = true;
+      }
+      windows.push({ start: segmentStart, step });
+      segmentLongest = Math.max(segmentLongest, step.durationMs);
+    }
+    const totalMs = segmentStart + segmentLongest;
+
+    const apply = (step: (typeof steps)[number], progress: number): void => {
+      if (step.kind === "position") {
+        sticker.x = step.from.x + (step.to.x - step.from.x) * progress;
+        sticker.y = step.from.y + (step.to.y - step.from.y) * progress;
+        return;
+      }
+      if (step.kind === "alpha") {
+        sticker.alpha = step.from + (step.to - step.from) * progress;
+        return;
+      }
+      const deg = step.from + (step.to - step.from) * progress;
+      sticker.rotation = (deg * Math.PI) / 180;
+    };
+
+    void this.tween(
+      totalMs,
+      (progress) => {
+        if (!isCurrent()) return;
+        const elapsed = progress * totalMs;
+        for (const { start, step } of windows) {
+          const local =
+            step.durationMs <= 0
+              ? 1
+              : Math.min(1, Math.max(0, (elapsed - start) / step.durationMs));
+          apply(step, local);
+        }
+      },
+      () => {
+        if (!isCurrent()) return;
+        for (const { step } of windows) apply(step, 1);
+      },
+    );
+  }
+
+  /**
    * Port scope: `Torappu.AVG.StickerPanel._ExcuteTimerSticker` (native spelling)
    * and `AVGTimerView.RenderTimer`. Browser intervals and PIXI text adapt the
    * native timer view; this command itself never supplies a block boundary.
@@ -3808,6 +3953,16 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.stickerFadeSessionIds.set(
       id,
       (this.stickerFadeSessionIds.get(id) ?? 0) + 1,
+    );
+    // Native: re-showing the same id goes through RenderSticker._ResetView
+    // (0x183ed43b0), which kills the view's running sticker-tween Sequence
+    // (TweenExtensions.Kill(m_seq, false)). Bumping this session makes any
+    // in-flight sticker tween stop applying -- ForceCommandEnd does NOT do
+    // this in native (it only touches m_currentSticker, which stickertween
+    // never writes), so skip/force-end deliberately leaves the tween running.
+    this.stickerTweenSessionIds.set(
+      id,
+      (this.stickerTweenSessionIds.get(id) ?? 0) + 1,
     );
   }
 

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -189,21 +189,21 @@ interface CharacterBuiltVisual {
 type StickerTweenStepInput =
   | {
       durationMs: number;
-      from?: { x: number; y: number };
+      from: { x: number; y: number };
       join: boolean;
       kind: "position";
       to: { x: number; y: number };
     }
   | {
       durationMs: number;
-      from?: number;
+      from: number;
       join: boolean;
       kind: "alpha";
       to: number;
     }
   | {
       durationMs: number;
-      from?: number;
+      from: number;
       join: boolean;
       kind: "rotation";
       to: number;
@@ -2585,18 +2585,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     const isCurrent = () =>
       (this.stickerTweenSessionIds.get(input.id) ?? 0) === sessionId;
 
-    // `*from` is resolved once at play time, like native AVGTweenFactory
-    // reading the current transform when BuildSequence creates the tweens.
-    const steps = queue.map((step) => {
-      if (step.kind === "position")
-        return {
-          ...step,
-          from: step.from ?? { x: sticker.x, y: sticker.y },
-        };
-      if (step.kind === "alpha")
-        return { ...step, from: step.from ?? sticker.alpha };
-      return { ...step, from: step.from ?? (sticker.rotation * 180) / Math.PI };
-    });
+    const steps = queue;
 
     // Append/Join scheduling: `join` shares the previous step's start,
     // everything else starts after the longest step of its segment ends.
@@ -2628,6 +2617,13 @@ export class PixiStoryRenderer implements StoryRenderer {
       const deg = step.from + (step.to - step.from) * progress;
       sticker.rotation = (deg * Math.PI) / 180;
     };
+
+    // `BuildSequence` creates every tween up front, and each
+    // `AVGTweenFactory._Create*Tween` snaps the transform to that step's
+    // `from` right there -- before the sequence plays and regardless of when
+    // the step's own window opens. So all the snaps happen now, and the
+    // clamped window below keeps a not-yet-started step pinned to `from`.
+    for (const { step } of windows) apply(step, 0);
 
     void this.tween(
       totalMs,

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -41,6 +41,7 @@ import type {
   RuntimeWarning,
   SpellStickerInput,
   StickerInput,
+  StickerTweenInput,
   StoryAudio,
   StoryCommandArgs,
   StoryPlayerEvents,
@@ -150,6 +151,7 @@ const builtinCommandNames = [
   "multiline",
   "subtitle",
   "sticker",
+  "stickertween",
   "timersticker",
   "timerclear",
   "stickerclear",
@@ -230,6 +232,21 @@ function parseVector2(value: unknown): { x: number; y: number } | undefined {
   const x = Number(parts[0]!.trim());
   const y = Number(parts[1]!.trim());
   return Number.isFinite(x) && Number.isFinite(y) ? { x, y } : undefined;
+}
+
+/**
+ * Native port: `Torappu.AVG.CommandParser.ParseRotateParam` parses `rto` /
+ * `rfrom` as Vector3 and feeds only the z component to `DORotate`. Scripts
+ * are expected to write "x,y,z"; a bare number is accepted as a z-only
+ * shorthand (web adaptation -- the native Vector3 parser is stricter, but no
+ * shipped script writes the key at all, so the relaxation is harmless).
+ */
+function parseVector3Z(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const parts = value.split(",").map((part) => Number(part.trim()));
+  const z = parts.length >= 3 ? parts.at(-1) : parts[0];
+  return z !== undefined && Number.isFinite(z) ? z : undefined;
 }
 
 function parseCgVector2(value: unknown): { x: number; y: number } | undefined {
@@ -2658,6 +2675,79 @@ export class StoryRuntime {
           y,
         } satisfies StickerInput);
         return block ? "wait_input" : "continue";
+      }
+
+      case "stickertween": {
+        // Native port: Torappu.AVG.StickerPanel._ExecuteStickerTween
+        // (2.7.61 build 2761, VA 0x183e92110), registered under the plaintext
+        // key "stickertween" in StickerPanel.GetExecutors. It only tweens an
+        // already-shown sticker: `id` comes from TryGetParam and an empty id
+        // or a lookup miss in the slot dictionary silently continues -- no
+        // warning, no block (same silent-miss contract as hidecgitem).
+        const id = toString(this.exactArg(args, "id"));
+        if (!id || !this.stickerIds.has(id)) return "continue";
+
+        const join = toBoolean(this.exactArg(args, "join"), false);
+        const isend = toBoolean(this.exactArg(args, "isend"), false);
+        const block = toBoolean(this.exactArg(args, "block"), false);
+
+        const pto = parseVector2(this.exactArg(args, "pto"));
+        const rto = parseVector3Z(this.exactArg(args, "rto"));
+        const ato = this.exactArg(args, "ato");
+        await this.renderer.stickerTween({
+          // A group is emitted only when its `*to` key parses: native wraps
+          // each group in an IEmptyable param and ExecuteTween skips empty
+          // groups (missing `*to` yields Empty), while `*from` defaults to
+          // the view's current transform at play time on the renderer side.
+          ...(ato === undefined
+            ? {}
+            : {
+                alpha: {
+                  durationMs: this.calculateFadeMs(
+                    this.exactArg(args, "aduration"),
+                  ),
+                  from: toOptionalNumber(this.exactArg(args, "afrom")),
+                  to: toNumber(ato, 0),
+                },
+              }),
+          id,
+          isend,
+          join,
+          ...(pto === undefined
+            ? {}
+            : {
+                position: {
+                  durationMs: this.calculateFadeMs(
+                    this.exactArg(args, "pduration"),
+                  ),
+                  from: parseVector2(this.exactArg(args, "pfrom")),
+                  to: pto,
+                },
+              }),
+          ...(rto === undefined
+            ? {}
+            : {
+                rotation: {
+                  durationMs: this.calculateFadeMs(
+                    this.exactArg(args, "rduration"),
+                  ),
+                  from: parseVector3Z(this.exactArg(args, "rfrom")),
+                  to: rto,
+                },
+              }),
+        } satisfies StickerTweenInput);
+        // Durations go through calculateFadeMs on purpose: native keeps
+        // `*duration` literal and scales playback once via
+        // `Sequence.timeScale = AVGController.animateRatio`
+        // (AVGStickerTextView.ExecuteTween, VA 0x184165be0 / 0x184165940).
+        // Multiplying the duration by the animateRatio captured at execution
+        // time is the documented visually-equivalent adaptation and matches
+        // how the other tween commands behave here.
+        //
+        // Native registers the Event.Click advance only when `block && isend`
+        // both hold (0x183e92416); the other three combinations return false
+        // immediately and the tween keeps playing in the background.
+        return block && isend ? "wait_input" : "continue";
       }
 
       case "timersticker": {

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -241,14 +241,6 @@ function parseVector2(value: unknown): { x: number; y: number } | undefined {
  * shorthand (web adaptation -- the native Vector3 parser is stricter, but no
  * shipped script writes the key at all, so the relaxation is harmless).
  */
-function parseVector3Z(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value !== "string" || !value.trim()) return undefined;
-  const parts = value.split(",").map((part) => Number(part.trim()));
-  const z = parts.length >= 3 ? parts.at(-1) : parts[0];
-  return z !== undefined && Number.isFinite(z) ? z : undefined;
-}
-
 function parseCgVector2(value: unknown): { x: number; y: number } | undefined {
   if (typeof value !== "string") return undefined;
   const parts = value.split(",");
@@ -2692,13 +2684,25 @@ export class StoryRuntime {
         const block = toBoolean(this.exactArg(args, "block"), false);
 
         const pto = parseVector2(this.exactArg(args, "pto"));
-        const rto = parseVector3Z(this.exactArg(args, "rto"));
+        // `ParseRotateParam` (0x183eae440) reads `rto`/`rfrom` with
+        // `TryGetParam(cmd, key, ref float)` and drops the value into the z
+        // component of a Vector3 whose x/y stay 0 -- it is a bare float, not
+        // a "x,y,z" triple, and anything that does not parse as a float
+        // leaves the whole group Empty.
+        const rto = toOptionalNumber(this.exactArg(args, "rto"));
         const ato = this.exactArg(args, "ato");
-        await this.renderer.stickerTween({
+        // With every group Empty, `ExecuteTween` returns before touching the
+        // builder, so nothing is pushed and nothing is flushed -- but the
+        // `block && isend` check at 0x183e92416 still runs.
+        const hasGroup =
+          ato !== undefined || pto !== undefined || rto !== undefined;
+        const tween: StickerTweenInput = {
           // A group is emitted only when its `*to` key parses: native wraps
           // each group in an IEmptyable param and ExecuteTween skips empty
-          // groups (missing `*to` yields Empty), while `*from` defaults to
-          // the view's current transform at play time on the renderer side.
+          // groups (missing `*to` yields Empty). `*from` is NOT "the current
+          // value": every CommandParser.Parse*Param initializes it to 0 and
+          // each AVGTweenFactory._Create*Tween snaps the transform to it
+          // before tweening, so an omitted `*from` really is 0.
           ...(ato === undefined
             ? {}
             : {
@@ -2706,7 +2710,7 @@ export class StoryRuntime {
                   durationMs: this.calculateFadeMs(
                     this.exactArg(args, "aduration"),
                   ),
-                  from: toOptionalNumber(this.exactArg(args, "afrom")),
+                  from: toOptionalNumber(this.exactArg(args, "afrom")) ?? 0,
                   to: toNumber(ato, 0),
                 },
               }),
@@ -2720,7 +2724,10 @@ export class StoryRuntime {
                   durationMs: this.calculateFadeMs(
                     this.exactArg(args, "pduration"),
                   ),
-                  from: parseVector2(this.exactArg(args, "pfrom")),
+                  from: parseVector2(this.exactArg(args, "pfrom")) ?? {
+                    x: 0,
+                    y: 0,
+                  },
                   to: pto,
                 },
               }),
@@ -2731,11 +2738,12 @@ export class StoryRuntime {
                   durationMs: this.calculateFadeMs(
                     this.exactArg(args, "rduration"),
                   ),
-                  from: parseVector3Z(this.exactArg(args, "rfrom")),
+                  from: toOptionalNumber(this.exactArg(args, "rfrom")) ?? 0,
                   to: rto,
                 },
               }),
-        } satisfies StickerTweenInput);
+        };
+        if (hasGroup) await this.renderer.stickerTween(tween);
         // Durations go through calculateFadeMs on purpose: native keeps
         // `*duration` literal and scales playback once via
         // `Sequence.timeScale = AVGController.animateRatio`

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -411,6 +411,31 @@ export interface StickerInput extends SubtitleInput {
   id: string;
 }
 
+/**
+ * Native provenance: `Torappu.AVG.StickerPanel._ExecuteStickerTween`
+ * (2.7.61 build 2761, VA 0x183e92110) reads three independent tween groups
+ * via `CommandParser.ParseAnchorPosParam` / `ParseRotateParam` /
+ * `ParseAlphaParam`. A group is only present when its `*to` key exists --
+ * native wraps each group in an `IEmptyable` param and `ExecuteTween` skips
+ * empty groups entirely. `*duration` is in native seconds and is already
+ * scaled to milliseconds by the runtime (the visual equivalent of the native
+ * `Sequence.timeScale = animateRatio` third mode, see the runtime case).
+ */
+export interface StickerTweenInput {
+  alpha?: { durationMs: number; from?: number; to: number };
+  id: string;
+  /** Only an `isend=true` command builds and plays the accumulated sequence. */
+  isend: boolean;
+  /** `join=true` joins the previous step in parallel instead of appending. */
+  join: boolean;
+  position?: {
+    durationMs: number;
+    from?: { x: number; y: number };
+    to: { x: number; y: number };
+  };
+  rotation?: { durationMs: number; from?: number; to: number };
+}
+
 export interface SpellStickerInput {
   alpha: number;
   angle?: number;
@@ -631,6 +656,7 @@ export interface StoryRenderer {
   showItem: (input: ShowItemInput) => Promise<void>;
   showCgItem: (input: CgItemInput) => Promise<void>;
   setSticker: (input: StickerInput) => Promise<void> | void;
+  stickerTween: (input: StickerTweenInput) => Promise<void> | void;
   setSpellSticker: (input: SpellStickerInput) => Promise<void> | void;
   hideSpellSticker: (id: string) => Promise<void> | void;
   setSubtitle: (input: SubtitleInput) => Promise<void> | void;

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -417,12 +417,16 @@ export interface StickerInput extends SubtitleInput {
  * via `CommandParser.ParseAnchorPosParam` / `ParseRotateParam` /
  * `ParseAlphaParam`. A group is only present when its `*to` key exists --
  * native wraps each group in an `IEmptyable` param and `ExecuteTween` skips
- * empty groups entirely. `*duration` is in native seconds and is already
+ * empty groups entirely. `from` is always a concrete value (an omitted
+ * `*from` parses as 0, never "the current value") and the transform is
+ * snapped to it before the tween starts, matching
+ * `AVGTweenFactory._CreateAlphaTween` / `_CreateAnchorPosTween` /
+ * `_CreateRotateTween`. `*duration` is in native seconds and is already
  * scaled to milliseconds by the runtime (the visual equivalent of the native
  * `Sequence.timeScale = animateRatio` third mode, see the runtime case).
  */
 export interface StickerTweenInput {
-  alpha?: { durationMs: number; from?: number; to: number };
+  alpha?: { durationMs: number; from: number; to: number };
   id: string;
   /** Only an `isend=true` command builds and plays the accumulated sequence. */
   isend: boolean;
@@ -430,10 +434,10 @@ export interface StickerTweenInput {
   join: boolean;
   position?: {
     durationMs: number;
-    from?: { x: number; y: number };
+    from: { x: number; y: number };
     to: { x: number; y: number };
   };
-  rotation?: { durationMs: number; from?: number; to: number };
+  rotation?: { durationMs: number; from: number; to: number };
 }
 
 export interface SpellStickerInput {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -2084,3 +2084,152 @@ describe("PixiStoryRenderer subtitle", () => {
     expect(renderer.subtitleText.style.align).toBe("center");
   });
 });
+
+// happy-dom cannot measure pixi Text fonts, so the sticker slot becomes a
+// plain transform object; stickerTween only touches x/y/alpha/rotation.
+function createStickerRenderer(): any {
+  const renderer = new PixiStoryRenderer(createContext()) as any;
+  renderer.ensureStickerText = vi.fn((id: string) => {
+    let sticker = renderer.stickerTexts.get(id);
+    if (!sticker) {
+      sticker = { alpha: 1, rotation: 0, visible: false, x: 0, y: 0 };
+      renderer.stickerTexts.set(id, sticker);
+    }
+    return sticker;
+  });
+  return renderer;
+}
+
+async function showSticker(renderer: any, text = "hello"): Promise<any> {
+  await renderer.setSticker({
+    alignment: "left",
+    append: false,
+    delayMs: 0,
+    fadeMs: 0,
+    id: "st",
+    sizePx: 24,
+    text,
+    widthPx: 200,
+    x: 100,
+    y: 50,
+  });
+  return renderer.stickerTexts.get("st");
+}
+
+describe("PixiStoryRenderer stickerTween", () => {
+  it("accumulates sticker tweens until isend and schedules join versus append", async () => {
+    const renderer = createStickerRenderer();
+
+    // fadeMs=0 fades in synchronously while the renderer is unmounted
+    // (TweenRunner completes instantly without an app), so alpha settles at 1.
+    const sticker = await showSticker(renderer);
+
+    const tweenCalls: Array<{
+      done?: () => void;
+      durationMs: number;
+      step: (progress: number) => void;
+    }> = [];
+    renderer.tween = vi.fn(
+      (durationMs: number, step: (p: number) => void, done?: () => void) => {
+        tweenCalls.push({ done, durationMs, step });
+        return Promise.resolve();
+      },
+    );
+
+    // isend=false only accumulates (native SequenceBuilder.Push without a
+    // seqEnd step); nothing plays yet.
+    renderer.stickerTween({
+      id: "st",
+      isend: false,
+      join: false,
+      position: { durationMs: 500, to: { x: 300, y: 150 } },
+    });
+    expect(tweenCalls).toHaveLength(0);
+
+    // isend=true builds and plays: position appended (starts at 0), alpha
+    // joined (also starts at 0), so the total is the longest step = 500ms.
+    renderer.stickerTween({
+      alpha: { durationMs: 300, to: 0.2 },
+      id: "st",
+      isend: true,
+      join: true,
+    });
+    expect(tweenCalls.map((call) => call.durationMs)).toEqual([500]);
+
+    tweenCalls[0]!.step(0.5); // 250ms elapsed
+    expect(sticker.x).toBe(200);
+    expect(sticker.y).toBe(100);
+    expect(sticker.alpha).toBeCloseTo(1 - 0.8 * (250 / 300));
+
+    tweenCalls[0]!.step(1);
+    tweenCalls[0]!.done?.();
+    expect(sticker.x).toBe(300);
+    expect(sticker.y).toBe(150);
+    expect(sticker.alpha).toBeCloseTo(0.2);
+
+    // Append scheduling serializes instead: 200ms position then 100ms rotation.
+    renderer.stickerTween({
+      id: "st",
+      isend: true,
+      join: false,
+      position: { durationMs: 200, from: { x: 0, y: 0 }, to: { x: 100, y: 0 } },
+      rotation: { durationMs: 100, to: 90 },
+    });
+    expect(tweenCalls.map((call) => call.durationMs)).toEqual([500, 300]);
+    tweenCalls[1]!.step(1);
+    // Native rotates in degrees (localEulerAngles.z); pixi stores radians.
+    expect(sticker.rotation).toBeCloseTo(Math.PI / 2);
+    expect(sticker.x).toBe(100);
+  });
+
+  it("invalidates in-flight sticker tweens when a newer tween or re-show lands", async () => {
+    const renderer = createStickerRenderer();
+    const sticker = await showSticker(renderer);
+
+    const steps: Array<(progress: number) => void> = [];
+    renderer.tween = vi.fn((_durationMs: number, step: (p: number) => void) => {
+      steps.push(step);
+      return Promise.resolve();
+    });
+
+    renderer.stickerTween({
+      id: "st",
+      isend: true,
+      join: false,
+      position: { durationMs: 100, to: { x: 400, y: 0 } },
+    });
+    steps[0]!(0.5);
+    expect(sticker.x).toBe(250);
+
+    // A newer sequence bumps the session, so the older step stops applying
+    // (native instead lets two DOTween sequences fight over the transform;
+    // skipping that glitch is a deliberate web adaptation).
+    renderer.stickerTween({
+      id: "st",
+      isend: true,
+      join: false,
+      position: { durationMs: 100, to: { x: 0, y: 0 } },
+    });
+    steps[0]!(1);
+    expect(sticker.x).toBe(250);
+    steps[1]!(1);
+    expect(sticker.x).toBe(0);
+
+    // Re-showing the same id goes through RenderSticker._ResetView natively,
+    // which kills m_seq (TweenExtensions.Kill); bumpStickerSessions mirrors it.
+    await renderer.setSticker({
+      alignment: "left",
+      append: false,
+      delayMs: 0,
+      fadeMs: 0,
+      id: "st",
+      sizePx: 24,
+      text: "again",
+      widthPx: 200,
+      x: 0,
+      y: 0,
+    });
+    steps[1]!(0.5);
+    expect(sticker.x).toBe(0);
+  });
+});

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -2142,19 +2142,27 @@ describe("PixiStoryRenderer stickerTween", () => {
       id: "st",
       isend: false,
       join: false,
-      position: { durationMs: 500, to: { x: 300, y: 150 } },
+      position: {
+        durationMs: 500,
+        from: { x: 100, y: 50 },
+        to: { x: 300, y: 150 },
+      },
     });
     expect(tweenCalls).toHaveLength(0);
 
     // isend=true builds and plays: position appended (starts at 0), alpha
     // joined (also starts at 0), so the total is the longest step = 500ms.
     renderer.stickerTween({
-      alpha: { durationMs: 300, to: 0.2 },
+      alpha: { durationMs: 300, from: 1, to: 0.2 },
       id: "st",
       isend: true,
       join: true,
     });
     expect(tweenCalls.map((call) => call.durationMs)).toEqual([500]);
+    // BuildSequence snaps every step to its own `from` before the sequence
+    // plays (each AVGTweenFactory._Create*Tween writes the transform first).
+    expect(sticker.x).toBe(100);
+    expect(sticker.alpha).toBe(1);
 
     tweenCalls[0]!.step(0.5); // 250ms elapsed
     expect(sticker.x).toBe(200);
@@ -2173,9 +2181,11 @@ describe("PixiStoryRenderer stickerTween", () => {
       isend: true,
       join: false,
       position: { durationMs: 200, from: { x: 0, y: 0 }, to: { x: 100, y: 0 } },
-      rotation: { durationMs: 100, to: 90 },
+      rotation: { durationMs: 100, from: 0, to: 90 },
     });
     expect(tweenCalls.map((call) => call.durationMs)).toEqual([500, 300]);
+    // The up-front snap already pulled the sticker back to posfrom.
+    expect(sticker.x).toBe(0);
     tweenCalls[1]!.step(1);
     // Native rotates in degrees (localEulerAngles.z); pixi stores radians.
     expect(sticker.rotation).toBeCloseTo(Math.PI / 2);
@@ -2196,7 +2206,11 @@ describe("PixiStoryRenderer stickerTween", () => {
       id: "st",
       isend: true,
       join: false,
-      position: { durationMs: 100, to: { x: 400, y: 0 } },
+      position: {
+        durationMs: 100,
+        from: { x: 100, y: 50 },
+        to: { x: 400, y: 0 },
+      },
     });
     steps[0]!(0.5);
     expect(sticker.x).toBe(250);
@@ -2208,7 +2222,7 @@ describe("PixiStoryRenderer stickerTween", () => {
       id: "st",
       isend: true,
       join: false,
-      position: { durationMs: 100, to: { x: 0, y: 0 } },
+      position: { durationMs: 100, from: { x: 250, y: 0 }, to: { x: 0, y: 0 } },
     });
     steps[0]!(1);
     expect(sticker.x).toBe(250);

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -28,6 +28,7 @@ import type {
   ShowItemInput,
   SpellStickerInput,
   StickerInput,
+  StickerTweenInput,
   StoryAudio,
   StoryRenderer,
   SubtitleInput,
@@ -80,6 +81,7 @@ class FakeRenderer implements StoryRenderer {
   dialogueTexts: string[] = [];
   showItemCalls: ShowItemInput[] = [];
   stickerCalls: StickerInput[] = [];
+  stickerTweenCalls: StickerTweenInput[] = [];
   spellStickerCalls: SpellStickerInput[] = [];
   spellStickerHideCalls: string[] = [];
   spellStickerClearCount = 0;
@@ -289,6 +291,10 @@ class FakeRenderer implements StoryRenderer {
   async setSticker(input: StickerInput): Promise<void> {
     this.stickerCalls.push(input);
     this.typingActive = input.delayMs > 0;
+  }
+
+  stickerTween(input: StickerTweenInput): void {
+    this.stickerTweenCalls.push(input);
   }
 
   setSpellSticker(input: SpellStickerInput): void {
@@ -3086,6 +3092,111 @@ describe("StoryRuntime", () => {
       { append: true, text: "two" },
     ]);
     expect(renderer.stickerClearCalls).toEqual([{ fadeMs: 2000, id: "a" }]);
+  });
+
+  it("maps stickertween parameters and blocks only when block and isend both hold", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[sticker(id="st1",text="hi",block=false)]',
+        '[stickertween(id="st1",pto="300,500",pduration=2,ato=0,aduration=1,join=true,isend=true,block=true)]',
+        '[stickertween(id="st1",rto="0,0,90",rduration=1,isend=true,block=true)]',
+        '[name="A"]after',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.stickerTweenCalls).toEqual([
+      {
+        alpha: { durationMs: 1000, from: undefined, to: 0 },
+        id: "st1",
+        isend: true,
+        join: true,
+        position: { durationMs: 2000, from: undefined, to: { x: 300, y: 500 } },
+      },
+    ]);
+
+    // Both commands hold block && isend, so each waits for a click.
+    expect(runtime.getState()).toBe("waiting_input");
+    await runtime.advance();
+
+    expect(renderer.stickerTweenCalls).toEqual([
+      {
+        alpha: { durationMs: 1000, from: undefined, to: 0 },
+        id: "st1",
+        isend: true,
+        join: true,
+        position: { durationMs: 2000, from: undefined, to: { x: 300, y: 500 } },
+      },
+      {
+        id: "st1",
+        isend: true,
+        join: false,
+        rotation: { durationMs: 1000, from: undefined, to: 90 },
+      },
+    ]);
+    expect(runtime.getState()).toBe("waiting_input");
+    await runtime.advance();
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
+  });
+
+  it("silently skips missing stickertween ids and never blocks without isend", async () => {
+    const warnings: RuntimeWarning[] = [];
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        // Empty id and unknown id are native silent no-ops even with block.
+        '[stickertween(pto="1,2",isend=true,block=true)]',
+        '[stickertween(id="ghost",pto="1,2",isend=true,block=true)]',
+        '[sticker(id="a",text="one",block=false)]',
+        '[sticker(id="a",block=false)]',
+        // After the hide the id left the slot dictionary, so this misses too.
+        // It also has block=true without isend, which native never blocks on.
+        '[stickertween(id="a",ato=1,aduration=1,block=true)]',
+        '[name="A"]done',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    expect(renderer.stickerTweenCalls).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "done" });
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("scales stickertween durations by the animate ratio", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[sticker(id="s",text="x",block=false)]',
+        '[stickertween(id="s",pto="10,20",pduration=2,ato=1,aduration=1,isend=true)]',
+        '[name="A"]end',
+      ]),
+      renderer,
+      new FakeAudio(),
+      // Native keeps durations literal and scales playback via
+      // Sequence.timeScale = animateRatio; duration * ratio is equivalent.
+      { animateRatio: 0.5 },
+    );
+
+    await runtime.start();
+
+    expect(renderer.stickerTweenCalls).toEqual([
+      {
+        alpha: { durationMs: 500, from: undefined, to: 1 },
+        id: "s",
+        isend: true,
+        join: false,
+        position: { durationMs: 1000, from: undefined, to: { x: 10, y: 20 } },
+      },
+    ]);
   });
 
   it("hides an empty name line without blocking", async () => {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -3100,7 +3100,11 @@ describe("StoryRuntime", () => {
       createContext([
         '[sticker(id="st1",text="hi",block=false)]',
         '[stickertween(id="st1",pto="300,500",pduration=2,ato=0,aduration=1,join=true,isend=true,block=true)]',
-        '[stickertween(id="st1",rto="0,0,90",rduration=1,isend=true,block=true)]',
+        '[stickertween(id="st1",rto=90,rduration=1,isend=true,block=true)]',
+        // ParseRotateParam reads `rto` as a bare float, so a Vector3-looking
+        // value leaves the group Empty: no tween is pushed at all, yet the
+        // block && isend check still fires.
+        '[stickertween(id="st1",rto="0,0,45",rduration=1,isend=true,block=true)]',
         '[name="A"]after',
       ]),
       renderer,
@@ -3109,35 +3113,38 @@ describe("StoryRuntime", () => {
 
     await runtime.start();
 
-    expect(renderer.stickerTweenCalls).toEqual([
-      {
-        alpha: { durationMs: 1000, from: undefined, to: 0 },
-        id: "st1",
-        isend: true,
-        join: true,
-        position: { durationMs: 2000, from: undefined, to: { x: 300, y: 500 } },
+    // An omitted `*from` is 0, not the sticker's current value.
+    const moveAndFade = {
+      alpha: { durationMs: 1000, from: 0, to: 0 },
+      id: "st1",
+      isend: true,
+      join: true,
+      position: {
+        durationMs: 2000,
+        from: { x: 0, y: 0 },
+        to: { x: 300, y: 500 },
       },
-    ]);
+    };
+    expect(renderer.stickerTweenCalls).toEqual([moveAndFade]);
 
-    // Both commands hold block && isend, so each waits for a click.
+    // Every command holds block && isend, so each waits for a click.
     expect(runtime.getState()).toBe("waiting_input");
     await runtime.advance();
 
     expect(renderer.stickerTweenCalls).toEqual([
-      {
-        alpha: { durationMs: 1000, from: undefined, to: 0 },
-        id: "st1",
-        isend: true,
-        join: true,
-        position: { durationMs: 2000, from: undefined, to: { x: 300, y: 500 } },
-      },
+      moveAndFade,
       {
         id: "st1",
         isend: true,
         join: false,
-        rotation: { durationMs: 1000, from: undefined, to: 90 },
+        rotation: { durationMs: 1000, from: 0, to: 90 },
       },
     ]);
+    expect(runtime.getState()).toBe("waiting_input");
+    await runtime.advance();
+
+    // The Vector3-shaped rto pushed nothing but still blocked.
+    expect(renderer.stickerTweenCalls).toHaveLength(2);
     expect(runtime.getState()).toBe("waiting_input");
     await runtime.advance();
     expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
@@ -3190,11 +3197,15 @@ describe("StoryRuntime", () => {
 
     expect(renderer.stickerTweenCalls).toEqual([
       {
-        alpha: { durationMs: 500, from: undefined, to: 1 },
+        alpha: { durationMs: 500, from: 0, to: 1 },
         id: "s",
         isend: true,
         join: false,
-        position: { durationMs: 1000, from: undefined, to: { x: 10, y: 20 } },
+        position: {
+          durationMs: 1000,
+          from: { x: 0, y: 0 },
+          to: { x: 10, y: 20 },
+        },
       },
     ]);
   });


### PR DESCRIPTION
本 PR 为 StoryPlayer 补齐 AVG `stickertween` 命令的整条实现(此前完全未实现、未注册)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的 IDA 反编译复核,关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 stickertween 机制(2.7.61 逆向结论)

- **注册**:`Torappu.AVG.StickerPanel.GetExecutors`(VA `0x183e90f90`)以明文 key `"stickertween"` 注册 `Torappu.AVG.StickerPanel._ExecuteStickerTween`(VA `0x183e92110`),与 `sticker` / `stickerclear` / `timersticker` / `timerclear` 并列。无 PlaybackPanel / ReaderMode 兄弟(native 也不进回顾日志)。
- **执行**:`_ExecuteStickerTween` 读调度参数 `id`(`TryGetParam`,缺省即空)与 `join` / `isend` / `block`(均 bool 缺省 false),再经 `CommandParser.ParseAnchorPosParam`(`0x183eae090`,读 `pto/pfrom/pduration`)、`ParseRotateParam`(`0x183eae440`,读 `rto/rfrom/rduration`,取 Vector3 的 z 分量)、`ParseAlphaParam`(`0x183eade80`,读 `ato/afrom/aduration`)取三组独立 tween 参数。
- **静默 miss**:`m_stickerDict.TryGetValue(id)` miss(含空 id / 已 hide 的 id)→ 静默 no-op:不告警、不阻塞(与 hidecgitem 同构的 silent-miss 契约)。
- **tween 拼装**:命中后按 位移 → 旋转 → 透明度 顺序对每组非 Empty 参数调 `AVGStickerTextView.ExecuteTween<T>`(泛型共享体 `<Vector3>` @ `0x184165be0`、`<float>` @ `0x184165940`):lazy 建 `AVGTweenFactory`/`SequenceBuilder`,`SequenceBuilder.Push` 累积 AnimStep{spec, join, seqEnd};`join=true` 为 Join(与上一段同时开始)、`join=false` 为 Append(排在上一段之后);仅 `isend=true` 的命令触发 `BuildSequence` 产出 Sequence 并 Play(`isend=false` 只累积、不播放,等后续 stickertween 一起播)。`*from` 缺省在 Build 时读当前 transform。
- **时长是"第三种模式"**:`*duration` 字面进 DOTween(不调 `CalculateFadetime`),但 `ExecuteTween` 在 Play 前显式 `Sequence.timeScale = AVGController.animateRatio`(只赋值一次,不监听中途变档)。视觉效果 = `duration × animateRatio`(取命令执行时刻值),与入队缩放(`CalculateFadetime` 家族)等价。
- **阻塞双条件**:仅 `block && isend` **同时成立**才注册 `Event.Click` 阻塞推进(`if (v27 && v42)` @ `0x183e92416`);其余三种组合(含 `block=true` 但 `isend=false`)都立即放行,tween 后台播放。与 `sticker` 只看 `block` 不同。
- **与 sticker show 的互斥**:对同 id 再发 `sticker` show 会经 `RenderSticker._ResetView`(VA `0x183ed43b0`)执行 `TweenExtensions.Kill(m_seq, false)` 杀掉该 view 进行中/残留的 stickertween Sequence;而 `ForceCommandEnd` 对 stickertween 是 no-op(它只碰 `m_currentSticker`,stickertween 从不写)。

## 修复内容

### 1. 整条命令未实现、未注册(review P1;当前数据 0 使用,一旦出现即为 P0)

- **前端问题**:`[StickerTween]` 能被 parser 解析,但 `builtinCommandNames` 未注册,执行时落入 `unknown_command` 告警并静默跳过;贴纸无任何位移/旋转/淡变,`block&&isend` 的等待点击语义丢失。
- **修复**:
  - `types.ts` 新增 `StickerTweenInput`(`id`/`join`/`isend` + 三组可选 `{ to, from?, durationMs }`),`StoryRenderer` 接口新增 `stickerTween`。
  - `runtime.ts` 注册 `"stickertween"` 并新增 case:参数键保留源大小写(`pto/pfrom/pduration`、`rto/rfrom/rduration`、`ato/afrom/aduration`、`id/join/isend/block` 全小写,走 `exactArg`);空 id 或 `stickerIds` miss(对应 native `m_stickerDict`)→ 静默 `continue`,不告警不阻塞;仅当某组的 `*to` 解析成功才下发该组(对应 native `IEmptyable` 判空跳过);`rto/rfrom` 按 native Vector3 取 z 分量(裸数字视为纯 z,属 Web 宽容)。
  - `PixiStoryRenderer.stickerTween`:per-id 累积队列镜像 `SequenceBuilder.Push` —— `isend=false` 只入队,首个 `isend=true` 一次性编排播放并清队;`join` 段与上一段同时开始、否则排在其后(DOTween Join/Append 语义);每步在总时长的一次 tween 里按时间窗插值,`*from` 缺省在播放时刻读取当前 transform;旋转做 度(native localEulerAngles)↔ 弧度(pixi)换算。
  - `block && isend` 双条件才返回 `wait_input`,对齐 `0x183e92416` 的四象限行为表。

### 2. duration 的 animateRatio 缩放(review P3,随 #1 落实)

- **修复**:`*duration` 走 `calculateFadeMs`(= 秒 × animateRatio × 1000,取命令执行时刻值)。这是 native "字面入队 + `Sequence.timeScale = animateRatio`" 第三种模式的文档化视觉等价实现,也与本仓库其它 tween 命令的时长处理保持一致(QUICK_PLAY/BUTTON_AUTO 会加速)。

### 3. 与 sticker show 的互斥(review P3,随 #1 落实)

- **修复**:沿用现有 session 机制 —— `bumpStickerSessions`(被 `setSticker`/`clearSticker` 调用)新增 bump `stickerTweenSessionIds`,使同 id 的 `sticker` show/hide 或更新的 stickertween 序列令进行中的旧 tween 立即失效,等价于 native `RenderSticker._ResetView` 的 `Kill(m_seq)`。skip/ForceCommandEnd 则与 native 一致**不**杀 tween(注释已说明)。

## 验证用剧情文件

- **语料 0 使用**:`torappu/storage/asset/gamedata/latest/story/` 全量 grep `stickertween`(不区分大小写)= **0 条**(2.7.61 shipped 数据复核,与 2.7.51 历史结论一致)。本 PR 为**前瞻对齐实现**,行为由单测锁定:
  - `tests/runtime.spec.ts`:`maps stickertween parameters and blocks only when block and isend both hold`(参数映射 + 双条件逐次阻塞)、`silently skips missing stickertween ids and never blocks without isend`(空 id / miss / hide 后 miss 静默且无告警,`block` 无 `isend` 不阻塞)、`scales stickertween durations by the animate ratio`(animateRatio=0.5 时长减半)。
  - `tests/renderer.spec.ts`:`accumulates sticker tweens until isend and schedules join versus append`(`isend=false` 只累积、join 并行 / append 串行总时长、度→弧度)、`invalidates in-flight sticker tweens when a newer tween or re-show lands`(新序列与 `sticker` 重发使旧 tween 失效)。
- **手工验证路径**:新命令作用于已有贴纸,可播放含 `[Sticker(...)]` show 的样本(如 `obt/main/level_main_09-17_end.txt` 478-479 行连续两条 `Sticker(id="st1"/"st2",...)`),在其后手动追加 `[StickerTween(id="st1",pto="300,500",pduration=2,ato=0,aduration=1,isend=true,block=true)]` 观察位移/淡出与点击推进。

## 测试

- `pnpm test`:20 个文件 227 个用例全部通过(基线 222 + 新增 5)。
- `pnpm exec vue-tsc -b` 通过。
- `pnpm exec eslint <改动文件>` 通过。
