### PR TITLE
fix(story-player): largeimgtween 实现 ease/loop 参数并修正 duration 默认值

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -63,7 +63,11 @@ import {
   rotateTweenDelta,
 } from "./core/SceneGeometry";
 import { buildShakePath, sampleShakePath } from "./core/ShakePath";
-import { TweenRunner } from "./core/TweenRunner";
+import {
+  dotweenEaseCurve,
+  TweenRunner,
+  type TweenRunOptions,
+} from "./core/TweenRunner";
 import { AnimTextPanel } from "./panels/AnimTextPanel";
 import { AvgDisplayPanel } from "./panels/AvgDisplayPanel";
 import { CgItemPanel } from "./panels/CgItemPanel";
@@ -1347,7 +1351,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   /**
    * Web-only companion to the legacy `setLargeImage` surface: the investigated
    * client has no `largeimgtween` executor. It is intentionally not a native
-   * provenance claim.
+   * provenance claim; the tween semantics (ease via `GetEnum<Ease>("ease",
+   * 1)`, loops via `SetLoops(2*!loop-1)`) mirror the closest native
+   * relative, `LargeBackgroundPanel._ExecuteImageTween` (`largebgtween`).
    */
   async setLargeImageTween(input: LargeBackgroundTweenInput): Promise<void> {
     const root = this.largeImageRoot;
@@ -1379,6 +1385,10 @@ export class PixiStoryRenderer implements StoryRenderer {
       return;
     }
 
+    // The native move and scale DOTweens share one duration, ease and loop
+    // count, so a single merged interpolation is frame-equivalent; loop=true
+    // turns the run into an infinite Restart loop that replays the From pose
+    // every cycle and never completes (block is dropped upstream for loops).
     const run = this.tween(
       input.durationMs,
       (progress) => {
@@ -1393,6 +1403,10 @@ export class PixiStoryRenderer implements StoryRenderer {
       () => {
         if (!this.isActiveLargeImage(root, sessionId)) return;
         this.applyCenteredTransform(root, to);
+      },
+      {
+        ease: dotweenEaseCurve(input.ease),
+        loops: input.loop ? -1 : 1,
       },
     );
 
@@ -3747,8 +3761,9 @@ export class PixiStoryRenderer implements StoryRenderer {
     durationMs: number,
     step: (progress: number) => void,
     done?: () => void,
+    options?: TweenRunOptions,
   ): Promise<void> {
-    return this.tweenRunner.run(durationMs, step, done);
+    return this.tweenRunner.run(durationMs, step, done, options);
   }
 }
 

--- a/src/widgets/StoryPlayer/engine/rendering/core/TweenRunner.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/TweenRunner.ts
@@ -1,5 +1,218 @@
 import { browserAnimationClock, type AnimationClock } from "../../execution";
 
+/** Normalized-time ([0, 1] input) interpolation curve. */
+export type EaseCurve = (time: number) => number;
+
+/** Optional DOTween `SetEase`/`SetLoops` behaviour for {@link TweenRunner.run}. */
+export interface TweenRunOptions {
+  /**
+   * Curve applied to each loop cycle's raw progress, mirroring DOTween's
+   * `SetEase(ease)`; defaults to Linear.
+   */
+  ease?: EaseCurve;
+  /**
+   * DOTween `SetLoops` count: 1 = single pass (default), negative = infinite
+   * Restart loop that replays from the start value every cycle and never
+   * completes (so `run` only settles once `isAlive` turns false — callers
+   * must not block on it).
+   */
+  loops?: number;
+}
+
+const linearEase: EaseCurve = (time) => time;
+
+// Native provenance: the DOTween `Ease` enum and its Robert Penner curves
+// compiled into 2.7.61 (build 2761) GameAssembly.dll
+// (`DG.Tweening.Core.Easing.EaseManager.Evaluate`). AVG executors select a
+// curve with `DotNetExtensionMethods.GetEnum<Ease>(param, "ease", ...)`,
+// which matches enum names case-sensitively and also accepts integer strings
+// as ordinals (`ease="6"` is OutQuad). The Flash family is deliberately not
+// ported — story scripts never pass it to these commands — and resolves to
+// Linear, as does anything the name table cannot parse (GetEnum's Linear
+// fallback).
+
+function powerCurves(power: number): Record<"in" | "inOut" | "out", EaseCurve> {
+  return {
+    in: (time) => time ** power,
+    inOut: (time) =>
+      time < 0.5
+        ? 2 ** (power - 1) * time ** power
+        : 1 - (-2 * time + 2) ** power / 2,
+    out: (time) => 1 - (1 - time) ** power,
+  };
+}
+
+const quad = powerCurves(2);
+const cubic = powerCurves(3);
+const quart = powerCurves(4);
+const quint = powerCurves(5);
+
+function outBounce(time: number): number {
+  const d1 = 2.75;
+  if (time < 1 / d1) return 7.5625 * time * time;
+  if (time < 2 / d1) {
+    const t = time - 1.5 / d1;
+    return 7.5625 * t * t + 0.75;
+  }
+  if (time < 2.5 / d1) {
+    const t = time - 2.25 / d1;
+    return 7.5625 * t * t + 0.9375;
+  }
+  const t = time - 2.625 / d1;
+  return 7.5625 * t * t + 0.984_375;
+}
+
+const backC1 = 1.701_58;
+const backC2 = backC1 * 1.525;
+const backC3 = backC1 + 1;
+const elasticC4 = (2 * Math.PI) / 3;
+const elasticC5 = (2 * Math.PI) / 4.5;
+
+const dotweenEaseCurves: Record<string, EaseCurve> = {
+  InBack: (time) => backC3 * time ** 3 - backC1 * time ** 2,
+  InBounce: (time) => 1 - outBounce(1 - time),
+  InCirc: (time) => 1 - Math.sqrt(1 - time ** 2),
+  InCubic: cubic.in,
+  InElastic: (time) =>
+    time === 0 || time === 1
+      ? time
+      : -(2 ** (10 * time - 10)) * Math.sin((10 * time - 10.75) * elasticC4),
+  InExpo: (time) => (time === 0 ? 0 : 2 ** (10 * time - 10)),
+  InOutBack: (time) =>
+    time < 0.5
+      ? ((2 * time) ** 2 * ((backC2 + 1) * 2 * time - backC2)) / 2
+      : ((2 * time - 2) ** 2 * ((backC2 + 1) * (2 * time - 2) + backC2) + 2) /
+        2,
+  InOutBounce: (time) =>
+    time < 0.5
+      ? (1 - outBounce(1 - 2 * time)) / 2
+      : (1 + outBounce(2 * time - 1)) / 2,
+  InOutCirc: (time) =>
+    time < 0.5
+      ? (1 - Math.sqrt(1 - (2 * time) ** 2)) / 2
+      : (Math.sqrt(1 - (-2 * time + 2) ** 2) + 1) / 2,
+  InOutCubic: cubic.inOut,
+  InOutElastic: (time) => {
+    if (time === 0 || time === 1) return time;
+    return time < 0.5
+      ? -(2 ** (20 * time - 10) * Math.sin((20 * time - 11.125) * elasticC5)) /
+          2
+      : (2 ** (-20 * time + 10) * Math.sin((20 * time - 11.125) * elasticC5)) /
+          2 +
+          1;
+  },
+  InOutExpo: (time) => {
+    if (time === 0) return 0;
+    if (time === 1) return 1;
+    return time < 0.5
+      ? 2 ** (20 * time - 10) / 2
+      : (2 - 2 ** (-20 * time + 10)) / 2;
+  },
+  InOutQuad: quad.inOut,
+  InOutQuart: quart.inOut,
+  InOutQuint: quint.inOut,
+  InOutSine: (time) => -(Math.cos(Math.PI * time) - 1) / 2,
+  InQuad: quad.in,
+  InQuart: quart.in,
+  InQuint: quint.in,
+  InSine: (time) => 1 - Math.cos((time * Math.PI) / 2),
+  Linear: linearEase,
+  OutBack: (time) => 1 + backC3 * (time - 1) ** 3 + backC1 * (time - 1) ** 2,
+  OutBounce: outBounce,
+  OutCirc: (time) => Math.sqrt(1 - (time - 1) ** 2),
+  OutCubic: cubic.out,
+  OutElastic: (time) =>
+    time === 0 || time === 1
+      ? time
+      : 2 ** (-10 * time) * Math.sin((10 * time - 0.75) * elasticC4) + 1,
+  OutExpo: (time) => (time === 1 ? 1 : 1 - 2 ** (-10 * time)),
+  OutQuad: quad.out,
+  OutQuart: quart.out,
+  OutQuint: quint.out,
+  OutSine: (time) => Math.sin((time * Math.PI) / 2),
+};
+
+/** DOTween `Ease` enum names in ordinal order (`Unset` = 0 … 37). */
+const dotweenEaseOrdinalNames = [
+  "Unset",
+  "Linear",
+  "InSine",
+  "OutSine",
+  "InOutSine",
+  "InQuad",
+  "OutQuad",
+  "InOutQuad",
+  "InCubic",
+  "OutCubic",
+  "InOutCubic",
+  "InQuart",
+  "OutQuart",
+  "InOutQuart",
+  "InQuint",
+  "OutQuint",
+  "InOutQuint",
+  "InExpo",
+  "OutExpo",
+  "InOutExpo",
+  "InCirc",
+  "OutCirc",
+  "InOutCirc",
+  "InElastic",
+  "OutElastic",
+  "InOutElastic",
+  "InBack",
+  "OutBack",
+  "InOutBack",
+  "InBounce",
+  "OutBounce",
+  "InOutBounce",
+  "Flash",
+  "InFlash",
+  "OutFlash",
+  "InOutFlash",
+  "INTERNAL_Zero",
+  "INTERNAL_Custom",
+] as const;
+
+const dotweenEaseByOrdinal: readonly EaseCurve[] = dotweenEaseOrdinalNames.map(
+  (name) => {
+    switch (name) {
+      case "Unset": {
+        // Never scripted; Ease.Linear keeps the fallback curve.
+        return linearEase;
+      }
+      case "INTERNAL_Zero": {
+        // Jumps straight to the end value.
+        return () => 1;
+      }
+      case "INTERNAL_Custom": {
+        // Native throws on the missing custom curve; Linear is the safe shape.
+        return linearEase;
+      }
+      default: {
+        // Includes the unported Flash family, which lands on Linear.
+        return dotweenEaseCurves[name] ?? linearEase;
+      }
+    }
+  },
+);
+
+/**
+ * Resolves a command's `ease` argument the way the AVG executors'
+ * `GetEnum<Ease>(param, "ease", Ease.Linear, ignoreCase: false)` does:
+ * case-sensitive enum names, integer strings as ordinals (`ease="6"` is
+ * OutQuad), and the Linear fallback for anything unparseable. Out-of-table
+ * ordinals land on EaseManager.Evaluate's default branch, the OutQuad
+ * parabola.
+ */
+export function dotweenEaseCurve(ease: string | undefined): EaseCurve {
+  if (ease === undefined) return linearEase;
+  if (/^-?\d+$/.test(ease)) {
+    return dotweenEaseByOrdinal[Number.parseInt(ease, 10)] ?? quad.out;
+  }
+  return dotweenEaseCurves[ease] ?? linearEase;
+}
+
 /**
  * Web-only animation adapter. AVG executors create DOTween sequences; callers
  * preserve their documented command timing while this class uses browser frames
@@ -15,12 +228,16 @@ export class TweenRunner {
     durationMs: number,
     step: (progress: number) => void,
     done?: () => void,
+    options?: TweenRunOptions,
   ): Promise<void> {
     if (durationMs <= 0) {
       step(1);
       done?.();
       return Promise.resolve();
     }
+    const ease = options?.ease ?? linearEase;
+    const loops = options?.loops ?? 1;
+    const totalMs = loops > 0 ? durationMs * loops : Number.POSITIVE_INFINITY;
     return new Promise((resolve) => {
       const start = this.clock.now();
       const tick = () => {
@@ -29,13 +246,20 @@ export class TweenRunner {
           resolve();
           return;
         }
-        const progress = Math.min(1, (this.clock.now() - start) / durationMs);
-        step(progress);
-        if (progress >= 1) {
+        const elapsed = this.clock.now() - start;
+        if (elapsed >= totalMs) {
+          step(ease(1));
           done?.();
           resolve();
           return;
         }
+        // DOTween's default Restart loop type replays from the start value
+        // at every cycle boundary.
+        const cycleProgress =
+          loops === 1
+            ? elapsed / durationMs
+            : (elapsed % durationMs) / durationMs;
+        step(ease(cycleProgress));
         this.clock.requestFrame(tick);
       };
       this.clock.requestFrame(tick);

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1508,17 +1508,50 @@ export class StoryRuntime {
 
       case "largeimgtween": {
         // Web-only compatibility extension paired with `largeimg`; it has no
+        // native executor or registration in the investigated client (2.7.61
+        // has no `largeimgtween` key in any GetExecutors table). Semantics
+        // follow the closest native relative, `largebgtween`
+        // (`Torappu.AVG.LargeBackgroundPanel._ExecuteImageTween`), with two
+        // deliberate Web-only extensions: keys are matched
+        // case-insensitively (`xFrom` and `xfrom` both hit; native reads
+        // exact CamelCase), and the eight tween params fall back to the
+        // static `x`/`y`/`xscale`/`yscale` keys before the current
+        // transform (native always falls back to the current transform).
+        const durationMs = Math.max(
+          0,
+          // Native GetOrDefault<float>("duration", 0.0): omitted duration
+          // snaps instantly instead of tweening.
+          toNumber(this.arg(args, "duration"), 0) * 1000,
+        );
+        const block =
+          durationMs > 0 && toBoolean(this.arg(args, "block"), false);
+        // `GetBool("loop", false)` feeds SetLoops(2*!loop-1): loop=true runs
+        // the tween as an infinite Restart loop.
+        const loop = toBoolean(this.arg(args, "loop"), false);
+        if (block && loop) {
+          // Native DLog.LogError text verbatim (typos and the copied
+          // "tween background" wording included), logged when
+          // effectiveBlock && loop. Native then blocks on a tween that never
+          // completes and the story hangs; we keep the error but drop block
+          // so playback continues.
+          this.warn(
+            "invalid_parameter",
+            "Loop and block both true when tween background! Will cause intinity lop!",
+          );
+        }
+
         const xScale = toOptionalNumber(this.arg(args, "xscale"));
         const yScale = toOptionalNumber(this.arg(args, "yscale"));
         const x = toOptionalNumber(this.arg(args, "x"));
         const y = toOptionalNumber(this.arg(args, "y"));
 
         await this.renderer.setLargeImageTween({
-          block: toBoolean(this.arg(args, "block"), false),
-          durationMs: Math.max(
-            0,
-            toNumber(this.arg(args, "duration"), 0.15) * 1000,
-          ),
+          block: block && !loop,
+          durationMs,
+          // `GetEnum<Ease>("ease", 1)`: DOTween Ease name or ordinal string,
+          // default Linear (= 1).
+          ease: toString(this.arg(args, "ease"), "Linear"),
+          loop,
           xFrom: toOptionalNumber(this.arg(args, "xfrom")) ?? x,
           xScaleFrom: toOptionalNumber(this.arg(args, "xscalefrom")) ?? xScale,
           xScaleTo: toOptionalNumber(this.arg(args, "xscaleto")) ?? xScale,

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -287,6 +287,17 @@ export interface ImageRotateInput {
 export interface LargeBackgroundTweenInput {
   block: boolean;
   durationMs: number;
+  /**
+   * Raw `ease` argument: a case-sensitive DOTween `Ease` name or ordinal
+   * string, resolved by the renderer (native `GetEnum<Ease>("ease", 1)`,
+   * default `Ease.Linear`).
+   */
+  ease?: string;
+  /**
+   * `loop=true` maps to native `SetLoops(2*!loop-1)` = -1, an infinite
+   * Restart loop that replays the From pose every cycle.
+   */
+  loop?: boolean;
   xFrom?: number;
   xScaleFrom?: number;
   xScaleTo?: number;

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -545,6 +545,63 @@ describe("PixiStoryRenderer", () => {
     ]);
   });
 
