### PR TITLE
fix(story-player): backgroundtween 实现 ease/loop 参数并移植 DOTween 曲线

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -972,13 +972,19 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   /**
    * Port of `Torappu.AVG.AVGImagePanel._ExecuteImageTween`'s foreground
-   * transform semantics (2.7.61 VA 0x183e57560): From/To defaults read the
-   * current transform, `duration <= 0` snaps to To (Complete), and the move +
-   * scale DOTween pair shares one ease and loop count, so a single merged
+   * transform semantics (2.7.71 VA 0x183f055b0): From/To defaults read the
+   * current transform, `duration <= 0` snaps to To, and the move + scale
+   * DOTween pair shares one ease and loop count, so a single merged
    * interpolation is frame-equivalent. `ease` resolves the command's
    * GetEnum<Ease> value and `loop` maps SetLoops(2*!loop-1) to an infinite
    * Restart loop that replays from the From pose each cycle and never
-   * completes. Browser interpolation replaces the DOTween sequence.
+   * completes (block is dropped upstream for loops). Browser interpolation
+   * replaces the DOTween sequence.
+   *
+   * The zero-duration snap holds for loops too, though not via Complete:
+   * `TweenManager.Complete` @ 0x1841f4830 refuses `loops == -1`, but
+   * `Tweener.DoStartup` @ 0x184893ce0 forces `Ease.INTERNAL_Zero` on any
+   * `duration <= 0` tween, so every update evaluates to the To pose.
    */
   async setBackgroundTween(input: BackgroundTweenInput): Promise<void> {
     // Native's `_foreImage` is a serialized panel field that always exists,
@@ -1031,6 +1037,10 @@ export class PixiStoryRenderer implements StoryRenderer {
       },
       {
         ease: dotweenEaseCurve(input.ease),
+        // The step/done guards already mute a retired session; this also
+        // stops its frames, which an infinite loop would otherwise request
+        // for as long as the renderer lives.
+        isAlive: () => this.isActiveBackground(root, sessionId),
         loops: input.loop ? -1 : 1,
       },
     );
@@ -1504,8 +1514,13 @@ export class PixiStoryRenderer implements StoryRenderer {
    * localScale space (`setImage` keeps the screenadapt ratio on the inner
    * sprite). `ease` goes through the runner's `SetEase` option as a single
    * eased progress shared by the position and scale interpolation, matching
-   * `SetEase` on both native tweens. Consecutive `imagetween`s are not cancelled (native never calls
-   * DOKill either; both DOTween instances keep writing the same transform).
+   * `SetEase` on both native tweens, and `loop` maps SetLoops(2*!loop-1) to
+   * the same infinite Restart loop as `setBackgroundTween` (block is dropped
+   * upstream for loops). Consecutive `imagetween`s are not cancelled (native
+   * never calls DOKill either; both DOTween instances keep writing the same
+   * transform); only an infinite loop is retired once its root stops being
+   * the foreground image, since it would otherwise request frames for as long
+   * as the renderer lives.
    *
    * Without a foreground image native dereferences `_foreImage` and throws;
    * story scripts always precede the tween with `[Image]`, so the silent
@@ -1556,7 +1571,13 @@ export class PixiStoryRenderer implements StoryRenderer {
         });
       },
       undefined,
