### PR TITLE
fix(story-player): largeimg 对齐 largebg 家族语义，修复 scale 参数失效

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -704,6 +704,9 @@ export class PixiStoryRenderer implements StoryRenderer {
    * Web-only legacy compatibility surface. The investigated client has no
    * `largeimg` command or corresponding native executor, so this must not be
    * represented as a port; it remains isolated from the real `image` path.
+   * Behavioral reference: `LargeBackgroundPanel._ExecuteImage` (`largebg`) —
+   * all-or-nothing two-tile loading, literal fade, panel reset on failure —
+   * adapted to the foreground image layer.
    */
   async setLargeImage(input: GridBackgroundInput): Promise<void> {
     const sessionId = ++this.largeImageSessionId;
@@ -715,11 +718,20 @@ export class PixiStoryRenderer implements StoryRenderer {
     );
     if (!this.app || sessionId !== this.largeImageSessionId) return;
 
-    if (textures.some((texture) => !texture)) return;
+    if (textures.some((texture) => !texture)) {
+      // Reference behavior: on any load failure LargeBackgroundPanel logs an
+      // error and resets the panel, clearing what is on screen. Per-tile
+      // warnings already come from textureForImageKey; this surfaces the
+      // all-or-nothing decision and performs the reset.
+      this.onWarning?.("largeimg tile load failed; resetting large image");
+      await this.clearLargeImage(0);
+      return;
+    }
 
     const root = this.buildGridBackgroundRoot(input, textures as Texture[]);
-    // largeimg is a legacy-only command and retains its existing transform.
-    root.scale.set(1.2);
+    // Scale comes from the command's xscale/yscale (negative mirror values
+    // included) via buildGridBackgroundRoot; the previous hard-coded 1.2
+    // override made those parameters entirely ineffective.
     const previous = [...this.largeImageRoots];
     this.largeImageRoot = root;
 
@@ -735,6 +747,9 @@ export class PixiStoryRenderer implements StoryRenderer {
       return;
     }
 
+    // Unlike the native `_ResetImages()` (which clears old sprites before the
+    // fade-in, leaving a short blank gap), the outgoing root is kept until the
+    // incoming fade completes — a web-extension cross-fade visual choice.
     const run = this.tween(
       input.fadeMs,
       (progress) => {

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1194,8 +1194,13 @@ export class StoryRuntime {
       }
 
       case "largeimg": {
-        // Web-only compatibility extension: no native panel registers `largeimg`
-        // in the documented client; native `image` is its closest equivalent.
+        // Web-only compatibility extension: no native panel registers
+        // `largeimg` (re-verified against the 2.7.61 executor tables). Its
+        // parameter set — imagegroup/solidwidth/solidheight two-tile
+        // composition, literal fadetime, cggroup asset switch — is taken from
+        // the LargeBackgroundPanel family (`largebg`), NOT from the native
+        // `image` command, which is single-image and shares no puzzle params;
+        // only the asset domain (avg/images/) follows AVGImagePanel.
         const imageGroup = toString(this.arg(args, "imagegroup"));
         const cgGroup = toString(this.arg(args, "cggroup"));
         const groupSelection = resolveGroupedAssetSelection(
@@ -1203,20 +1208,24 @@ export class StoryRuntime {
           cgGroup,
           "image",
         );
-        const groupValue = groupSelection?.groupValue ?? "";
+        // Like the LargeBackgroundPanel family, fadetime is a literal second
+        // count (calculateFadeMs/animateRatio is bypassed) and defaults to 0.
         const fadeMs = Math.max(
           0,
-          Math.round(
-            toNumber(this.arg(args, "fadetime"), groupValue ? 0.15 : 0) * 1000,
-          ),
+          Math.round(toNumber(this.arg(args, "fadetime"), 0) * 1000),
         );
-        const block = toBoolean(
-          this.arg(args, "blok"),
+        // Legacy alias fallbacks (`blok`/`isblock`) and case-insensitive keys
+        // (`xscale` matching native CamelCase `xScale`) are web-extension
+        // tolerance for fan scripts; the native family reads exact keys only.
+        const block =
+          fadeMs > 0 &&
           toBoolean(
-            this.arg(args, "isblock"),
-            toBoolean(this.arg(args, "block"), false),
-          ),
-        );
+            this.arg(args, "blok"),
+            toBoolean(
+              this.arg(args, "isblock"),
+              toBoolean(this.arg(args, "block"), false),
+            ),
+          );
 
         if (!groupSelection) {
           await this.renderer.clearLargeImage(fadeMs, block);
@@ -1227,24 +1236,33 @@ export class StoryRuntime {
           .split("/")
           .map((item) => this.resolveImageKey(item))
           .filter((key): key is string => key !== null);
-        const solidWidths = parseNumberSequence(this.arg(args, "solidwidth"));
-        const solidHeights = parseNumberSequence(this.arg(args, "solidheight"));
+        const solidWidths = parseNumberSequence(
+          this.arg(args, "solidwidth"),
+        ).slice(0, 2);
+        const solidHeights = parseNumberSequence(
+          this.arg(args, "solidheight"),
+        ).slice(0, 1);
 
+        // Reference behavior: LargeBackgroundPanel._ExecuteImage accepts
+        // exactly two horizontal tiles (imagegroup Count==2, one height) and
+        // resets the panel via _ResetPanel() on any parse failure — the
+        // previous layer is cleared instead of kept.
         if (imageKeys.length === 0) {
           this.warn("parse", "largeimg imagegroup is empty");
+          await this.renderer.clearLargeImage(0);
           return "continue";
         }
 
-        const expectedTileCount = solidWidths.length * solidHeights.length;
         if (
-          solidWidths.length === 0 ||
-          solidHeights.length === 0 ||
-          expectedTileCount !== imageKeys.length
+          imageKeys.length !== 2 ||
+          solidWidths.length !== 2 ||
+          solidHeights.length !== 1
         ) {
           this.warn(
             "parse",
-            `largeimg expects width_count * height_count === image_count, got ${solidWidths.length} * ${solidHeights.length} !== ${imageKeys.length}`,
+            `largeimg expects exactly two horizontal tiles (2 widths x 1 height), got ${imageKeys.length} images / ${solidWidths.length} widths / ${solidHeights.length} heights`,
           );
+          await this.renderer.clearLargeImage(0);
           return "continue";
         }
 
@@ -1254,12 +1272,17 @@ export class StoryRuntime {
           fadeMs,
           imageKeys,
           layout: "large",
-          scaleX: Math.max(0, toNumber(this.arg(args, "xscale"), 1)),
-          scaleY: Math.max(0, toNumber(this.arg(args, "yscale"), 1)),
+          // Negative scales (mirror flips) pass through like the reference's
+          // localScale assignment; no clamping to 0.
+          scaleX: toNumber(this.arg(args, "xscale"), 1),
+          scaleY: toNumber(this.arg(args, "yscale"), 1),
           solidHeights,
           solidWidths,
           x: toNumber(this.arg(args, "x"), 0),
           y: toNumber(this.arg(args, "y"), 0),
+          // initposmode is intentionally not read: largeimg is a web-only
+          // extension, so the largebg initOffset placement has no script
+          // corpus to serve here.
         });
         return "continue";
       }

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -603,4 +603,63 @@ describe("PixiStoryRenderer", () => {
     expect(root.position.x - 640).toBe(-160);
     expect(360 - root.position.y).toBe(0);
   });
+
+  it("applies largeimg input scale instead of the legacy 1.2 override", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setLargeImage({
+      ...createGridBackgroundInput(),
+      fadeMs: 0,
+      imageKeys: ["tile-0", "tile-1"],
+      layout: "large",
+      scaleX: -1.25,
+      scaleY: 0.8,
+      solidHeights: [900],
+      solidWidths: [1600, 1600],
+      x: -160,
+    });
+
+    // The former hard-coded root.scale.set(1.2) discarded the command's
+    // xscale/yscale entirely; the reference applies localScale verbatim.
+    const root = renderer.largeImageRoot;
+    expect(root.scale.x).toBe(-1.25);
+    expect(root.scale.y).toBe(0.8);
+    expect(root.parent).toBe(renderer.imageLayer);
+  });
+
+  it("resets the large image layer when a largeimg tile fails to load", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    const warnings: string[] = [];
+    renderer.onWarning = (detail: string) => warnings.push(detail);
+    renderer.textureForImageKey = vi
+      .fn()
+      .mockResolvedValueOnce(Texture.EMPTY)
+      .mockResolvedValueOnce(null);
+
+    const stale = new Container();
+    renderer.imageLayer.addChild(stale);
+    renderer.largeImageRoots.add(stale);
+    renderer.largeImageRoot = stale;
+
+    await renderer.setLargeImage({
+      ...createGridBackgroundInput(),
+      fadeMs: 0,
+      imageKeys: ["tile-0", "tile-1"],
+      layout: "large",
+      solidHeights: [900],
+      solidWidths: [1600, 1600],
+    });
+
+    // Reference: on any load failure LargeBackgroundPanel logs and resets
+    // the panel, so the previous layer must not survive the failed swap.
+    expect(stale.parent).toBeNull();
+    expect(renderer.largeImageRoot).toBeNull();
+    expect(renderer.largeImageRoots.size).toBe(0);
+    expect(warnings).toContain(
+      "largeimg tile load failed; resetting large image",
+    );
+  });
 });

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2088,6 +2088,95 @@ describe("StoryRuntime", () => {
     ]);
   });
 
