### PR TITLE
fix(story-player): image 命令 width/height 乘数、加载失败清屏、tiled 平铺与切图不冻结 imagerotate 旋转

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1259,8 +1259,12 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   /**
-   * Port scope: `Torappu.AVG.AVGImagePanel._ExecuteImage` / `_LoadImage` for
-   * the `image` path. Sprite replacement and fade behavior are preserved.
+   * Port scope: `Torappu.AVG.AVGImagePanel._ExecuteImage` / `_LoadImage`
+   * (2.7.61 @0x183e57cf0 / @0x183e58390) for the `image` path. Sprite
+   * replacement, cross-fade and the block boundary are preserved; the
+   * width/height sizeDelta multipliers and the `tiled` Image type are applied
+   * like `_LoadImage` steps 5-9, and a failed texture load falls back to the
+   * clear branch (LogError + fade the old image out) instead of keeping it.
    *
    * Native `_foreImage` is an Image whose RectTransform sizeDelta carries the
    * screenadapt-fit size while a parent transform carries `xScale`/`yScale` as
@@ -1271,14 +1275,37 @@ export class PixiStoryRenderer implements StoryRenderer {
    */
   async setImage(key: string, input?: BackgroundInput): Promise<void> {
     const texture = await this.textureForImageKey(key, "image");
-    if (!texture) return;
+    if (!texture) {
+      // `_LoadImage` on a null sprite logs "Failed to load image: [{0}]"
+      // (textureForUrl already reports it) and takes the clear branch:
+      // DOFade(_backImage → 0), waiting for the fade when block is set.
+      await this.clearImage(input?.fadeMs ?? 0, input?.block ?? false);
+      return;
+    }
 
-    this.imageRotateSessionId += 1;
+    // `_ExecuteImage` only DOKills `_backImage` and its transform; the
+    // panel-level rotation tween from `imagerotate` keeps running across
+    // image swaps and the panel's current angle is preserved. Do NOT bump
+    // imageRotateSessionId here (that would freeze a rotation mid-flight).
     const root = new Container();
-    const sprite = new Sprite(texture);
+    // `_LoadImage`: TryGetParam("tiled", false) switches Image.type between
+    // Tiled and Simple, tiling the sprite inside the final sizeDelta rect;
+    // a repeat-addressed TilingSprite is the PIXI equivalent (same
+    // construction as the background path -- see setBackground).
+    let sprite: Sprite | TilingSprite;
+    if (input?.tiled) {
+      texture.source.style.addressMode = "repeat";
+      sprite = new TilingSprite({ texture });
+    } else {
+      sprite = new Sprite(texture);
+    }
     sprite.anchor.set(0.5);
-    this.layoutImageForScreenAdapt(sprite, input?.screenAdapt);
-    root.addChild(sprite);
+    // Image art keeps the texture's pixel size as the SetNativeSize rect;
+    // the ppu sidecar only covers AVG/Backgrounds keys.
+    this.layoutImageForScreenAdapt(sprite, input?.screenAdapt, {
+      height: input?.height ?? 1,
+      width: input?.width ?? 1,
+    });
     // `_ExecuteImage` reads `xScale`/`yScale` with a 1.0 fallback, so an
     // omitted scale must leave the screen-adapted size alone.
     this.applyCenteredTransform(root, {
@@ -1287,6 +1314,7 @@ export class PixiStoryRenderer implements StoryRenderer {
       x: input?.x ?? 0,
       y: input?.y ?? 0,
     });
+    root.addChild(sprite);
 
     const previous = this.imageRoot;
     this.imageRoot = root;
@@ -1307,7 +1335,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   async clearImage(fadeMs = 0, block = false): Promise<void> {
-    this.imageRotateSessionId += 1;
+    // Same as setImage: the clear branch fades `_backImage` out and never
+    // touches the panel rotation tween, so imagerotate keeps its angle and
+    // any in-flight rotation keeps playing (see setImageRotate).
     const root = this.imageRoot;
     this.imageRoot = null;
     if (!root) return;

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1640,6 +1640,10 @@ export class StoryRuntime {
       case "image": {
         // Native port: Torappu.AVG.AVGImagePanel._ExecuteImage. This is the
         // foreground-panel registration of the same inherited executor used by
+        // the `background` command (AVGImagePanel.GetExecutors @0x183e56250
+        // binds "image" → _ExecuteImage @0x183e57cf0; BackgroundPanel binds
+        // "background" to the same MethodInfo). Covers the clear branch, the
+        // load-failure clear branch, the scaled fade and the block boundary.
         const image = toString(this.exactArg(args, "image"));
         const fadeMs = this.calculateFadeMs(this.exactArg(args, "fadetime"));
         const block =
@@ -1659,12 +1663,17 @@ export class StoryRuntime {
         await this.renderer.setImage(resolved, {
           block,
           fadeMs,
+          // `_LoadImage` multiplies the SetNativeSize rect by the `width`/
+          // `height` params (GetOrDefault<float>(..., 1.0); the mulss at
+          // 0x183e587b0/0x183e587b4 in build 2761) before screenadapt reads it.
+          height: toNumber(this.exactArg(args, "height"), 1),
           scaleX: toNumber(this.exactArg(args, "xScale"), 1),
           scaleY: toNumber(this.exactArg(args, "yScale"), 1),
           screenAdapt: this.parseScreenAdapt(
             this.exactArg(args, "screenadapt"),
           ),
           tiled: toBoolean(this.exactArg(args, "tiled"), false),
+          width: toNumber(this.exactArg(args, "width"), 1),
           x: toNumber(this.exactArg(args, "x"), 0),
           y: toNumber(this.exactArg(args, "y"), 0),
         });

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1883,6 +1883,159 @@ describe("PixiStoryRenderer", () => {
     expect(cornerGlobal.y).toBeCloseTo(720);
   });
 
+  it("multiplies the native size by width/height before screenadapt", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    // _LoadImage: SetNativeSize, then sizeDelta = (w * width, h * height)
+    // with a 1.0 fallback, before any screenadapt step.
+    await renderer.setImage("avg_5_boom", {
+      block: false,
+      fadeMs: 0,
+      height: 0.5,
+      scaleX: 1,
+      scaleY: 1,
+      tiled: false,
+      width: 2,
+      x: 0,
+      y: 0,
+    });
+
+    expect(renderer.imageRoot.children[0].width).toBe(Texture.EMPTY.width * 2);
+    expect(renderer.imageRoot.children[0].height).toBe(
+      Texture.EMPTY.height * 0.5,
+    );
+  });
+
+  it("feeds the multiplied rect into the screenadapt aspect comparison", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    // A square texture is taller than 16:9, but width=2 flips the multiplied
+    // rect to 2:1, so showall must take the width-fit branch
+    // (`_AdaptScreenShowAll`: target ratio > reference ratio → adapt width).
+    await renderer.setImage("avg_5_boom", {
+      block: false,
+      fadeMs: 0,
+      height: 1,
+      scaleX: 1,
+      scaleY: 1,
+      screenAdapt: "showall",
+      tiled: false,
+      width: 2,
+      x: 0,
+      y: 0,
+    });
+
+    expect(renderer.imageRoot.children[0].width).toBe(1280);
+    expect(renderer.imageRoot.children[0].height).toBe(
+      (Texture.EMPTY.height * 1280) / (Texture.EMPTY.width * 2),
+    );
+  });
+
+  it("takes the clear branch when the image texture fails to load", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    const clearImage = vi.spyOn(renderer, "clearImage");
+
+    await renderer.setImage("first");
+    expect(renderer.imageRoot).not.toBeNull();
+
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(null);
+    await renderer.setImage("missing", {
+      block: true,
+      fadeMs: 0,
+      scaleX: 1,
+      scaleY: 1,
+      tiled: false,
+      x: 0,
+      y: 0,
+    });
+
+    // _LoadImage on a null sprite logs the failure and fades the old image
+    // out (clear branch) instead of keeping the previous image on screen.
+    expect(clearImage).toHaveBeenCalledWith(0, true);
+    expect(renderer.imageRoot).toBeNull();
+    expect(renderer.imageLayer.children).toHaveLength(0);
+  });
+
+  it("renders a tiled image as a TilingSprite sized to the final rect", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setImage("bg_0_am", {
+      block: false,
+      fadeMs: 0,
+      scaleX: 1,
+      scaleY: 1,
+      tiled: true,
+      x: 0,
+      y: 0,
+    });
+
+    expect(renderer.imageRoot.children[0]).toBeInstanceOf(TilingSprite);
+    // Image.type = Tiled with no multipliers/adapt tiles at the native size.
+    expect(renderer.imageRoot.children[0].width).toBe(Texture.EMPTY.width);
+    expect(renderer.imageRoot.children[0].height).toBe(Texture.EMPTY.height);
+
+    await renderer.setImage("bg_0_am", {
+      block: false,
+      fadeMs: 0,
+      scaleX: 1,
+      scaleY: 1,
+      screenAdapt: "fill",
+      tiled: true,
+      x: 0,
+      y: 0,
+    });
+
+    // The tiling rect is the final sizeDelta (native x multipliers x adapt).
+    expect(renderer.imageRoot.children[0].width).toBe(1280);
+    expect(renderer.imageRoot.children[0].height).toBe(720);
+    // Restore the shared EMPTY texture so the address mode does not leak into
+    // the other specs.
+    Texture.EMPTY.source.style.addressMode = "clamp-to-edge";
+  });
+
+  it("keeps an in-flight imagerotate tween running across image swaps", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    const rotateSteps: Array<(progress: number) => void> = [];
+    renderer.tween = vi.fn(
+      async (_durationMs: number, step: (progress: number) => void) => {
+        rotateSteps.push(step);
+      },
+    );
+
+    // angle=90 without circles sweeps -270 degrees (AVGUtils.CreateRotateTween).
+    await renderer.setImageRotate({
+      angleDeg: 90,
+      block: false,
+      circles: 0,
+      durationMs: 1000,
+      inverse: false,
+    });
+    rotateSteps.at(-1)!(0.5);
+    expect(renderer.imageLayer.angle).toBe(-135);
+
+    // _ExecuteImage only DOKills the back Image, never the panel rotation
+    // tween: the swap must neither freeze nor reset the rotation.
+    await renderer.setImage("30_i04");
+    rotateSteps.at(-1)!(1);
+    expect(renderer.imageLayer.angle).toBe(-270);
+
+    // The clear branch must not freeze it either.
+    rotateSteps.at(-1)!(0.5);
+    await renderer.clearImage();
+    rotateSteps.at(-1)!(1);
+    expect(renderer.imageLayer.angle).toBe(-270);
+  });
+
   it("applies the strict gridbg xScale and yScale transform", () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const root = renderer.buildGridBackgroundRoot(createGridBackgroundInput(), [

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -74,6 +74,7 @@ class FakeRenderer implements StoryRenderer {
   ) => Promise<void> | void;
   gridBackgroundCalls: GridBackgroundInput[] = [];
   gridBackgroundClearCalls: Array<{ block: boolean; fadeMs: number }> = [];
+  imageCalls: Array<{ input?: BackgroundInput; key: string }> = [];
   imageRotateCalls: ImageRotateInput[] = [];
   imageTweenCalls: ImageTweenInput[] = [];
   interludeCalls: InterludeInput[] = [];
@@ -262,7 +263,9 @@ class FakeRenderer implements StoryRenderer {
     this.dialogueTexts.push(text);
   }
 
-  async setImage(): Promise<void> {}
+  async setImage(key: string, input?: BackgroundInput): Promise<void> {
+    this.imageCalls.push({ input, key });
+  }
   async setImageRotate(input: ImageRotateInput): Promise<void> {
     this.imageRotateCalls.push(input);
   }
@@ -2966,6 +2969,73 @@ describe("StoryRuntime", () => {
           y: -36,
         },
         key: "beach_1",
+      },
+    ]);
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("maps image width/height multipliers and tiled with lowercase keys", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[Image(image="avg_5_boom", width=1, height=1,screenadapt="coverall")]',
+        '[image(image="bg_0_am", tiled=true, fadetime=0, block=false)]',
+        '[image(image="side_i01",width=1.5,Height=2,xScale=1.2)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // `width`/`height` are lowercase in _LoadImage (unlike xScale/yScale);
+    // a CamelCase `Height` must not leak into the multiplier.
+    expect(renderer.imageCalls).toEqual([
+      {
+        input: {
+          block: false,
+          fadeMs: 0,
+          height: 1,
+          scaleX: 1,
+          scaleY: 1,
+          screenAdapt: "coverall",
+          tiled: false,
+          width: 1,
+          x: 0,
+          y: 0,
+        },
+        key: "avg_5_boom",
+      },
+      {
+        input: {
+          block: false,
+          fadeMs: 0,
+          height: 1,
+          scaleX: 1,
+          scaleY: 1,
+          screenAdapt: undefined,
+          tiled: true,
+          width: 1,
+          x: 0,
+          y: 0,
+        },
+        key: "bg_0_am",
+      },
+      {
+        input: {
+          block: false,
+          fadeMs: 0,
+          height: 1,
+          scaleX: 1.2,
+          scaleY: 1,
+          screenAdapt: undefined,
+          tiled: false,
+          width: 1.5,
+          x: 0,
+          y: 0,
+        },
+        key: "side_i01",
       },
     ]);
     expect(runtime.getState()).toBe("waiting_input");


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `image` 命令移植中的全部可修复行为差异(P1×2、P2×2,另有 2 处注释补全小项)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的逆向分析,关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 image 命令(2.7.61 IDA 反编译复核结论)

- `Torappu.AVG.AVGImagePanel.GetExecutors()` @ 0x183e56250 注册 `"image"` → `_ExecuteImage` @ 0x183e57cf0,与 `"background"` 命令共用同一 executor(`BackgroundPanel.GetExecutors` 绑同一 MethodInfo);资源路径经 `AVGImagePanel._LoadSprite` @ 0x183e58970 → `ResourceRouter.GetImagePath` @ 0x183e8ffd0(`AVG/Images/<key>`)。
- `_ExecuteImage` → `_LoadImage` @ 0x183e58390 的尺寸链:① `Image.SetNativeSize()` @ 0x183e58688 把 sizeDelta 重置为 sprite 原生尺寸;② `tiled=true` → `Image.type = Tiled`(按最终 rect 平铺);③ `sizeDelta = (w × width, h × height)`,`width`/`height` 由 `GetOrDefault("width"/"height", 1.0)` 读取(**小写键**,与 `xScale`/`yScale` 的 CamelCase 不同),mulss @ 0x183e587b0/b4 已在反汇编直接证实;④ 之后才进 `SCREEN_ADAPT_FUNCTION_MAP` 的五个适配函数——**比例判断用乘完后的 sizeDelta**。
- 贴图加载失败(sprite == null):`DLog.LogError("Failed to load image: [{0}]")` 后走**清屏分支**(`DOFade(_backImage → 0)`,block 时等淡出完成),与 image 键为空时的清屏分支完全一致。
- `_ExecuteImage` 的 DOKill 只作用于 `_backImage` 及其 transform,**不碰 panel(`_rectTransform`)上的 `imagerotate` 旋转 tween**——交叉淡入期间旋转继续播放,面板已旋转的角度在切图/清屏后保留。
- 预加载 collector `AVGImagePanel.InternalResRefCollector.GatherResRefs` @ 0x183e626d0 只对 `command == "image"` 的命令登记 `AVG/Images/<key>`(前端 preload.ts 已一致,本 PR 未动)。

## 修复内容

### 1. `width`/`height` sizeDelta 乘数未实现(P1)

- **native 行为**:`SetNativeSize()` 后 `sizeDelta = (w×width, h×height)` 再进 screenadapt,比例判断用乘完后的 sizeDelta。
- **前端行为**:runtime 不解析该参数,`BackgroundInput` 无此字段,尺寸恒按乘数 1 计算。
- **修复**:`runtime.ts` 的 `image` 分支解析 `width`/`height`(默认 1.0,`exactArg` 小写精确匹配);`types.ts` 的 `BackgroundInput` 新增可选 `widthMultiplier`/`heightMultiplier`;`layoutImageForScreenAdapt` 新增 multipliers 参数,按 native 顺序(原生尺寸 × 乘数 → screenadapt)计算,showall/coverall 的比例分支改用乘后的宽高比。`background` 路径调用方不传乘数(默认 1),行为不变。

### 2. 贴图实际加载失败时保留旧图而非走清屏分支(P1)

- **native 行为**:`LogError` + 清屏分支:`DOFade(_backImage → 0)`,block 时等淡出完成。
- **前端行为**:`textureForImageKey` 返回 null 时 `setImage` 直接 return,旧前景图原样保留且 `block` 等待丢失(runtime 只在 image 键为空/不可解析时才走 clearImage)。
- **修复**:`setImage` 内纹理加载失败(`textureForUrl` 已上报 `failed image: <key>` 警告,对应 native LogError)时复用 `clearImage(fadeMs, block)` 语义,把旧前景图淡出。

### 3. `tiled` 参数解析后未消费(P2)

- **native 行为**:`tiled=true` → `Image.type = Tiled`,按最终 sizeDelta(SetNativeSize × 乘数 × screenadapt)平铺,tile 尺寸为 sprite 原生尺寸。
- **前端行为**:runtime 传入 `tiled`,但 `setImage` 全程未读,恒为 Simple 拉伸。
- **修复**:`tiled=true` 时用 PIXI `TilingSprite`(tile = 纹理原生尺寸,平铺区域 = layoutImageForScreenAdapt 算出的最终 rect),后续 `xScale`/`yScale`/`x`/`y`/交叉淡入与 Simple 路径共用。

### 4. 切图/清屏会冻结进行中的 `imagerotate` 旋转 tween(P2)

- **native 行为**:`_ExecuteImage` 只 DOKill `_backImage` 及其 transform,不碰 panel 旋转 tween——交叉淡入期间旋转继续播放,面板已旋转角度保留。
- **前端行为**:`setImage`/`clearImage` 第一行 `imageRotateSessionId += 1`,把进行中的旋转 tween 冻结在当前角度(静态角度仍保留,不归零)。
- **修复**:删除 `setImage`/`clearImage` 里的 sessionId 递增。旋转 tween 步进本身仍有 sessionId 守护(由 `setImageRotate` 自己递增开启新会话),因此进行中的旋转在切图/清屏后继续收敛,面板角度不重置。

### 注释项(P3)

- `runtime.ts` `image` 分支的 provenance 注释原本在 "used by" 处截断,补全为完整说明(同一 executor 同时服务 background)。
- `resolveImageKey` 补注释,说明 trim + 小写是**有意的 web 资源映射适配**(native 原样拼 `AVG/Images/<key>`,游戏数据 key 本身全小写)——维持行为不变,仅记录偏差。
- `layoutImageForScreenAdapt` 内原注释声称 "Unity swaps Image.sprite without calling SetNativeSize" 与 2.7.61 反汇编直接矛盾(`_LoadImage` 在 set_sprite 后立即调 SetNativeSize @ 0x183e58688),已改写为准确描述;`background` 路径的 1280×720 缺省(已知 web 侧偏差,属 background 路径、另行跟踪)行为保持不变。

## 验证用剧情文件

生产剧情文件位于本地 `torappu/storage/asset/gamedata/latest/story`:

- **修复 1(width/height 乘数)**:`obt/main/level_main_05-10_beg.txt` 440、450 行 —— 全语料仅有的两条带 `width`/`height` 的 `[Image]`(均为 `width=1, height=1, screenadapt="coverall"`),验证参数被正确接受且现网值下无回归;非 1 乘数(含 showall/coverall 比例判断用乘后宽高比)为**前瞻对齐,由单测锁定**:`tests/renderer.spec.ts` 的 `multiplies the native size by width/height before screenadapt` 与 `feeds the multiplied rect into the screenadapt aspect comparison`、`tests/runtime.spec.ts` 的 `maps image width/height multipliers and tiled with lowercase keys`(含 CamelCase `Height` 必须失效的大小写锁定)。
- **修复 2(加载失败清屏)**:生产语料中 image 键均随包预载、无加载失败样本,**前瞻对齐,由单测锁定**:`tests/renderer.spec.ts` 的 `takes the clear branch when the image texture fails to load`。
- **修复 3(tiled)**:`obt/guide/beg/0_welcome_to_guide.txt:31`、`obt/main/level_main_05-04_end.txt:129`、`obt/main/level_main_9_chapter_recap.txt:14`、`activities/act6fun/level_act6fun_entry.txt:35`(均为 `[Image(image="bg_0_am"/"avg_5_photo", tiled=true)]`)——播放可见平铺而非单图拉伸;渲染细节由 `tests/renderer.spec.ts` 的 `renders a tiled image as a TilingSprite sized to the final rect` 锁定。
- **修复 4(旋转不冻结)**:`activities/act25side/level_act25side_06_beg.txt` 408-409 行 —— `[imagerotate(angle=0,fadetime=0.01)]`(非阻塞,10ms 回正 tween 进行中)紧接 `[Image(image="38_i03",...)]` 换图,修复前回正会被冻结在 30 度附近,修复后回正完成;`obt/main/level_main_13-05_beg.txt` 904-905 行、`obt/main/level_main_13-19_end.txt` 801-802 行(即时 rotate 后切图)验证面板角度跨切图保留、不归零。由 `tests/renderer.spec.ts` 的 `keeps an in-flight imagerotate tween running across image swaps` 锁定。

## 测试

- `pnpm test`:20 个文件 228 个用例全部通过(基线 222,新增 6)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint <改动文件>`:通过。