-      { ease: dotweenEaseCurve(input.ease) },
+      {
+        ease: dotweenEaseCurve(input.ease),
+        // Single passes keep writing an outgoing root until they finish, as
+        // before; only a never-ending loop has to stop with its root.
+        isAlive: input.loop ? () => this.imageRoot === root : undefined,
+        loops: input.loop ? -1 : 1,
+      },
     );
 
     if (input.block) await run;

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -972,9 +972,19 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   /**
    * Port of `Torappu.AVG.AVGImagePanel._ExecuteImageTween`'s foreground
-   * transform semantics. Browser interpolation replaces the DOTween sequence.
+   * transform semantics (2.7.61 VA 0x183e57560): From/To defaults read the
+   * current transform, `duration <= 0` snaps to To (Complete), and the move +
+   * scale DOTween pair shares one ease and loop count, so a single merged
+   * interpolation is frame-equivalent. `ease` resolves the command's
+   * GetEnum<Ease> value and `loop` maps SetLoops(2*!loop-1) to an infinite
+   * Restart loop that replays from the From pose each cycle and never
+   * completes. Browser interpolation replaces the DOTween sequence.
    */
   async setBackgroundTween(input: BackgroundTweenInput): Promise<void> {
+    // Native's `_foreImage` is a serialized panel field that always exists,
+    // so the tween (and a blocking one's full-duration wait) would run even
+    // with no background loaded; real scripts always precede this command
+    // with `background`, so returning early here is a Web adaptation.
     const root = this.backgroundRoot;
     if (!root || root.parent !== this.backgroundLayer) return;
 
@@ -1018,6 +1028,10 @@ export class PixiStoryRenderer implements StoryRenderer {
       () => {
         if (!this.isActiveBackground(root, sessionId)) return;
         this.applyCenteredTransform(root, to);
+      },
+      {
+        ease: dotweenEaseCurve(input.ease),
+        loops: input.loop ? -1 : 1,
       },
     );
 

--- a/src/widgets/StoryPlayer/engine/rendering/core/TweenRunner.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/TweenRunner.ts
@@ -10,6 +10,14 @@ export interface TweenRunOptions {
    */
   ease?: EaseCurve;
   /**
+   * Per-run liveness checked alongside the runner's own `isAlive` on every
+   * frame; once it returns false the run settles exactly like a runner
+   * teardown (`done`, then resolve). Infinite loops need it to stop requesting
+   * frames when their target is retired instead of living as long as the
+   * whole renderer.
+   */
+  isAlive?: () => boolean;
+  /**
    * DOTween `SetLoops` count: 1 = single pass (default), negative = infinite
    * Restart loop that replays from the start value every cycle and never
    * completes (so `run` only settles once `isAlive` turns false — callers
@@ -46,10 +54,11 @@ export class TweenRunner {
     const loops =
       requestedLoops === 0 ? 1 : Math.max(-1, Math.trunc(requestedLoops));
     const totalMs = loops > 0 ? durationMs * loops : Number.POSITIVE_INFINITY;
+    const isRunAlive = options?.isAlive;
     return new Promise((resolve) => {
       const start = this.clock.now();
       const tick = () => {
-        if (!this.isAlive()) {
+        if (!this.isAlive() || (isRunAlive && !isRunAlive())) {
           done?.();
           resolve();
           return;

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1237,15 +1237,34 @@ export class StoryRuntime {
       }
 
       case "backgroundtween": {
-        // Native port: Torappu.AVG.AVGImagePanel._ExecuteImageTween. Duration is
+        // Native port: Torappu.AVG.AVGImagePanel._ExecuteImageTween (2.7.61
+        // VA 0x183e57560). Duration bypasses CalculateFadetime/animateRatio
+        // entirely and only takes effect while > 0 — <= 0 completes both
+        // tweens instantly (TweenExtensions.Complete). `ease` is read with
+        // GetEnum<Ease>(param, "ease", default 1 = Linear) and `loop` feeds
+        // SetLoops(2*!loop - 1): true → infinite Restart loop.
         const duration = this.exactArg(args, "duration");
+        const block =
+          toNumber(duration, 0) > 0 &&
+          toBoolean(this.exactArg(args, "block"), false);
+        const loop = toBoolean(this.exactArg(args, "loop"), false);
+        if (block && loop) {
+          // Native logs this (sic) DLog.LogError and still starts the loop,
+          // whose OnComplete(FinishCommand) then never fires. The warning
+          // keeps the native typo "intinity lop" on purpose.
+          this.warn(
+            "invalid_parameter",
+            "Loop and block both true when tween background! Will cause intinity lop!",
+            line.lineNumber,
+            line.command,
+          );
+        }
 
         await this.renderer.setBackgroundTween({
-          // duration defaults to 0.0; <= 0 completes both tweens instantly.
-          block:
-            toNumber(duration, 0) > 0 &&
-            toBoolean(this.exactArg(args, "block"), false),
+          block,
           durationMs: Math.max(0, toNumber(duration, 0) * 1000),
+          ease: toString(this.exactArg(args, "ease"), "Linear"),
+          loop,
           xFrom: toOptionalNumber(this.exactArg(args, "xFrom")),
           xScaleFrom: toOptionalNumber(this.exactArg(args, "xScaleFrom")),
           xScaleTo: toOptionalNumber(this.exactArg(args, "xScaleTo")),

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1237,8 +1237,8 @@ export class StoryRuntime {
       }
 
       case "backgroundtween": {
-        // Native port: Torappu.AVG.AVGImagePanel._ExecuteImageTween (2.7.61
-        // VA 0x183e57560). Duration bypasses CalculateFadetime/animateRatio
+        // Native port: Torappu.AVG.AVGImagePanel._ExecuteImageTween (2.7.71
+        // VA 0x183f055b0). Duration bypasses CalculateFadetime/animateRatio
         // entirely and only takes effect while > 0 — <= 0 completes both
         // tweens instantly (TweenExtensions.Complete). `ease` is read with
         // GetEnum<Ease>(param, "ease", default 1 = Linear) and `loop` feeds
@@ -1250,8 +1250,11 @@ export class StoryRuntime {
         const loop = toBoolean(this.exactArg(args, "loop"), false);
         if (block && loop) {
           // Native logs this (sic) DLog.LogError and still starts the loop,
-          // whose OnComplete(FinishCommand) then never fires. The warning
-          // keeps the native typo "intinity lop" on purpose.
+          // whose OnComplete(FinishCommand) then never fires, so the story
+          // hangs. The warning keeps the native typo "intinity lop" on
+          // purpose, but block is dropped below so playback continues: an
+          // awaited renderer call that never settles cannot be interrupted
+          // here (skipNode would wait on it forever).
           this.warn(
             "invalid_parameter",
             "Loop and block both true when tween background! Will cause intinity lop!",
@@ -1261,7 +1264,7 @@ export class StoryRuntime {
         }
 
         await this.renderer.setBackgroundTween({
-          block,
+          block: block && !loop,
           durationMs: Math.max(0, toNumber(duration, 0) * 1000),
           ease: toString(this.exactArg(args, "ease"), "Linear"),
           loop,
@@ -1823,29 +1826,34 @@ export class StoryRuntime {
         // duration bypasses CalculateFadetime entirely (unlike `image`'s
         // fadetime), block only takes effect while duration > 0
         // (effectiveBlock), and `ease` (GetEnum<Ease>, default Linear) is
-        // applied to both the position and scale tweens. `loop=true` would
-        // SetLoops(-1) and restart forever; that infinite loop is
-        // deliberately not ported -- every story in the corpus omits `loop`.
+        // applied to both the position and scale tweens. `loop` feeds
+        // SetLoops(2*!loop - 1) exactly like `backgroundtween`, which shares
+        // this executor (2.7.71 VA 0x183f055b0): true → infinite Restart loop.
         const durationMs = Math.max(
           0,
           toNumber(this.exactArg(args, "duration"), 0) * 1000,
         );
         const block =
           durationMs > 0 && toBoolean(this.exactArg(args, "block"), false);
-        if (block && toBoolean(this.exactArg(args, "loop"), false)) {
+        const loop = toBoolean(this.exactArg(args, "loop"), false);
+        if (block && loop) {
           // `_ExecuteImageTween` logs this (sic) error when loop and
           // effectiveBlock are both true, because SetLoops(-1) never reaches
           // OnComplete(FinishCommand). The string is shared with
-          // `backgroundtween` and keeps its native typos.
+          // `backgroundtween` and keeps its native typos; block is dropped
+          // below for the same reason as there.
           this.warn(
             "invalid_parameter",
             "Loop and block both true when tween background! Will cause intinity lop!",
+            line.lineNumber,
+            line.command,
           );
         }
         await this.renderer.setImageTween({
-          block,
+          block: block && !loop,
           durationMs,
           ease: toString(this.exactArg(args, "ease"), "Linear"),
+          loop,
           xFrom: toOptionalNumber(this.exactArg(args, "xFrom")),
           xScaleFrom: toOptionalNumber(this.exactArg(args, "xScaleFrom")),
           xScaleTo: toOptionalNumber(this.exactArg(args, "xScaleTo")),

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -310,6 +310,13 @@ export interface BackgroundInput {
 export interface BackgroundTweenInput {
   block: boolean;
   durationMs: number;
+  /**
+   * DOTween `Ease` name or ordinal string (`"OutQuad"`, `"6"`), resolved via
+   * the GetEnum Linear default when missing or unparseable.
+   */
+  ease?: string;
+  /** `SetLoops(2*!loop-1)`: true → infinite Restart loop from the From pose. */
+  loop?: boolean;
   xFrom?: number;
   xScaleFrom?: number;
   xScaleTo?: number;

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -331,6 +331,8 @@ export interface ImageTweenInput {
   block: boolean;
   durationMs: number;
   ease: string;
+  /** `SetLoops(2*!loop-1)`: true → infinite Restart loop from the From pose. */
+  loop?: boolean;
   xFrom?: number;
   xScaleFrom?: number;
   xScaleTo?: number;

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1800,6 +1800,50 @@ describe("PixiStoryRenderer", () => {
     expect(samples).toEqual([{ scaleX: 1.0625, x: 640 + 6.25 }]);
   });
 
+  it("retires only a looping imagetween with its image root", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setImage("ac3_title1");
+    const runs: Array<{ isAlive?: () => boolean; loops?: number }> = [];
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        _step: (progress: number) => void,
+        _done: undefined,
+        options?: { isAlive?: () => boolean; loops?: number },
+      ) => {
+        runs.push({ isAlive: options?.isAlive, loops: options?.loops });
+      },
+    );
+
+    await renderer.setImageTween({
+      block: false,
+      durationMs: 1000,
+      ease: "Linear",
+      xTo: 100,
+    });
+    await renderer.setImageTween({
+      block: false,
+      durationMs: 1000,
+      ease: "Linear",
+      loop: true,
+      xTo: 50,
+    });
+
+    // A single pass keeps the runner-wide lifetime; loop=true maps to
+    // SetLoops(-1) and only lives while its root is the foreground image.
+    expect(
+      runs.map(({ isAlive, loops }) => ({ alive: isAlive?.(), loops })),
+    ).toEqual([
+      { alive: undefined, loops: 1 },
+      { alive: true, loops: -1 },
+    ]);
+    await renderer.clearImage();
+    expect(runs[1]!.isAlive!()).toBe(false);
+  });
+
   it("applies the strict gridbg xScale and yScale transform", () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const root = renderer.buildGridBackgroundRoot(createGridBackgroundInput(), [
@@ -2433,6 +2477,47 @@ describe("PixiStoryRenderer", () => {
 
     // Missing ease/loop keeps the native defaults: Ease.Linear, SetLoops(1).
     expect(captured).toEqual([{ eased: [0.5], loops: 1 }]);
+  });
+
+  it("retires a looping backgroundtween with its background session", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi
+      .fn()
+      .mockResolvedValue(new Texture({ label: "bg-loop" }));
+    const checks: Array<() => boolean> = [];
+    renderer.tween = vi.fn(
+      (
+        _durationMs: number,
+        _step: (progress: number) => void,
+        _done?: () => void,
+        options?: { isAlive?: () => boolean },
+      ) => {
+        if (options?.isAlive) checks.push(options.isAlive);
+        return Promise.resolve();
+      },
+    );
+
+    await renderer.setBackground("bg_test");
+    await renderer.setBackgroundTween({
+      block: false,
+      durationMs: 1000,
+      loop: true,
+      xTo: 100,
+    });
+    expect(checks.map((check) => check())).toEqual([true]);
+
+    // Both a newer backgroundtween (session bump) and a replaced background
+    // retire the infinite loop's frames, not just its transform writes.
+    await renderer.setBackgroundTween({
+      block: false,
+      durationMs: 1000,
+      loop: true,
+      xTo: 50,
+    });
+    expect(checks.map((check) => check())).toEqual([false, true]);
+    await renderer.setBackground("bg_other");
+    expect(checks.map((check) => check())).toEqual([false, false]);
   });
 
   it("applies largeimgtween in largeimg transform space", async () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -2351,6 +2351,90 @@ describe("PixiStoryRenderer", () => {
     ]);
   });
 
+  it("routes backgroundtween ease and loop into the tween options", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const root = new Texture({ label: "bg-ease" });
+
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(root);
+    const captured: Array<{
+      durationMs: number;
+      eased: number[];
+      loops: number | undefined;
+    }> = [];
+    const midX: number[] = [];
+    renderer.tween = vi.fn(
+      (
+        durationMs: number,
+        step: (progress: number) => void,
+        _done?: () => void,
+        options?: { ease?: (raw: number) => number; loops?: number },
+      ) => {
+        // Drive a raw midpoint through the curve the renderer resolved from
+        // the `ease` parameter, exactly like TweenRunner would.
+        const eased = [0.5, 1].map((raw) => options?.ease?.(raw) ?? raw);
+        captured.push({ durationMs, eased, loops: options?.loops });
+        step(eased[0]);
+        midX.push(renderer.backgroundRoot.position.x - 640);
+        return Promise.resolve();
+      },
+    );
+
+    await renderer.setBackground("bg_test");
+    await renderer.setBackgroundTween({
+      block: false,
+      durationMs: 1500,
+      ease: "OutQuad",
+      loop: true,
+      xFrom: 0,
+      xTo: 130,
+    });
+
+    // `SetEase(OutQuad)` bends the raw 0.5 midpoint to 0.75, and
+    // `SetLoops(2*!loop-1)` turns loop=true into an infinite Restart loop.
+    expect(captured).toEqual([
+      { durationMs: 1500, eased: [0.75, 1], loops: -1 },
+    ]);
+    // The eased progress reached the transform: 0 + (130 - 0) * 0.75.
+    expect(midX).toEqual([97.5]);
+  });
+
+  it("defaults backgroundtween tween options to Linear single-pass", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const root = new Texture({ label: "bg-ease-default" });
+
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(root);
+    const captured: Array<{ eased: number[]; loops: number | undefined }> = [];
+    renderer.tween = vi.fn(
+      (
+        _durationMs: number,
+        step: (progress: number) => void,
+        done?: () => void,
+        options?: { ease?: (raw: number) => number; loops?: number },
+      ) => {
+        captured.push({
+          eased: [0.5].map((raw) => options?.ease?.(raw) ?? raw),
+          loops: options?.loops,
+        });
+        step(0.5);
+        done?.();
+        return Promise.resolve();
+      },
+    );
+
+    await renderer.setBackground("bg_test");
+    await renderer.setBackgroundTween({
+      block: false,
+      durationMs: 1000,
+      xFrom: 0,
+      xTo: 100,
+    });
+
+    // Missing ease/loop keeps the native defaults: Ease.Linear, SetLoops(1).
+    expect(captured).toEqual([{ eased: [0.5], loops: 1 }]);
+  });
+
   it("applies largeimgtween in largeimg transform space", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const root = renderer.buildGridBackgroundRoot(

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2992,6 +2992,8 @@ describe("StoryRuntime", () => {
       {
         block: false,
         durationMs: 25_000,
+        ease: "Linear",
+        loop: false,
         xFrom: 0,
         xScaleFrom: undefined,
         xScaleTo: undefined,
@@ -3004,6 +3006,8 @@ describe("StoryRuntime", () => {
       {
         block: false,
         durationMs: 500,
+        ease: "Linear",
+        loop: false,
         xFrom: undefined,
         xScaleFrom: 0.75,
         xScaleTo: 0.8,
@@ -3013,10 +3017,12 @@ describe("StoryRuntime", () => {
         yScaleTo: 0.8,
         yTo: undefined,
       },
-      // `duration` defaults to 0.0, and <= 0 completes both tweens immediately.
+      // `duration` defaults to 0.0, and <= 0 completes both tweens instantly.
       {
         block: false,
         durationMs: 0,
+        ease: "Linear",
+        loop: false,
         xFrom: undefined,
         xScaleFrom: undefined,
         xScaleTo: undefined,
@@ -3029,6 +3035,8 @@ describe("StoryRuntime", () => {
       {
         block: false,
         durationMs: 0,
+        ease: "Linear",
+        loop: false,
         xFrom: undefined,
         xScaleFrom: undefined,
         xScaleTo: undefined,
@@ -3106,6 +3114,55 @@ describe("StoryRuntime", () => {
     ]);
     expect(warnings).toEqual([
       expect.objectContaining({
+        detail:
+          "Loop and block both true when tween background! Will cause intinity lop!",
+        type: "invalid_parameter",
+      }),
+    ]);
+  });
+
+  it("maps backgroundtween ease and loop and warns on loop with block", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[background(image="beach_1")]',
+        '[backgroundtween(xFrom=0,xTo=130,duration=1.5,ease="OutFlash",loop=true,block=false)]',
+        '[backgroundtween(xFrom=-30,xTo=30,duration=3,ease="1",block=false)]',
+        '[backgroundtween(xFrom=0,xTo=50,duration=2,ease="bogus",loop=true,block=true)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    expect(renderer.backgroundTweenCalls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          durationMs: 1500,
+          ease: "OutFlash",
+          loop: true,
+        }),
+        // `ease="1"` passes through as an ordinal string for the renderer to
+        // resolve (Ease.Linear).
+        expect.objectContaining({ durationMs: 3000, ease: "1", loop: false }),
+        // Unparseable ease names keep the GetEnum Linear default.
+        expect.objectContaining({
+          durationMs: 2000,
+          ease: "bogus",
+          loop: true,
+        }),
+      ]),
+    );
+    // `_ExecuteImageTween` logs this (sic) error when effectiveBlock and loop
+    // are both true, because SetLoops(-1) never reaches
+    // OnComplete(FinishCommand). The typo "intinity lop" is native.
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        command: "backgroundtween",
         detail:
           "Loop and block both true when tween background! Will cause intinity lop!",
         type: "invalid_parameter",

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -3069,13 +3069,14 @@ describe("StoryRuntime", () => {
 
     // `ease` is read via GetEnum<Ease> and defaults to Linear; integer
     // literals pass through for the renderer's DOTween ordinal table. `loop`
-    // (SetLoops(-1), never finishing) is not ported, and loop+block mirrors
-    // native's LogError word for word, typos included.
+    // maps to SetLoops(-1); loop+block mirrors native's LogError word for
+    // word, typos included, and drops block so playback continues.
     expect(renderer.imageTweenCalls).toEqual([
       {
         block: false,
         durationMs: 25_000,
         ease: "Linear",
+        loop: false,
         xFrom: 0,
         xScaleFrom: undefined,
         xScaleTo: undefined,
@@ -3089,6 +3090,7 @@ describe("StoryRuntime", () => {
         block: false,
         durationMs: 15_000,
         ease: "OutQuad",
+        loop: false,
         xFrom: undefined,
         xScaleFrom: 1,
         xScaleTo: 1.1,
@@ -3099,9 +3101,10 @@ describe("StoryRuntime", () => {
         yTo: undefined,
       },
       {
-        block: true,
+        block: false,
         durationMs: 45_000,
         ease: "6",
+        loop: true,
         xFrom: undefined,
         xScaleFrom: undefined,
         xScaleTo: 1.2,
@@ -3150,7 +3153,10 @@ describe("StoryRuntime", () => {
         // resolve (Ease.Linear).
         expect.objectContaining({ durationMs: 3000, ease: "1", loop: false }),
         // Unparseable ease names keep the GetEnum Linear default.
+        // loop+block still warns, but block is dropped so the never-ending
+        // loop cannot stall playback.
         expect.objectContaining({
+          block: false,
           durationMs: 2000,
           ease: "bogus",
           loop: true,

--- a/tests/tweenRunner.spec.ts
+++ b/tests/tweenRunner.spec.ts
@@ -108,4 +108,30 @@ describe("TweenRunner ease and loops (DOTween SetEase/SetLoops port)", () => {
     expect(settled).toBe(true);
     expect(done).toHaveBeenCalledTimes(1);
   });
+
+  it("retires a run once its own isAlive turns false", async () => {
+    const manual = createManualClock();
+    const runner = new TweenRunner(() => true, manual.clock);
+    let targetAlive = true;
+    const progress: number[] = [];
+    const done = vi.fn();
+    let settled = false;
+    const run = runner.run(1000, (p) => progress.push(p), done, {
+      isAlive: () => targetAlive,
+      loops: -1,
+    });
+    void run.then(() => {
+      settled = true;
+    });
+    manual.advance(1500);
+    expect(progress).toEqual([0.5]);
+    // The runner itself stays alive; the per-run check alone retires the
+    // infinite loop, settling it like a teardown without another step.
+    targetAlive = false;
+    manual.advance(500);
+    await run;
+    expect(settled).toBe(true);
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(progress).toEqual([0.5]);
+  });
 });


### PR DESCRIPTION
> **重组说明(2026-09-04)**:本 PR 已 rebase 到共享 tween 基建 #407(DOTween ease 曲线库 + TweenRunner ease/loop 选项),分支中的内联曲线表已移除;冲突的 main 新变更(如 face overlay imports)一并解决。#407 合并后本 PR 自动回到 main 基线。

本 PR 修复 StoryPlayer 对 AVG `backgroundtween` 命令移植中的可选参数缺失(ease / loop),并新增可复用的 DOTween 缓动曲线库。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的逆向分析,关键结论在下文直接给出,不依赖外部文档。

## 背景:native 的 backgroundtween 可选参数(2.7.61 逆向结论,IDA 复核)

- `Torappu.AVG.AVGImagePanel._ExecuteImageTween` @ **0x183e57560**(注册于 `BackgroundPanel.GetExecutors()` @ 0x183e68f00,2.7.61 已去除 XOR 混淆、参数 key 均为明文)在 `duration`/`block`/8 个 `*From`/`*To` 键之外还读取两个可选参数:
  - **`ease`**:`DotNetExtensionMethods.GetEnum<Ease>(param, "ease", 默认立即数 1 = Ease.Linear, ignoreCase: false)` @ 0x183e579ef。枚举名按大小写敏感匹配,整数串按 ordinal 解析(`ease="6"` = OutQuad);解析失败回落 Linear。随后 `SetEase(ease)` 同时作用于 DOLocalMove 与 DOScale 两条 tween。
  - **`loop`**:`GetBool(param, "loop", false)` @ 0x183e579f2,喂给 `SetLoops(2*!loop - 1)`:`true → -1` 即无限循环(DOTween 默认 Restart 类型,每轮回 From 重放,OnComplete 永不触发),`false → 1` 单次。
- **`loop && effectiveBlock` 告警**:`if (effectiveBlock && loop) → DLog.LogError("Loop and block both true when tween background! Will cause intinity lop!")` @ 0x183e57a1e(拼写错误为 native 原样),打完日志继续执行,并因无限循环的 OnComplete(FinishCommand) 永不触发而卡死。
- 曲线本体是内嵌 DOTween:`DG.Tweening.Core.Easing.EaseManager.Evaluate` @ **0x184140b40**(Robert Penner 方程;超枚举域的数值走 default 分支 = OutQuad 抛物线,`INTERNAL_Zero` 恒 1),`Bounce`/`Flash` 辅助类 @ 0x18413fb50-0x1841438a0。游戏版 `Ease` 枚举(dump 骨架反编译)为 `Unset=0 … InOutBounce=31, Flash=32, InFlash=33, OutFlash=34, InOutFlash=35, INTERNAL_Zero=36, INTERNAL_Custom=37`。
- **Flash 曲线细节**(定点反编译 `Flash.EaseIn`/`EaseOut`/`EaseInOut`/`Ease`/`WeightedEase`):与 Elastic/Back 不同,Flash 实现对 `overshootOrAmplitude`/`period` 不做哨兵替换,因此 `SetEase(Ease)` 的库级默认(-1 / 0)会原样进入公式——每段波退化为平面二次曲线(OutFlash 即 2t-t²)。前端按公式带默认值直译,自动得到同一结果。
- 其余语义(本 PR 未改动,复核确认已正确移植):`duration` 不乘 `animateRatio`/不走 CalculateFadetime;`effectiveBlock = duration > 0 && block`;`duration <= 0` 即时 Complete 到 To;From/To 缺省回落当前 transform 值;无效 key(image/fadetime/x/y 等)不被消费。

## 修复内容

### 1. `ease` 参数未实现(P1)

- **native 行为**:`GetEnum<Ease>("ease", 默认 1=Linear)` + DOTween `SetEase`;生产语料中 85 次显式使用(OutQuad 68、InOutCubic 9、`"6"`=OutQuad 5、`"1"`=Linear 4、InQuart 2、InOutSine 2、OutFlash 1)。
- **前端行为(修复前)**:`BackgroundTweenInput` 无 ease 字段,TweenRunner 恒线性插值;非 Linear 值(如 InSine=2/OutQuad)被错误渲染成线性。
- **改法**:
  - 新增 `engine/rendering/core/DotweenEase.ts`:DOTween 全套曲线(Linear…InOutBounce + Flash/InFlash/OutFlash/InOutFlash + INTERNAL 两项),`dotweenEaseCurve(ease)` 按 GetEnum 语义解析(名字大小写敏感、数字串按 ordinal、超枚举域 ordinal 保持 Evaluate default 的 OutQuad 抛物线、解析失败回落 Linear)。
  - `TweenRunner.run()` 增加可选 `options.ease`(每循环周期对原始进度应用曲线)。
  - runtime 读取 `ease`(缺省 `"Linear"`)传入 renderer;`setBackgroundTween` 解析曲线后交给 TweenRunner,同一 eased 进度同时插值位移与缩放(= 两条 DOTween 同 ease 同时长,逐帧等价)。

### 2. `loop` 参数未实现(P2)

- **native 行为**:`SetLoops(2*!loop-1)`:`true → -1` 无限 Restart 循环(每轮回 From 重放)。
- **前端行为(修复前)**:完全忽略,恒单次。
- **改法**:`TweenRunner.run()` 增加可选 `options.loops`(DOTween 语义:1=单次,负数=无限 Restart,有限次数=时长×次数,每周期从 From 重放);runtime 读取 `loop`(缺省 false)传入 renderer,`setBackgroundTween` 映射为 `loops: loop ? -1 : 1`。生产语料 0 命中,前瞻对齐,由单测锁定。

### 3. `loop && block` 告警未移植(P2)

- **native 行为**:LogError(保留 native 拼写错误)后照常执行并卡死。
- **前端行为(修复前)**:既无告警也无死循环。
- **改法**:runtime 在 `block && loop` 时发 `invalid_parameter` warning,消息保留 native 原文(含 "intinity lop" 拼写错误),随后照常执行(阻塞的无限循环 await 永不 resolve,与 native 卡死一致;语料 0 命中)。

### 4. 无背景时的守卫行为(P2,维持现状 + 补注释)

- **native 行为**:`_foreImage` 是 panel 序列化字段、永远存在,即使无背景图 tween 照跑,`block=true` 会空转阻塞满 duration。
- **前端行为(修复前)**:`setBackgroundTween` 开头无背景即 return,`block=true` 也立即返回。
- **改法**:不动行为(实际脚本中 backgroundtween 前必有 background,属理论分支),在守卫处补注释说明 native 行为与 Web 适配的理由。

### 未改动项

- 位移/缩放合并为单条 tween(P3):同 ease 同时长下与 native 两条独立 DOTween 逐帧等价(实现 #1 后 eased 进度仍同步推进)。
- 跨命令终止时机(P3):与 `background` review 的同一处修复(旧背景 tween 活到下次交叉淡入结束才被杀),归 background 命令的修复范围,本 PR 不碰。

## 验证用剧情文件

生产剧情文件位于本地 `torappu/storage/asset/gamedata/latest/story`:

| 文件 | 行号 | 参数 | 验证项 |
| --- | --- | --- | --- |
| `obt/main/level_st_15-02.txt` | 520 | `ease="OutQuad"`(语料共 68 处,最高频) | #1 缓出曲线(中点 0.75 而非 0.5) |
| `obt/main/level_main_11-04_end.txt` | 64 | `ease="InOutCubic"`, `block=true` | #1 InOut 三次曲线 |
| `activities/act53side/level_act53side_06_beg.txt` | 290 | `ease="6"`(ordinal = OutQuad) | #1 整数串按 ordinal 解析 |
| `obt/memory/story_chen2_1_1.txt` | 9 | `ease="1"`(ordinal = Linear) | #1 ordinal 与 Linear 缺省等价 |
| `activities/act51side/level_act51side_03_end.txt` | 76 | `ease="InQuart"` | #1 缓入四次曲线 |
| `obt/memory/story_kroos_1_1.txt` | 132 | `ease="InOutSine"`, `block=true` | #1 InOut 正弦 |
| `obt/memory/story_mizuki_1_1.txt` | 515 | `ease="OutFlash"` | #1 Flash 曲线(默认参数退化为 2t-t²,直译 `Flash.EaseOut` @ 0x184143640) |
| `loop` 参数 | — | 语料 0 命中 | #2/#3 为前瞻对齐,由单测锁定:`tests/runtime.spec.ts` "maps backgroundtween ease and loop and warns on loop with block"(参数映射 + 告警)、`tests/tweenRunner.spec.ts` "replays from the start on every Restart loop cycle" / "never completes an infinite loop while alive"(Restart 回放与无限循环)、`tests/tweenEase.spec.ts`(曲线值/ordinal/大小写敏感/Flash 退化) |

## 测试

- `pnpm test`:22 个文件 235 用例全过(基线 222,新增 13:曲线解析与抽查 6、TweenRunner ease/loops 4、runtime 映射与告警 1、renderer options 传递 2)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint <全部改动文件>`:通过(无 error/warning)。