+  it("maps largeimgtween ease and loop onto the tween engine", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const root = renderer.buildGridBackgroundRoot(
+      {
+        ...createGridBackgroundInput(),
+        imageKeys: ["tile-0", "tile-1"],
+        layout: "large",
+        solidHeights: [900],
+        solidWidths: [1600, 1600],
+        x: -160,
+      },
+      [Texture.EMPTY, Texture.EMPTY],
+    );
+    const tweenOptions: Array<{
+      ease?: (t: number) => number;
+      loops?: number;
+    }> = [];
+
+    renderer.app = {};
+    renderer.imageLayer.addChild(root);
+    renderer.largeImageRoot = root;
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        step: (progress: number) => void,
+        done?: () => void,
+        options?: { ease?: (t: number) => number; loops?: number },
+      ) => {
+        tweenOptions.push(options ?? {});
+        step(0.5);
+        done?.();
+      },
+    );
+
+    await renderer.setLargeImageTween({
+      block: true,
+      durationMs: 1000,
+      // ease="6" is the DOTween ordinal syntax: 6 resolves to OutQuad, so
+      // the raw 0.5 step lands at eased 0.75.
+      ease: "6",
+      xFrom: -160,
+      xTo: -720,
+    });
+    await renderer.setLargeImageTween({
+      block: false,
+      durationMs: 1000,
+      loop: true,
+      xFrom: -160,
+      xTo: -720,
+    });
+
+    expect(tweenOptions.map(({ loops }) => loops)).toEqual([1, -1]);
+    expect(tweenOptions[0]?.ease?.(0.5)).toBe(0.75);
+    // No ease argument keeps Ease.Linear (= GetEnum<Ease>("ease", 1)).
+    expect(tweenOptions[1]?.ease?.(0.5)).toBe(0.5);
+  });
+
   it("applies zero-duration largeimgtween immediately and cancels stale tweens", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const root = renderer.buildGridBackgroundRoot(

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2400,6 +2400,8 @@ describe("StoryRuntime", () => {
       {
         block: false,
         durationMs: 25_000,
+        ease: "Linear",
+        loop: false,
         xFrom: 0,
         xScaleFrom: undefined,
         xScaleTo: undefined,
@@ -2412,6 +2414,8 @@ describe("StoryRuntime", () => {
       {
         block: false,
         durationMs: 500,
+        ease: "Linear",
+        loop: false,
         xFrom: undefined,
         xScaleFrom: 0.75,
         xScaleTo: 0.8,
@@ -2422,8 +2426,13 @@ describe("StoryRuntime", () => {
         yTo: undefined,
       },
       {
-        block: true,
-        durationMs: 150,
+        // Omitted `duration` keeps the native-referenced default 0
+        // (GetOrDefault<float>("duration", 0.0)): the command snaps
+        // instantly and never blocks, even with block=true.
+        block: false,
+        durationMs: 0,
+        ease: "Linear",
+        loop: false,
         xFrom: undefined,
         xScaleFrom: undefined,
         xScaleTo: undefined,
@@ -2432,6 +2441,51 @@ describe("StoryRuntime", () => {
         yScaleFrom: undefined,
         yScaleTo: undefined,
         yTo: 360,
+      },
+    ]);
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("keeps playing when largeimgtween combines loop with block", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[largeimg(imagegroup="61_i12/61_i11",solidwidth="1600/1600",solidheight="900",x=-160,fadetime=0)]',
+        '[largeimgtween(xFrom=0,xTo=-720,duration=1,block=true,loop=true,ease="OutQuad")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    // Native logs the DLog.LogError text verbatim (typos included) and then
+    // hangs waiting for a looping tween's OnComplete; the port keeps the
+    // error but drops block so playback reaches the next line.
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        detail:
+          "Loop and block both true when tween background! Will cause intinity lop!",
+        type: "invalid_parameter",
+      }),
+    ]);
+    expect(renderer.largeImageTweenCalls).toEqual([
+      {
+        block: false,
+        durationMs: 1000,
+        ease: "OutQuad",
+        loop: true,
+        xFrom: 0,
+        xScaleFrom: undefined,
+        xScaleTo: undefined,
+        xTo: -720,
+        yFrom: undefined,
+        yScaleFrom: undefined,
+        yScaleTo: undefined,
+        yTo: undefined,
       },
     ]);
     expect(runtime.getState()).toBe("waiting_input");

--- a/tests/tweenRunner.spec.ts
+++ b/tests/tweenRunner.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dotweenEaseCurve,
+  TweenRunner,
+} from "../src/widgets/StoryPlayer/engine/rendering/core/TweenRunner";
+
+describe('dotweenEaseCurve (GetEnum<Ease>("ease", Ease.Linear))', () => {
+  it("resolves integer strings as DOTween ordinals", () => {
+    // ease="1" is corpus-attested and is the GetEnum default: Linear.
+    expect(dotweenEaseCurve("1")(0.25)).toBe(0.25);
+    // ease="6" (act12d0_st02) is OutQuad, ease="7" (act12side_03_end) is
+    // InOutQuad.
+    expect(dotweenEaseCurve("6")(0.25)).toBe(0.4375);
+    expect(dotweenEaseCurve("7")(0.25)).toBe(0.125);
+  });
+
+  it("resolves enum names case-sensitively like ignoreCase: false", () => {
+    // Names used by production largebgtween scripts.
+    expect(dotweenEaseCurve("InOutCubic")(0.25)).toBe(0.0625);
+    expect(dotweenEaseCurve("InQuart")(0.5)).toBe(0.0625);
+    expect(dotweenEaseCurve("InExpo")(0.5)).toBe(0.03125);
+    // GetEnum falls back to Ease.Linear for anything it cannot parse.
+    expect(dotweenEaseCurve("inoutcubic")(0.25)).toBe(0.25);
+    expect(dotweenEaseCurve("NoSuchEase")(0.25)).toBe(0.25);
+    expect(dotweenEaseCurve(undefined)(0.25)).toBe(0.25);
+  });
+
+  it("keeps EaseManager's edge-ordinal behaviour", () => {
+    // Ease.Unset never appears in scripts; treated as Linear.
+    expect(dotweenEaseCurve("0")(0.25)).toBe(0.25);
+    // Out-of-table ordinals hit EaseManager.Evaluate's default branch, the
+    // OutQuad parabola.
+    expect(dotweenEaseCurve("99")(0.5)).toBe(0.75);
+    // The Flash family is not ported (absent from the story corpus) and
+    // resolves to Linear.
+    expect(dotweenEaseCurve("OutFlash")(0.5)).toBe(0.5);
+    expect(dotweenEaseCurve("34")(0.5)).toBe(0.5);
+    // INTERNAL_Zero jumps straight to the end value.
+    expect(dotweenEaseCurve("36")(0.25)).toBe(1);
+  });
+});
+
+function manualClock() {
+  let now = 0;
+  const frames: Array<() => void> = [];
+  return {
+    advance(to: number): void {
+      now = to;
+      frames.shift()?.();
+    },
+    clock: {
+      cancelFrame: () => {},
+      now: () => now,
+      requestFrame: (callback: () => void) => frames.push(callback),
+    },
+  };
+}
+
+describe("TweenRunner ease/loops (SetEase/SetLoops)", () => {
+  it("eases the stepped progress", async () => {
+    const { advance, clock } = manualClock();
+    const stepped: number[] = [];
+    const runner = new TweenRunner(() => true, clock);
+    const run = runner.run(
+      1000,
+      (progress) => stepped.push(progress),
+      undefined,
+      { ease: dotweenEaseCurve("6") },
+    );
+
+    advance(250);
+    advance(500);
+    advance(1000);
+    await run;
+
+    expect(stepped).toEqual([0.4375, 0.75, 1]);
+  });
+
+  it("restarts from the From pose each loop cycle and never completes", async () => {
+    const { advance, clock } = manualClock();
+    const stepped: number[] = [];
+    let settled = false;
+    let completed = false;
+    const runner = new TweenRunner(() => true, clock);
+    const run = runner.run(
+      1000,
+      (progress) => stepped.push(progress),
+      () => {
+        completed = true;
+      },
+      { loops: -1 },
+    );
+    run.then(() => {
+      settled = true;
+    });
+
+    advance(500);
+    advance(1250);
+    advance(2000);
+    await Promise.resolve();
+
+    // SetLoops(-1): cycle progress wraps at each duration boundary.
+    expect(stepped).toEqual([0.5, 0.25, 0]);
+    expect(completed).toBe(false);
+    expect(settled).toBe(false);
+  });
+
+  it("settles a looping tween once the runner stops being alive", async () => {
+    const { advance, clock } = manualClock();
+    let alive = true;
+    let completed = false;
+    const runner = new TweenRunner(() => alive, clock);
+    const run = runner.run(
+      1000,
+      () => {},
+      () => {
+        completed = true;
+      },
+      { loops: -1 },
+    );
+
+    advance(500);
+    alive = false;
+    advance(600);
+    await run;
+
+    expect(completed).toBe(true);
+  });
+});


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 `largeimgtween` 命令移植中的全部建议修复项(3 项 P2 + 4 项顺手注释小项)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的逆向分析,关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 无此命令,前端为兼容扩展

`largeimgtween` 与 `largeimg` 一样**不是 native 命令**(2.7.61/build 2761 GameAssembly.dll IDA 反编译复核):

- `find_regex "largeimg"` 全字符串缓存 0 命中(正向对照 `largebgtween`/`imagetween` 明文命中);
- `LargeBackgroundPanel.GetExecutors`(VA `0x183e758e0`)仅注册 `largebg`/`largebgtween`/`verticalbg`/`gridbg` 四个 key;
- `AVGImagePanel.GetExecutors`(VA `0x183e56250`)仅注册 `image`/`imagetween`/`imagerotate` 三个 key;
- 官服真实剧情样本 `grep -ri largeimg` 0 命中(`largeimgtween` 一并覆盖)。

因此前端在 runtime 中保留 `largeimgtween` 作为**配对 `largeimg` 的 Web-only 兼容扩展**,行为参照系取语义最近的 native 亲戚 `Torappu.AVG.LargeBackgroundPanel._ExecuteImageTween`(largebgtween 的 executor,VA `0x183e777a0`):参数按序读 `duration`(默认 0.0)、`block`、8 个 CamelCase float(`xFrom`/`yFrom`/`xScaleFrom`/`yScaleFrom`/`xTo`/`yTo`/`xScaleTo`/`yScaleTo`,缺省回落当前 transform 分量)、`ease`(`GetEnum<Ease>("ease", 1)` 默认 Linear,enum 名大小写敏感、整数字符串按 ordinal)、`loop`(`GetBool("loop", false)` 喂 `SetLoops(2*!loop-1)`,loop=true 为无限 Restart 循环);`effectiveBlock = duration>0 && block`;loop+block 触发 `DLog.LogError("Loop and block both true when tween background! Will cause intinity lop!")`(措辞原样)后继续执行。

本 PR 的 TweenRunner ease/loops 能力与 largebgtween 修复分支(#361)采用同一份实现,合并时两侧完全一致、无语义分叉。

## 修复内容

### 1. `duration` 默认值 0.15 → 0(P2)

- **前端问题**:省略 `duration` 时默认 0.15s,会跑一段 150ms tween;native 参照默认 0.0,`Complete()` 瞬时到位、命令等效非阻塞 no-op。
- **修复**:默认值改为 0,并在注释标注 `GetOrDefault<float>("duration", 0.0)` 出处。

### 2. 实现 `ease` 参数(P2)

- **前端问题**:完全不读 `ease`,恒线性插值(仅与 native 默认 Linear 碰巧一致)。
- **修复**:runtime 读取 `ease` 原始字符串(默认 `"Linear"`,对应 `GetEnum<Ease>("ease", 1)`);TweenRunner 新增 DOTween Ease 曲线表(Robert Penner 全家 + ordinal 字符串解析,大小写敏感、无法解析回落 Linear,Flash 族不移植),`setLargeImageTween` 按曲线对每循环进度插值。

### 3. 实现 `loop` 参数与 intinity lop 警告(P2)

- **前端问题**:完全忽略 `loop`,恒单程。
- **修复**:`loop=true` 映射 `SetLoops(-1)` 无限 Restart 循环(每个周期从 From 姿势重放,永不完成);`block && loop` 时按 native 原文打 `invalid_parameter` 警告("Loop and block both true when tween background! Will cause intinity lop!",拼写错误原样保留),但**不照抄 native 的挂死语义**——丢弃 block 让播放继续。

### 4. `block` 归一公式对齐(P3,纯风格)

- 对齐 native 显式公式 `effectiveBlock = duration > 0 && block`(duration<=0 时非阻塞),替换原来的直接透传。

### 5~7. 注释补全(P3)

- runtime.ts:1510 处截断注释 "…paired with `largeimg`; it has no" 补全为完整说明(无 native executor/注册,参照 largebgtween);
- 注释声明两个 Web 扩展语法非 native 行为:参数键大小写宽容(`xFrom` 与 `xfrom` 均命中,native 为精确 CamelCase)、8 个 tween 参数缺省先回落静态 `x`/`y`/`xscale`/`yscale` 键再回落当前 transform(native 只回落当前 transform)——行为本身按 review 建议保留;
- renderer 侧 `setLargeImageTween` 的 Web-only 定位注释补充 ease/loops 参照出处。

**有意不改的项**(review 建议为维持现状/无需处理):无 root 时直接 no-op 不等待(P3 #5,Web 扩展无 `_offset` 等价物,与 largebg 系列保持同构);浏览器动画时钟无 timeScale 概念(P3 #9,平台适配)。

## 验证用剧情文件

`/home/xwbx/Documents/torappu/storage/asset/gamedata/latest/story/` 全语料 `grep -ri largeimg` **0 命中**(与 2.7.61 官服样本一致,该命令为前端兼容扩展,预留给二创脚本),故验证以单测为主:

- `tests/runtime.spec.ts` `maps largeimgtween with legacy aliases and current-transform fallbacks`:锁定 duration 默认 0(第三条调用断言 `durationMs: 0`、`block: false`)、ease/loop 默认值透传、CamelCase 键(`xFrom=0`)命中;
- `tests/runtime.spec.ts` `keeps playing when largeimgtween combines loop with block`:锁定 intinity lop 警告原文、loop 时 block 被丢弃(`block: false`)、`ease="OutQuad"` 透传、播放不卡死;
- `tests/renderer.spec.ts` `maps largeimgtween ease and loop onto the tween engine`:锁定 ease 曲线(`ease="6"` → OutQuad,0.5 步进落在 0.75)与 `loops: [1, -1]` 映射;
- `tests/renderer.spec.ts` `applies largeimgtween in largeimg transform space` / `applies zero-duration largeimgtween immediately and cancels stale tweens`:既有回归,确认 From 瞬移/插值/瞬时到位/会话失效语义未被破坏;
- `tests/tweenRunner.spec.ts`:DOTween 曲线解析(ordinal/大小写敏感/Linear 回落/Flash 族/INTERNAL_Zero)与 Restart 循环时序、循环永不完成、isAlive 失效时收尾。

## 测试

- `pnpm test`:21 个文件 **230 个用例全部通过**(基线 222 + 新增 8);
- `pnpm exec vue-tsc -b`:通过;
- `pnpm exec eslint <改动文件>`:通过。