+  it("passes largeimg scales through verbatim, including negative mirrors", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[largeimg(imagegroup="61_i12/61_i11",solidwidth="1600/1600",solidheight="900",xScale=-1.25,yScale=1.5,fadetime=0)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // Case-insensitive keys accept native CamelCase xScale/yScale, and the
+    // negative mirror value must survive (reference: localScale assignment).
+    expect(renderer.gridBackgroundCalls).toEqual([
+      {
+        assetKind: "image",
+        block: false,
+        fadeMs: 0,
+        imageKeys: ["61_i12", "61_i11"],
+        layout: "large",
+        scaleX: -1.25,
+        scaleY: 1.5,
+        solidHeights: [900],
+        solidWidths: [1600, 1600],
+        x: 0,
+        y: 0,
+      },
+    ]);
+  });
+
+  it("defaults largeimg fadetime to zero and normalizes block", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[largeimg(imagegroup="61_i12/61_i11",solidwidth="1600/1600",solidheight="900",blok=true)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // fadetime defaults to 0 like the LargeBackgroundPanel family, and a
+    // zero-duration fade forces block=false (native: fadetime<=0 => !block).
+    expect(renderer.gridBackgroundCalls).toEqual([
+      {
+        assetKind: "image",
+        block: false,
+        fadeMs: 0,
+        imageKeys: ["61_i12", "61_i11"],
+        layout: "large",
+        scaleX: 1,
+        scaleY: 1,
+        solidHeights: [900],
+        solidWidths: [1600, 1600],
+        x: 0,
+        y: 0,
+      },
+    ]);
+  });
+
+  it("resets the large image layer when largeimg breaks the two-tile contract", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[largeimg(imagegroup="a/b/c",solidwidth="1600/1600/1600",solidheight="900",fadetime=0.5,blok=true)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // Reference: LargeBackgroundPanel._ExecuteImage accepts exactly two
+    // horizontal tiles and calls _ResetPanel() on mismatch — the previous
+    // layer is cleared immediately instead of kept.
+    expect(renderer.gridBackgroundCalls).toEqual([]);
+    expect(renderer.gridBackgroundClearCalls).toEqual([
+      {
+        block: false,
+        fadeMs: 0,
+      },
+    ]);
+  });
+
   it("maps characteraction move with legacy slot aliases and block args", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 `largeimg` 命令（Web-only 兼容扩展）的行为缺陷，并使其对齐 largebg 家族参照系（共 7 项行为修复 + 3 项注释澄清）。依据是对明日方舟官服客户端（2.7.61 / build 2761，Unity IL2CPP）GameAssembly.dll 的 IDA 反编译复核，关键结论已在下文直接给出，不依赖外部文档。

## 背景：native 无 largeimg 命令（2.7.61 逆向复核结论）

`largeimg` 在官服客户端 2.7.61（build 2761）中**不是一条真实命令**，前端实现是 Web-only 兼容扩展（供二创/旧版残留脚本使用）：

- 全字符串缓存搜索 `largeimg`（覆盖 `largeimgtween` 等一切前缀变体）**0 命中**；正向对照 `largebg`/`largebgtween`/`image`/`imagetween`/`imagerotate` 均为明文命中，证明搜索方法有效。
- `LargeBackgroundPanel.GetExecutors`（VA `0x183e758e0`）完整反编译：仅注册 `largebg`/`largebgtween`/`verticalbg`/`gridbg` 四个 key，无第五个。
- `AVGImagePanel.GetExecutors`（VA `0x183e56250`）完整反编译：仅注册 `image`/`imagetween`/`imagerotate` 三个 key，无第四个。
- 全库无任何 `*LargeImage*`/`*LargeImg*` 的 AVG 类型（仅干员图鉴/枪械/活动 logo 等无关命中）。
- 官服真实剧情脚本语料 `grep -ri largeimg` **0 命中**。

因此本 PR 的参照系不是"native largeimg 语义"（不存在），而是前端参数集的来源 **`LargeBackgroundPanel._ExecuteImage`**（largebg 的 executor，VA `0x183e77ee0`）：拼图参数（`imagegroup` 严格 2 图、`solidwidth`×2、`solidheight`×1）、`fadetime` 字面秒数默认 0（bypass animateRatio）、`fadetime<=0` 强制不阻塞、加载/解析失败 `LogError` + `_ResetPanel()` 清面板、`localScale=(xScale,yScale,1)` 负值镜像直接生效。资源域取 `avg/images/`（image 域）是 web 扩展自定。

## 修复内容

### 1. `xscale`/`yscale` 参数整体失效（P1）

- **原行为**：runtime 正确读参并传入 `setLargeImage`，但渲染层 `PixiStoryRenderer.setLargeImage` 无条件 `root.scale.set(1.2)`，把 `buildGridBackgroundRoot` 刚按 `input.scaleX/scaleY` 设好的缩放覆盖掉——脚本写 `xscale=1.5` 显示仍是 1.2，且 `largeimgtween` 的 scale 基准恒为 1.2。
- **修复**：删除硬编码覆盖，缩放（含负值）直接来自命令参数。

### 2. 图块数量契约不一致（P2）

- **参照（largebg）**：`imagegroup.Split('/')` 严格 `Count==2`，≠2 报错清面板；渲染层 layout "large" 也只按 2 宽 1 高取 pivot。
- **原行为**：runtime 泛化为任意 `width_count × height_count === image_count`，3+ 图或 2 行时 pivot/高度错位。
- **修复**：runtime 收紧为严格两图横排契约（`solidwidth` 取前 2 段、`solidheight` 取前 1 段，与 largebg case 同构），超出的段忽略、不足则进入失败路径。

### 3. 失败路径不清面板（P2）

- **参照（largebg）**：任何校验/加载失败 → `LogError` + `_ResetPanel()`（面板清空）+ 非阻塞返回。
- **原行为**：runtime 校验失败仅 warn 后 continue（旧画面保留）；渲染层纹理加载失败静默 return（旧画面保留）。
- **修复**：runtime 校验失败（空 imagegroup / 契约不匹配）warn 后调用 `clearLargeImage(0)` 立即清层；渲染层任一子图加载失败时经 `onWarning` 报告 all-or-nothing 决策并 `clearLargeImage(0)` 复刻 `_ResetPanel`。

### 4. 注释把 native `image` 误标为 closest equivalent（P2）

- **原行为**：runtime 注释称 "native `image` is its closest equivalent"，但 native `image` 是单图命令，无任何拼图参数，下游读者会误按 image 命令对齐。
- **修复**：注释改为指向 `LargeBackgroundPanel._ExecuteImage`（largebg）为语义参照，仅资源域跟随 `AVGImagePanel`；渲染层 jsdoc 同步补充参照系说明。

### 5. `fadetime` 默认值偏离参照（P2）

- **参照（largebg 家族）**：默认 0.0（省略 → 立即显示）。
- **原行为**：有图时默认 0.15（150ms 淡入），web 扩展自定。
- **修复**：显示分支默认改为 0（清屏分支原本就是 0），对齐参照系。

### 6. 负缩放被 clamp（P3，随 #1）

- **参照**：`localScale` 允许负值（镜像翻转）。
- **原行为**：`Math.max(0, xscale)` clamp 到 0（且被 #1 覆盖后不可见）。
- **修复**：随 #1 一并放开，负值原样透传。

### 7. `block` 未按 fade 归一（P3）

- **参照**：`fadetime<=0` 显式强制 `block=false`；前端 largebg/gridbg/verticalbg 均写 `fadeMs > 0 && block`。
- **原行为**：直接透传（`fadeMs=0` 时实际等效，但语义有歧义）。
- **修复**：对齐家族写法 `fadeMs > 0 && toBoolean(...)`。

### 注释澄清（不改变行为）

- `initposmode` 有意不读取（web 扩展无脚本语料需要 largebg 的 initOffset 定位）。
- `blok`/`isblock` 别名回退与大小写不敏感键是面向二创脚本的 web 容错（native 家族只读精确键）。
- 旧画面保留至新图淡入完成（近似交叉淡入）是 web 扩展视觉选择，与参照的 `_ResetImages()` 立即清空不同。

## 验证用剧情文件

官服剧情语料（`torappu/storage/asset/gamedata/latest/story`，覆盖 activities/obt/main/obt/memory/obt/guide 等）`grep -ri largeimg` **0 使用**——largeimg 非官服命令，无生产样本可回归，全部行为由单测锁定：

- `tests/runtime.spec.ts`
  - `passes largeimg scales through verbatim, including negative mirrors`（#1/#6 + CamelCase 键命中）
  - `defaults largeimg fadetime to zero and normalizes block`（#5/#10）
  - `resets the large image layer when largeimg breaks the two-tile contract`（#2/#3 runtime 侧）
  - 既有 `maps largeimg into a legacy large tiled image layer` / `clears largeimg with fade parameters when no image group is provided` 回归通过
- `tests/renderer.spec.ts`
  - `applies largeimg input scale instead of the legacy 1.2 override`（#1 渲染层）
  - `resets the large image layer when a largeimg tile fails to load`（#3 渲染层）
- `tests/preload.spec.ts` 既有 `preloads largeimg imagegroup tiles as image assets` 回归通过（预载逻辑未动）

## 测试

- `pnpm test`：20 个文件 227 个用例全部通过（基线 222 + 新增 5）。
- `pnpm exec vue-tsc -b`：通过。
- `pnpm exec eslint`（改动文件）：通过。
