### PR TITLE
fix(story-player): largebg 失败清面板与替换空白期对齐官服 2.7.61

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -730,10 +730,10 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.backgroundSprite = null;
     this.backgroundTweenSessionId += 1;
     this.backgroundLayer.removeChildren();
+    // panel_large_background is a permanent scene-level sibling in front of
+    // panel_background (LayerGraph.attach), so the grid layer keeps its parent
+    // and only its tile roots need clearing here.
     this.gridBackgroundLayer.removeChildren();
-    // panel_large_background is a permanent sibling in front of panel_background,
-    // so it goes back as child 0 rather than being re-appended on each gridbg.
-    this.backgroundLayer.addChild(this.gridBackgroundLayer);
     this.blockerSprite = null;
     // Blocker's closest OnReset equivalent on destroy: drop in-flight tween
     // callbacks and restore the prefab color (0,0,0,0). OnReset also clears

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1029,10 +1029,24 @@ export class PixiStoryRenderer implements StoryRenderer {
    * Port scope: `Torappu.AVG.LargeBackgroundPanel._ExecuteGridBG` and
    * `_LoadImage`, including all-or-nothing asset loading and replacement.
    * `Container` composition is the Web adaptation of Unity RectTransforms.
+   * Load failures empty the panel like native `_ResetPanel()`; the
+   * largebg-specific immediate reset is opted into via
+   * `resetPreviousImmediately` (see the inline notes below).
    */
   async setGridBackground(input: GridBackgroundInput): Promise<void> {
     const sessionId = ++this.gridBackgroundSessionId;
     this.largeBackgroundTweenSessionId += 1;
+    // Native port: `_ExecuteImage` (2.7.61, VA 0x183e77ee0) calls
+    // `_ResetImages()` before `_LoadImage`, so the previous tiles vanish the
+    // moment the command executes and the new puzzle fades in over an emptied
+    // panel — a blank gap, never a cross-fade. Grid/vertical replacements keep
+    // the legacy cross-fade until their own alignment change, so this reset is
+    // opt-in.
+    if (input.resetPreviousImmediately) {
+      if (input.layout === "large") this.largeBackgroundRoot = null;
+      const previous = [...this.gridBackgroundLayer.children];
+      for (const child of previous) child.removeFromParent();
+    }
     const textures = await Promise.all(
       input.imageKeys.map((key) =>
         this.textureForImageKey(key, input.assetKind ?? "background"),
@@ -1040,7 +1054,14 @@ export class PixiStoryRenderer implements StoryRenderer {
     );
     if (!this.app || sessionId !== this.gridBackgroundSessionId) return;
 
-    if (textures.some((texture) => !texture)) return;
+    if (textures.some((texture) => !texture)) {
+      // Native port: a failed `_LoadImage` makes `_ExecuteImage` log
+      // "[AVG.LargeBG] An error occurred when load image {0}.", call
+      // `_ResetPanel()` and return false without blocking, so the panel is
+      // emptied instead of keeping the previous composition.
+      await this.clearGridBackground(0);
+      return;
+    }
 
     const root = this.buildGridBackgroundRoot(input, textures as Texture[]);
     const previous = [...this.gridBackgroundLayer.children];
@@ -1071,6 +1092,14 @@ export class PixiStoryRenderer implements StoryRenderer {
     else void run;
   }
 
+  /**
+   * Native port note: `_ExecuteImage`'s clear branch (imagegroup and cggroup
+   * both empty) runs `DOFade(0, fadetime)` on the panel's CanvasGroup even
+   * when it is already empty, so `block=true` still waits out the fade. The
+   * Web adaptation returns early on an empty panel instead of animating
+   * nothing — an intentional simplification (no shipped script issues a
+   * parameterized clear on an empty panel).
+   */
   async clearGridBackground(fadeMs = 0, block = false): Promise<void> {
     const sessionId = ++this.gridBackgroundSessionId;
     this.largeBackgroundRoot = null;
@@ -2621,7 +2650,9 @@ export class PixiStoryRenderer implements StoryRenderer {
         return [this.imageLayer];
       }
       // `LargeBackgroundPanel._PostDisplayKey` registers ck_lbg_1..4 over its
-      // `_images` list, which only `largebg` fills.
+      // `_images` list, which the whole LargeBackgroundPanel family (largebg /
+      // verticalbg / gridbg) fills. The Web port only tracks the composed
+      // root, so focus effects apply to the whole puzzle rather than one tile.
       case "lbg": {
         return this.largeBackgroundRoot ? [this.largeBackgroundRoot] : [];
       }

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1043,7 +1043,10 @@ export class PixiStoryRenderer implements StoryRenderer {
     // the legacy cross-fade until their own alignment change, so this reset is
     // opt-in.
     if (input.resetPreviousImmediately) {
-      if (input.layout === "large") this.largeBackgroundRoot = null;
+      // The reset drops every root in the layer, so a largebg composition
+      // left over from an earlier command goes with it regardless of the
+      // incoming layout -- `largeBackgroundRoot` must not outlive it.
+      this.largeBackgroundRoot = null;
       const previous = [...this.gridBackgroundLayer.children];
       for (const child of previous) child.removeFromParent();
     }

--- a/src/widgets/StoryPlayer/engine/rendering/core/LayerGraph.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/LayerGraph.ts
@@ -24,13 +24,17 @@ export class LayerGraph {
   readonly world = new Container();
 
   attach(stage: Container): void {
-    // Unity panel_avg sibling order (2.7.71 scene data): background,
-    // panel_background, panel_large_background, panel_bgoverlay, then image /
-    // character layers. The large background renders in front of the normal
-    // background (nested Canvas sortingOrder 2 vs 1), so a later [Background]
-    // must never cover a [largebg] composition. Existing panels are attached
-    // to their nearest stable web equivalent until their strict pass is
-    // migrated.
+    // Unity panel_avg children, in nested-Canvas sortingOrder (2.7.71
+    // sharedassets1.assets): background (no Canvas) and panel_common_executors
+    // (non-visual), panel_background 1, panel_large_background 2,
+    // panel_bgoverlay 10, panel_character 61, panel_charoverlay 70,
+    // panel_image 121, panel_showItem 130, panel_cgoverlay 131,
+    // panel_character_cutin 180. Only the first three are strict here: the
+    // large background renders in front of the normal background (2 vs 1), so
+    // a later [Background] must never cover a [largebg] composition. The
+    // layers below panel_bgoverlay still sit at their nearest stable web
+    // equivalent -- notably images/characters are inverted versus native --
+    // until their strict pass is migrated.
     this.scene.addChild(this.background);
     this.scene.addChild(this.gridBackground);
     this.scene.addChild(this.avgDisplayBackground);

--- a/src/widgets/StoryPlayer/engine/rendering/core/LayerGraph.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/LayerGraph.ts
@@ -24,11 +24,15 @@ export class LayerGraph {
   readonly world = new Container();
 
   attach(stage: Container): void {
-    this.background.addChild(this.gridBackground);
-    // Unity SceneCanvas sibling order: large background, background, image,
-    // character cutin/items, then characters. Existing panels are attached to
-    // their nearest stable web equivalent until their strict pass is migrated.
+    // Unity panel_avg sibling order (2.7.71 scene data): background,
+    // panel_background, panel_large_background, panel_bgoverlay, then image /
+    // character layers. The large background renders in front of the normal
+    // background (nested Canvas sortingOrder 2 vs 1), so a later [Background]
+    // must never cover a [largebg] composition. Existing panels are attached
+    // to their nearest stable web equivalent until their strict pass is
+    // migrated.
     this.scene.addChild(this.background);
+    this.scene.addChild(this.gridBackground);
     this.scene.addChild(this.avgDisplayBackground);
     this.scene.addChild(this.images);
     this.scene.addChild(this.avgDisplayCg);

--- a/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
@@ -18,6 +18,26 @@ const largeBackgroundInitOffsets = new WeakMap<
   { x: number; y: number }
 >();
 
+/**
+ * Port of `LargeBackgroundPanel.POSITION_INIT_FUNCTION` as applied by
+ * `_ExecuteImage` (2.7.71 VA 0x183f32f40-0x183f3308e): the selected
+ * `_InitPosition*` result is written verbatim into
+ * `_initOffset.localPosition`.
+ *
+ * `_ExecuteImage` hands those helpers the parsed `solidwidth` list plus
+ * `new List<float> { solidheight, 0f }` (VA 0x183f33005-0x183f33025; the
+ * second `Add` takes a register zeroed at 0x183f32947). largebg is a single
+ * row, so the second row height is **0**, not a repeat of `solidheight` —
+ * `_InitPositionDefault` reads `height[1]` and `_InitPositionUpperLeft` /
+ * `_InitPositionLowerCenter` sum `height[0] + height[1]`.
+ *
+ * No coordinate conversion is needed on top of that: native's `_offset`
+ * RectTransform gets `sizeDelta = (w0 + w1, solidheight)` (VA 0x183f32c23)
+ * with a centered pivot and the two top-left-pivoted tiles at anchored
+ * positions (0, 0) and (w0, 0), which is exactly the flattened Pixi root
+ * (`buildGridBackgroundRoot` pivots on the same rect). The caller applies the
+ * only remaining difference, Pixi's downward y axis.
+ */
 function largeBackgroundInitOffset(input: GridBackgroundInput): {
   x: number;
   y: number;
@@ -27,25 +47,30 @@ function largeBackgroundInitOffset(input: GridBackgroundInput): {
 
   const widths = input.solidWidths;
   const height = input.solidHeights[0] ?? 0;
-  // Unity's children use a top-left anchor/pivot, while the flattened Pixi
-  // root uses a centered pivot. The latter already contributes -height / 2,
-  // so convert native initOffset.y into that centered coordinate space.
-  const centeredY = (nativeY: number) => nativeY + height / 2;
   switch (input.initPositionMode) {
+    // `_InitPositionCenter` (VA 0x183f34390) returns `Vector2.zero`, and an
+    // unregistered `initposmode` leaves the same zero in place, so this is
+    // also the fallback the runtime maps unknown values onto.
     case "center": {
-      return { x: 0, y: centeredY(0) };
+      return { x: 0, y: 0 };
     }
+    // `_InitPositionUpperLeft` (VA 0x183f34640):
+    // ((width[0] + width[1] - 1280) / 2, (720 - (height[0] + height[1])) / 2).
     case "upperleft": {
       return {
         x: (widths.reduce((sum, width) => sum + width, 0) - STORY_WIDTH) / 2,
-        y: centeredY((STORY_HEIGHT - height * 2) / 2),
+        y: (STORY_HEIGHT - height) / 2,
       };
     }
+    // `_InitPositionLowerCenter` (VA 0x183f34550):
+    // (0, (height[0] + height[1] - 720) / 2).
     case "lowercenter": {
-      return { x: 0, y: centeredY((height * 2 - STORY_HEIGHT) / 2) };
+      return { x: 0, y: (height - STORY_HEIGHT) / 2 };
     }
+    // `_InitPositionDefault` (VA 0x183f34450): (width[1] / 2, -height[1] / 2),
+    // and height[1] is the padded 0.
     default: {
-      return { x: (widths[1] ?? 0) / 2, y: centeredY(-height / 2) };
+      return { x: (widths[1] ?? 0) / 2, y: 0 };
     }
   }
 }

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1388,9 +1388,12 @@ export class StoryRuntime {
       }
 
       case "largebg": {
-        // Native port: Torappu.AVG.LargeBackgroundPanel._ExecuteImage (the
-        // LargeBackgroundPanel method, not AVGImagePanel's namesake). It composes
-        // two horizontal tiles and keeps fadetime literal.
+        // Native port: Torappu.AVG.LargeBackgroundPanel._ExecuteImage (2.7.61,
+        // VA 0x183e77ee0; the LargeBackgroundPanel method, not AVGImagePanel's
+        // namesake). It composes two horizontal tiles and keeps fadetime
+        // literal. Every validation/load failure makes native log an error,
+        // call `_ResetPanel()` and return false without blocking — mirrored
+        // below by clearing the grid background before continuing.
         const imageGroup = toString(this.exactArg(args, "imagegroup"));
         const cgGroup = toString(this.exactArg(args, "cggroup"));
         const groupSelection = resolveGroupedAssetSelection(
@@ -1401,12 +1404,17 @@ export class StoryRuntime {
           this.exactArg(args, "initposmode"),
           "default",
         );
+        // Native port: POSITION_INIT_FUNCTION only registers
+        // upperleft/center/lowercenter/default (VA 0x183e7b120). An
+        // unregistered key still writes `_initOffset.localPosition =
+        // (0,0,0)` (VA 0x183e78d10) — the same offset as `center` — so
+        // unknown values fall back to center, not default.
         const initPositionMode =
-          initPositionModeArg === "center" ||
+          initPositionModeArg === "default" ||
           initPositionModeArg === "lowercenter" ||
           initPositionModeArg === "upperleft"
             ? initPositionModeArg
-            : "default";
+            : "center";
         const fadeMs = Math.max(
           0,
           toNumber(this.exactArg(args, "fadetime"), 0) * 1000,
@@ -1426,23 +1434,24 @@ export class StoryRuntime {
         const solidWidths = parseNumberSequence(
           this.exactArg(args, "solidwidth"),
         ).slice(0, 2);
+        // Native port: `solidheight` (float, default 0.0) has no validation —
+        // 0 still lays out a zero-height, invisible composition that runs its
+        // fade and honors block for the full fadetime.
         const solidHeight = toNumber(this.exactArg(args, "solidheight"), 0);
-        const solidHeights = solidHeight > 0 ? [solidHeight] : [];
+        const solidHeights = [solidHeight];
 
         if (imageKeys.length === 0) {
           this.warn("parse", "largebg imagegroup is empty");
+          await this.renderer.clearGridBackground(0);
           return "continue";
         }
 
-        if (
-          imageKeys.length !== 2 ||
-          solidWidths.length !== 2 ||
-          solidHeights.length !== 1
-        ) {
+        if (imageKeys.length !== 2 || solidWidths.length !== 2) {
           this.warn(
             "parse",
             `largebg expects width_count * height_count === image_count, got ${solidWidths.length} * ${solidHeights.length} !== ${imageKeys.length}`,
           );
+          await this.renderer.clearGridBackground(0);
           return "continue";
         }
 
@@ -1453,6 +1462,10 @@ export class StoryRuntime {
           imageKeys,
           initPositionMode,
           layout: "large",
+          // Native port: `_ExecuteImage` calls `_ResetImages()` before
+          // loading, so the previous puzzle disappears immediately and the
+          // new one fades in over the emptied panel (no cross-fade).
+          resetPreviousImmediately: true,
           scaleX: toNumber(this.exactArg(args, "xScale"), 1),
           scaleY: toNumber(this.exactArg(args, "yScale"), 1),
           solidHeights,

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1449,7 +1449,7 @@ export class StoryRuntime {
         if (imageKeys.length !== 2 || solidWidths.length !== 2) {
           this.warn(
             "parse",
-            `largebg expects width_count * height_count === image_count, got ${solidWidths.length} * ${solidHeights.length} !== ${imageKeys.length}`,
+            `largebg expects width_count * height_count === image_count, got ${solidWidths.length} * 1 !== ${imageKeys.length}`,
           );
           await this.renderer.clearGridBackground(0);
           return "continue";

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -362,6 +362,15 @@ export interface GridBackgroundInput {
   imageKeys: string[];
   initPositionMode?: "center" | "default" | "lowercenter" | "upperleft";
   layout?: "grid" | "large" | "vertical";
+  /**
+   * Native port: `LargeBackgroundPanel._ExecuteImage` (2.7.61, VA 0x183e77ee0)
+   * calls `_ResetImages()` before `_LoadImage`, so the previous tiles vanish
+   * the moment the command executes and the new puzzle fades in over an
+   * emptied panel (a blank gap, not a cross-fade). Opt-in because the shared
+   * grid/vertical executors keep the legacy cross-fade until their own
+   * alignment change.
+   */
+  resetPreviousImmediately?: boolean;
   scaleX: number;
   scaleY: number;
   solidHeights: number[];

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1307,6 +1307,93 @@ describe("PixiStoryRenderer", () => {
     );
   });
 
+  it("removes the previous largebg composition before fading in the new one", async () => {
+    // Native port: `_ExecuteImage` (2.7.61, VA 0x183e77ee0) calls
+    // `_ResetImages()` before `_LoadImage`, so a fadetime>0 replacement
+    // starts from an emptied panel — a blank gap while the new puzzle fades
+    // in, never a cross-fade. The never-completing tween keeps that fade
+    // mid-flight.
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    renderer.tween = vi.fn(() => new Promise<void>(() => {}));
+
+    const first = {
+      ...createGridBackgroundInput(),
+      fadeMs: 0,
+      imageKeys: ["l1", "r1"],
+      layout: "large",
+      resetPreviousImmediately: true,
+      solidHeights: [720],
+      solidWidths: [100, 100],
+    };
+    await renderer.setGridBackground(first);
+    const firstRoot = renderer.gridBackgroundLayer.children.at(0);
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+
+    await renderer.setGridBackground({ ...first, fadeMs: 500 });
+
+    expect(firstRoot.parent).toBeNull();
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+    expect(renderer.gridBackgroundLayer.children.at(0).alpha).toBe(0);
+    expect(renderer.largeBackgroundRoot).toBe(
+      renderer.gridBackgroundLayer.children.at(0),
+    );
+  });
+
+  it("keeps the legacy cross-fade for layouts without the immediate reset", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    renderer.tween = vi.fn(() => new Promise<void>(() => {}));
+
+    const input = createGridBackgroundInput();
+    await renderer.setGridBackground({ ...input, fadeMs: 0 });
+    const firstRoot = renderer.gridBackgroundLayer.children.at(0);
+
+    // grid/vertical replacements keep the outgoing composition parented until
+    // the fade completes; their executors adopt the immediate reset in their
+    // own alignment change.
+    await renderer.setGridBackground({ ...input, fadeMs: 500 });
+
+    expect(firstRoot.parent).not.toBeNull();
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(2);
+  });
+
+  it("empties the panel when a largebg tile fails to load", async () => {
+    // Native port: a failed `_LoadImage` logs
+    // "[AVG.LargeBG] An error occurred when load image {0}.", calls
+    // `_ResetPanel()` and returns false without blocking.
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    const input = {
+      ...createGridBackgroundInput(),
+      fadeMs: 0,
+      imageKeys: ["l1", "r1"],
+      layout: "large",
+      resetPreviousImmediately: true,
+      solidHeights: [720],
+      solidWidths: [100, 100],
+    };
+    await renderer.setGridBackground(input);
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+
+    renderer.textureForImageKey = vi
+      .fn()
+      .mockImplementation((key: string) =>
+        key === "r1" ? Promise.resolve(null) : Promise.resolve(Texture.EMPTY),
+      );
+    await renderer.setGridBackground(input);
+
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(0);
+    expect(renderer.largeBackgroundRoot).toBeNull();
+  });
+
   it("draws a curtain as a solid body plus a fixed-width feather strip", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1395,6 +1395,31 @@ describe("PixiStoryRenderer", () => {
     expect(renderer.largeBackgroundRoot).toBeNull();
   });
 
+  it("empties the panel when a gridbg tile fails to load", async () => {
+    // The load-failure branch is shared with largebg on purpose:
+    // `_ExecuteGridBG` (2.7.71 VA 0x183f304c0) ends a failed `_LoadImage`
+    // with the same `DLog.LogError` + `_ResetPanel()` (VA 0x183f318aa) as
+    // `_ExecuteImage`, so grid/vertical must not keep the previous
+    // composition either -- even though they still cross-fade on success.
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    const input = { ...createGridBackgroundInput(), fadeMs: 0 };
+    await renderer.setGridBackground(input);
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+
+    renderer.textureForImageKey = vi
+      .fn()
+      .mockImplementation((key: string) =>
+        key === "r2" ? Promise.resolve(null) : Promise.resolve(Texture.EMPTY),
+      );
+    await renderer.setGridBackground(input);
+
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(0);
+  });
+
   it("draws a curtain as a solid body plus a fixed-width feather strip", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};
@@ -1870,6 +1895,44 @@ describe("PixiStoryRenderer", () => {
       { label: "tile-0", x: 0, y: 0 },
       { label: "tile-1", x: 640, y: 0 },
     ]);
+  });
+
+  it("places every largebg initposmode at its native _initOffset", () => {
+    // Native port: `_ExecuteImage` writes the selected `_InitPosition*`
+    // result straight into `_initOffset.localPosition`, and the helpers get
+    // `heights = [solidheight, 0]` (2.7.71 VA 0x183f33005-0x183f33025) --
+    // largebg is a single row, so `height[1]` is 0 rather than a repeat of
+    // `solidheight`. With two tiles of 400 + 600 and solidheight 500:
+    //   center      `Vector2.zero`                          -> (0, 0)
+    //   default     (width[1] / 2, -height[1] / 2)          -> (300, 0)
+    //   upperleft   ((1000 - 1280) / 2, (720 - 500) / 2)    -> (-140, 110)
+    //   lowercenter (0, (500 - 720) / 2)                    -> (0, -110)
+    // The Pixi root pivots on the same rect as native's `_offset`, so the
+    // only conversion is the flipped y axis: (640 + x, 360 - y).
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const place = (initPositionMode: string) => {
+      const root = renderer.buildGridBackgroundRoot(
+        {
+          ...createGridBackgroundInput(),
+          imageKeys: ["tile-0", "tile-1"],
+          initPositionMode,
+          layout: "large",
+          scaleX: 1,
+          scaleY: 1,
+          solidHeights: [500],
+          solidWidths: [400, 600],
+          x: 0,
+          y: 0,
+        },
+        [Texture.EMPTY, Texture.EMPTY],
+      );
+      return { x: root.position.x, y: root.position.y };
+    };
+
+    expect(place("center")).toEqual({ x: 640, y: 360 });
+    expect(place("default")).toEqual({ x: 940, y: 360 });
+    expect(place("upperleft")).toEqual({ x: 500, y: 250 });
+    expect(place("lowercenter")).toEqual({ x: 640, y: 470 });
   });
 
   it("applies largebgtween in largebg transform space", async () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1274,34 +1274,35 @@ describe("PixiStoryRenderer", () => {
     expect(order()).toEqual(["outgoing", "l", "r", "m"]);
   });
 
-  it("keeps the large background behind the background regardless of update order", async () => {
+  it("keeps the large background in front of the background regardless of update order", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const input = createGridBackgroundInput();
 
     renderer.app = {};
-    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    // Mirror LayerGraph.attach's scene order: background first, grid layer next.
+    renderer.sceneLayer.addChild(renderer.backgroundLayer);
+    renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
 
     // panel_large_background is a permanent sibling in front of panel_background
-    // in SceneCanvas, so it always renders underneath -- executing gridbg after
-    // background must not lift the puzzle above it.
+    // in SceneCanvas (nested Canvas sortingOrder 2 vs 1), so it always renders
+    // on top -- executing background after gridbg must not sink the puzzle
+    // below it.
+    const gridIndex = () =>
+      renderer.sceneLayer.children.indexOf(renderer.gridBackgroundLayer) -
+      renderer.sceneLayer.children.indexOf(renderer.backgroundLayer);
+
     await renderer.setGridBackground(input);
-    expect(renderer.backgroundLayer.children.at(0)).toBe(
-      renderer.gridBackgroundLayer,
-    );
+    expect(gridIndex()).toBeGreaterThan(0);
 
     await renderer.setBackground("bg_test");
-    expect(renderer.backgroundLayer.children.at(0)).toBe(
-      renderer.gridBackgroundLayer,
-    );
+    expect(gridIndex()).toBeGreaterThan(0);
     expect(renderer.backgroundLayer.children.at(-1)).toBe(
       renderer.backgroundRoot,
     );
 
     await renderer.setGridBackground(input);
-    expect(renderer.backgroundLayer.children.at(0)).toBe(
-      renderer.gridBackgroundLayer,
-    );
+    expect(gridIndex()).toBeGreaterThan(0);
     expect(renderer.backgroundLayer.children.at(-1)).toBe(
       renderer.backgroundRoot,
     );
@@ -1315,7 +1316,7 @@ describe("PixiStoryRenderer", () => {
     // mid-flight.
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};
-    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
     renderer.tween = vi.fn(() => new Promise<void>(() => {}));
 
@@ -1345,7 +1346,7 @@ describe("PixiStoryRenderer", () => {
   it("keeps the legacy cross-fade for layouts without the immediate reset", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};
-    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
     renderer.tween = vi.fn(() => new Promise<void>(() => {}));
 
@@ -1368,7 +1369,7 @@ describe("PixiStoryRenderer", () => {
     // `_ResetPanel()` and returns false without blocking.
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};
-    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
 
     const input = {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2506,6 +2506,7 @@ describe("StoryRuntime", () => {
         imageKeys: ["bg_beach_1", "bg_beach_2"],
         initPositionMode: "default",
         layout: "large",
+        resetPreviousImmediately: true,
         scaleX: 1,
         scaleY: 1,
         solidHeights: [720],
@@ -2540,6 +2541,7 @@ describe("StoryRuntime", () => {
         imageKeys: ["61_i12", "61_i11"],
         initPositionMode: "default",
         layout: "large",
+        resetPreviousImmediately: true,
         scaleX: 1,
         scaleY: 0.8,
         solidHeights: [900],
@@ -2553,6 +2555,80 @@ describe("StoryRuntime", () => {
         block: true,
         fadeMs: 200,
       },
+    ]);
+  });
+
+  it("maps unknown largebg initposmode values to the center offset", async () => {
+    // Native port: POSITION_INIT_FUNCTION has no entry for an unknown key, so
+    // `_ExecuteImage` still writes `_initOffset.localPosition = (0,0,0)` (VA
+    // 0x183e78d10) — the same offset as `center`, not `default`.
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[largebg(imagegroup="a/b",solidwidth="1/1",solidheight=720,initposmode="diagonal")]',
+        '[largebg(imagegroup="a/b",solidwidth="1/1",solidheight=720,initposmode="upperleft")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(
+      renderer.gridBackgroundCalls.map((call) => call.initPositionMode),
+    ).toEqual(["center", "upperleft"]);
+  });
+
+  it("keeps largebg running with a zero or missing solidheight", async () => {
+    // Native port: `solidheight` (float, default 0.0) has no validation in
+    // `_ExecuteImage`; a zero-height invisible composition still fades in and
+    // still blocks for the full fadetime.
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[largebg(imagegroup="a/b",solidwidth="1/1",solidheight=0,fadetime=1,block=true)]',
+        '[largebg(imagegroup="a/b",solidwidth="1/1",fadetime=0)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(
+      renderer.gridBackgroundCalls.map((call) => call.solidHeights),
+    ).toEqual([[0], [0]]);
+    expect(renderer.gridBackgroundCalls.map((call) => call.block)).toEqual([
+      true,
+      false,
+    ]);
+    expect(renderer.gridBackgroundClearCalls).toEqual([]);
+  });
+
+  it("empties the large background panel when largebg validation fails", async () => {
+    // Native port: Count!=2 / empty-tile / bad-width failures make
+    // `_ExecuteImage` log an error, `_ResetPanel()` and return false without
+    // blocking — the previous composition must not survive the failed command.
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[largebg(imagegroup="a/b",solidwidth="1/1",solidheight=720,fadetime=0)]',
+        '[largebg(imagegroup="a/b/c",solidwidth="1/1",solidheight=720,fadetime=0)]',
+        '[largebg(imagegroup="a",solidwidth="1/1",solidheight=720,fadetime=0)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.gridBackgroundCalls).toHaveLength(1);
+    expect(renderer.gridBackgroundClearCalls).toEqual([
+      { block: false, fadeMs: 0 },
+      { block: false, fadeMs: 0 },
     ]);
   });
 


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `largebg` 命令移植中差异清单里建议修复的全部条目(P1×1、P2×3,另含两处注释修正);追加提交 `faf9e40d` 另修复 largebg 图层级序(§6)——story-compare 对比批次确认的既有 bug,与本 PR 主修复独立但同属 largebg 渲染对齐。依据是对明日方舟官服客户端(2.7.61 / build 2761 与 2.7.71 / build 2771,Unity IL2CPP)GameAssembly.dll 的 IDA 反编译复核,关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 largebg 机制(2.7.61 逆向结论)

- 执行器为 `Torappu.AVG.LargeBackgroundPanel._ExecuteImage`(VA `0x183e77ee0`),把 `imagegroup` 按 `/` 拆成恰好 2 张横向拼图(`cggroup` 回退到 images 资源路径),`fadetime` 字面秒数直传 DOFade(不乘 animateRatio),`fadetime<=0` 强制非阻塞。
- **加载分支第一步是 `_ResetImages()`**:旧拼图瞬间清空,新拼图从 alpha 0 淡入 —— 存在短暂空白期,新旧图无叠加。
- **任何校验/加载失败**(子图段数 ≠2、子图为空、宽度缺失/解析失败、`_LoadImage` 失败)→ `DLog.LogError` + `_ResetPanel()`(面板清空) + 返回 false(非阻塞)。
- **未知 `initposmode`**:`POSITION_INIT_FUNCTION`(VA `0x183e7b120`)只注册 `upperleft`/`center`/`lowercenter`/`default` 四个 key;key 未命中时仍写 `_initOffset.localPosition = (0,0,0)`(VA `0x183e78d10`),效果等同 `center`,**不是**回退到 `default`。
- **`solidheight` 无校验**:float 参数默认 0.0,照样走完布局(总高 0、子图高 0 的不可见拼图)、照跑淡入、block 时照样阻塞 fadetime 秒。
- `_LoadImage`(VA `0x183e7a570`)失败日志为 `"[AVG.LargeBG] An error occurred when load image {0}."`。

## 修复内容

### 1. 连续 largebg 的旧内容处理(P1)

| | native | 修复前 | 修复后 |
| --- | --- | --- | --- |
| 行为 | `_ResetImages()` 先清空旧拼图,新拼图淡入期间面板为空(空白期) | 旧 root 保留到新图淡入完成才移除,视觉上是交叉淡入 | largebg 路径在命令执行瞬间移除旧 root,仅保留新图淡入 |

- `PixiStoryRenderer.setGridBackground` 新增 opt-in 字段 `GridBackgroundInput.resetPreviousImmediately`:置位时在发起纹理加载前立即清空 `gridBackgroundLayer`(复刻 `_ResetImages()` 在 `_LoadImage` 之前的顺序),并同步失效 `largeBackgroundRoot`。runtime 的 `largebg` 分支固定传 `true`。
- 该函数为 largebg/gridbg/verticalbg 共用:grid/vertical 路径不传该字段,保持既有交叉淡入,由各自的对齐 PR(#344/#345)处理,本 PR 对共享函数的改动保持最小。**这是本 PR 唯一动到的共享路径,已用单测锁定非 largebg 布局行为不变。**

### 2. 参数校验 / 加载失败后的面板状态(P2)

| | native | 修复前 | 修复后 |
| --- | --- | --- | --- |
| 行为 | 任何失败 → LogError + `_ResetPanel()` + 返回 false(非阻塞) | `warn` 后 `continue`,旧背景原样保留;纹理加载失败也仅 return | runtime 两个校验失败分支与 renderer 纹理加载失败分支均调用 `clearGridBackground(0)` 立即清空面板,非阻塞继续 |

### 3. 未知 `initposmode` 值(P2)

| | native | 修复前 | 修复后 |
| --- | --- | --- | --- |
| 行为 | key 未命中 → 写 `(0,0,0)`,效果同 `center` | fallback 到 `default` 模式(x = w1/2 偏移) | 未注册值映射到 `center`;四个注册值(含显式 `default`)保持原样 |

### 4. `solidheight` 缺失或 ≤0(P2)

| | native | 修复前 | 修复后 |
| --- | --- | --- | --- |
| 行为 | 无校验,默认 0.0 照样走完:总高 0 的不可见拼图,DOFade 照跑,block 照样阻塞 | `h>0 ? [h] : []`,length≠1 → 整条命令 warn + 跳过(不渲染、不阻塞) | `solidHeights = [solidHeight]` 恒单元素,0/缺失照样渲染(不可见)并保留淡入与 block 语义 |

### 5. 注释修正(顺手项)

- `clearGridBackground` 补注:native 清屏分支空面板也跑 fadetime 且 block 阻塞,Web 端空面板早退是**有意简化**(生产语料无参数化空清屏,维持现状)。
- `lbg` 特效挂点注释修正:`_PostDisplayKey` 的 `ck_lbg_1..4` 挂在 `_images` 上,由整个 LargeBackgroundPanel 家族(largebg/verticalbg/gridbg)填充,并非 largebg 专属;Web 端只有整个 root 的粗粒度挂点,维持现状。

### 6. largebg 图层级序:恒在普通背景之上(追加提交 `faf9e40d`)

| | native | 修复前 | 修复后 |
| --- | --- | --- | --- |
| 层级 | `panel_avg` sibling 顺序:`panel_background`(嵌套 Canvas sortingOrder **1**)在前、`panel_large_background`(**2**)在后 → **大图恒在普通背景之上**,后到的 `[Background]` 盖不住已显示的 largebg | `gridBackground` 是 `background` 容器的 child 0(最底层),`[Background]` 的 root 追加在后 → **普通背景盖住 largebg**,与 native 相反 | `gridBackground` 提升为 scene 级兄弟节点,插在 `background` 与 `avgDisplayBackground`(= `panel_bgoverlay`)之间 |

- 层级证据:2.7.61 Android 场景数据(`panel_avg` 11 个子节点顺序 + 嵌套 Canvas sortingOrder 1/2);2.7.71(build 2771)GameAssembly.dll IDA 复核:全 AVG 命名空间对 `SetSiblingIndex`/`SetAsFirstSibling`/`SetAsLastSibling` 的调用仅 6 处(角色槽排序、CG item 重排、面板内 fore/back 图交换),`LargeBackgroundPanel._ExecuteImage`(0x183F32110)只操作面板自身子树 —— **无运行时层级重排,顺序纯场景数据驱动**。
- `destroy()` 同步删除"grid 层塞回 backgroundLayer 当 child 0"的逻辑(该层保持 scene 挂载,仅清 tile roots)。
- 附带修复 `ck_bg` 焦点特效误伤:`resolveFocusTargets("bg")` 返回整个 `backgroundLayer`,grid 层原先作为其子节点会被连带(native `ck_bg_1/2` 只作用于 `panel_background` 内部 fore/back 两张图);移出后不再受影响。
- 这是 story-compare 2026-09-12 对比批次(`arknights-rev/story-compare/reports/2026-09-12-pr360-largebg-replace.md`)B/C/D/E 四段 MISMATCH 的共同根因;四段差异经旧实现基线(437134e8)与 09-04 r1 录制确认**早于本 PR 存在**,A 段 P1 主判据三方 MATCH 不受影响。

## 验证用剧情文件

语料:`torappu` 剧情库(torappu/storage/asset/gamedata/latest/story,2.7.61 对应内容):

- `activities/act32side/level_act32side_08_beg.txt:376` — **修复项 1(P1)**:第 349 行已有 `largebg(...,fadetime=0)`,第 376 行同图 `fadetime=0.5` 替换(x 不同);且 371-375 行紧跟一组 Blocker 白闪——正是官方用白闪掩盖 native 清空→淡入之间空白期的手法,佐证 native 无交叉淡入。修复后前端同样立即清旧图。
- `activities/act12side/level_act12side_06_beg.txt:56→66` — largebg 生命周期回归参照:56 行 `[largebg]` 清屏、66 行 `fadetime=0.2` 空面板淡入,时序行为不因本 PR 改变(追加的图层级序修复后,L66 重设的大图改为置顶显示,见 §6)。
- `activities/act12d0/level_act12d0_st02.txt:6→118` — **修复项 6(图层级序)**:L6 `[Background(bg_desert_1)]` 先占位、L118 `largebg(bg_falls_1/bg_falls_2)` 后到;修复前大图被沙漠盖住(整窗无瀑布内容),修复后瀑布置顶,L124 终态与官服一致(dev 调试页 `?line=124` 实测)。
- `activities/act12side/level_act12side_06_beg.txt:57→66` — 修复项 6 反向:普通 `[Background(bg_20_G02)]` 先设、L66 largebg 重设;修复后大图压过街景回到海滩(native 同款,`?line=69` 终态实测一致)。
- 修复项 2(失败清面板):全语料 0 命中(官服端此类脚本会 LogError,不会上线)——**前瞻对齐,由单测锁定**:`tests/runtime.spec.ts` "empties the large background panel when largebg validation fails"、`tests/renderer.spec.ts` "empties the panel when a largebg tile fails to load"。
- 修复项 3(未知 initposmode):全语料 0 命中(`initposmode` 参数本身未被任何生产剧情使用)——**前瞻对齐,由单测锁定**:`tests/runtime.spec.ts` "maps unknown largebg initposmode values to the center offset"。
- 修复项 4(solidheight 缺失/≤0):全语料 123 处带图 largebg 均显式给出 `solidheight>0`——**前瞻对齐,由单测锁定**:`tests/runtime.spec.ts` "keeps largebg running with a zero or missing solidheight"。
- 修复项 6 资产可达性:`bg_falls_1/2`、`bg_20_G02`、`bg_20_G04_1/2`、`bg_desert_1` 在 `torappu.prts.wiki/assets/avg/background/<key小写>.png` 均 200,排除缺资产解释。

## 测试

- `pnpm test`:370 用例全部通过(分支 rebase 后全量;本 PR 主修复新增 6 条 = runtime 3 + renderer 3,追加提交反转 renderer 层级断言为 largebg 置顶,用例数不变)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm lint`:通过。
- 修复项 6 终态画面:dev 调试页 seek 实测 `act12d0_st02` L124 瀑布、`act12side_06_beg` L69 海滩,均与官服一致。
