### PR TITLE
fix(story-player): showitem 单槽替换链与失败路径对齐 native

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -219,6 +219,11 @@ export class PixiStoryRenderer implements StoryRenderer {
   private imageSprite: Sprite | null = null;
   private imageRotateSessionId = 0;
   private readonly itemLayer = this.layers.items;
+  // Handle on the single show-item slot root, the PIXI stand-in for
+  // `Torappu.AVG.AVGShowItemPanel._slotInUse`. Only this root is swapped by
+  // showItem(); `animtext` shares `itemLayer` but is a separate native panel,
+  // so it must never be dragged along with item swaps.
+  private showItemRoot: Container | null = null;
   private readonly onWarning?: (detail: string) => void;
   private readonly sceneLayer = this.layers.scene;
   private readonly uiLayer = this.layers.ui;
@@ -399,6 +404,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.imageSprite = null;
     this.imageLayer.removeChildren();
     this.itemLayer.removeChildren();
+    this.showItemRoot = null;
     for (const state of this.cutinStates.values()) state.sprite.destroy();
     this.cutinStates.clear();
     this.cutinStoredPositions.clear();
@@ -1113,82 +1119,119 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   /**
-   * Port scope: `Torappu.AVG.AVGShowItemPanel._ExecuteShowItem` / `_ShowItem`.
-   * It retains the single-slot replacement and photo fade; PIXI drawing is an
+   * Port scope: `Torappu.AVG.AVGShowItemPanel._ExecuteShowItem` / `_ShowItem`
+   * (2.7.61 VAs 0x183E5BE10 / 0x183E5C290). Native owns a single slot
+   * (`_slotInUse`): while a slot is on stage the executor hands the NEW
+   * command to the old slot's `Hide` (vtable slot 5), so the old picture
+   * fades out with the NEW command's fadetime, then the `b__0` closure
+   * (`_Reset` + `_ShowItem`, 0x183E62FB0) destroys the slot before the next
+   * picture fades in — both stages block the executor. PIXI drawing is an
    * approximation of the serialized show-item prefab.
    */
   async showItem(input: ShowItemInput): Promise<void> {
-    const texture = await this.textureForImageKey(input.key, "image");
-    if (!texture) return;
+    const chain = async (): Promise<void> => {
+      // Replacement branch of `_ExecuteShowItem`: fade the previous slot out
+      // with the new command's fadetime, then detach it (`_Reset`). A root
+      // already detached from the layer (hideitem / scene reset) mirrors a
+      // cleared `_slotInUse`, so it takes the direct-show branch instead.
+      const previousRoot = this.showItemRoot;
+      this.showItemRoot = null;
+      if (previousRoot?.parent) {
+        const startAlpha = previousRoot.alpha;
+        if (input.fadeMs <= 0) {
+          previousRoot.removeFromParent();
+        } else {
+          await this.tween(
+            input.fadeMs,
+            (progress) => {
+              previousRoot.alpha = startAlpha * (1 - progress);
+            },
+            () => {
+              previousRoot.removeFromParent();
+            },
+          );
+        }
+      }
 
-    // `AVGShowItemPanel._ExecuteShowItem` owns one slot, so a second showitem
-    // replaces the first rather than stacking on it. See the command evidence
-    // above; PIXI children are only the storage adaptation.
-    this.itemLayer.removeChildren();
+      const texture = await this.textureForImageKey(input.key, "image");
+      // `AVGShowItemSlot.Show` (0x183ED3E80) skips only the sprite assignment
+      // when the asset fails to load; the photo slot still plays its fade and
+      // blocks for fadetime. Keep a backdrop-only root instead of bailing out.
+      const sprite = texture ? new Sprite(texture) : null;
+      const layout = texture
+        ? computeLegacyShowItemLayout(texture.width, texture.height)
+        : null;
 
-    const sprite = new Sprite(texture);
-    sprite.anchor.set(0.5);
+      const root = new Container();
+      root.alpha = input.fadeMs > 0 ? 0 : 1;
+      if (input.blackAlpha > 0) {
+        const backdrop = new Graphics();
+        backdrop.rect(0, 0, STORY_WIDTH, STORY_HEIGHT);
+        backdrop.fill({ alpha: input.blackAlpha, color: 0x00_00_00 });
+        root.addChild(backdrop);
+      }
 
-    const layout = computeLegacyShowItemLayout(texture.width, texture.height);
-    sprite.scale.set(layout.scale);
+      if (sprite && layout) {
+        sprite.anchor.set(0.5);
+        sprite.scale.set(layout.scale);
 
-    const border = new Graphics();
-    border.rect(
-      -layout.contentWidth / 2 - layout.borderPx,
-      -layout.contentHeight / 2 - layout.borderPx,
-      layout.contentWidth + layout.borderPx * 2,
-      layout.borderPx,
-    );
-    border.fill(0xff_ff_ff);
-    border.rect(
-      -layout.contentWidth / 2 - layout.borderPx,
-      layout.contentHeight / 2,
-      layout.contentWidth + layout.borderPx * 2,
-      layout.borderPx,
-    );
-    border.fill(0xff_ff_ff);
-    border.rect(
-      -layout.contentWidth / 2 - layout.borderPx,
-      -layout.contentHeight / 2,
-      layout.borderPx,
-      layout.contentHeight,
-    );
-    border.fill(0xff_ff_ff);
-    border.rect(
-      layout.contentWidth / 2,
-      -layout.contentHeight / 2,
-      layout.borderPx,
-      layout.contentHeight,
-    );
-    border.fill(0xff_ff_ff);
+        const border = new Graphics();
+        border.rect(
+          -layout.contentWidth / 2 - layout.borderPx,
+          -layout.contentHeight / 2 - layout.borderPx,
+          layout.contentWidth + layout.borderPx * 2,
+          layout.borderPx,
+        );
+        border.fill(0xff_ff_ff);
+        border.rect(
+          -layout.contentWidth / 2 - layout.borderPx,
+          layout.contentHeight / 2,
+          layout.contentWidth + layout.borderPx * 2,
+          layout.borderPx,
+        );
+        border.fill(0xff_ff_ff);
+        border.rect(
+          -layout.contentWidth / 2 - layout.borderPx,
+          -layout.contentHeight / 2,
+          layout.borderPx,
+          layout.contentHeight,
+        );
+        border.fill(0xff_ff_ff);
+        border.rect(
+          layout.contentWidth / 2,
+          -layout.contentHeight / 2,
+          layout.borderPx,
+          layout.contentHeight,
+        );
+        border.fill(0xff_ff_ff);
 
-    const root = new Container();
-    root.alpha = input.fadeMs > 0 ? 0 : 1;
-    if (input.blackAlpha > 0) {
-      const backdrop = new Graphics();
-      backdrop.rect(0, 0, STORY_WIDTH, STORY_HEIGHT);
-      backdrop.fill({ alpha: input.blackAlpha, color: 0x00_00_00 });
-      root.addChild(backdrop);
-    }
+        const content = new Container();
+        content.position.set(
+          STORY_WIDTH / 2 + input.offsetX,
+          STORY_HEIGHT / 2 + input.offsetY,
+        );
+        content.addChild(border);
+        content.addChild(sprite);
+        root.addChild(content);
+      }
 
-    const content = new Container();
-    content.position.set(
-      STORY_WIDTH / 2 + input.offsetX,
-      STORY_HEIGHT / 2 + input.offsetY,
-    );
-    content.addChild(border);
-    content.addChild(sprite);
-    root.addChild(content);
-    this.itemLayer.addChild(root);
+      // Only the tracked slot root is added here: `animtext` renders into the
+      // same layer but is an independent native panel (`AnimTextPanel`), so it
+      // must survive item swaps instead of being swept by removeChildren().
+      this.showItemRoot = root;
+      this.itemLayer.addChild(root);
 
-    if (input.fadeMs <= 0) return;
+      if (input.fadeMs <= 0) return;
 
-    const run = this.tween(input.fadeMs, (progress) => {
-      root.alpha = progress;
-    });
+      const run = this.tween(input.fadeMs, (progress) => {
+        root.alpha = progress;
+      });
 
-    if (input.block) await run;
-    else void run;
+      await run;
+    };
+
+    if (input.block) await chain();
+    else void chain();
   }
 
   async showCgItem(input: CgItemInput): Promise<void> {

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1314,6 +1314,11 @@ export class StoryRuntime {
           return "continue";
         }
         if (style === "cutin")
+          // Native runs `AVGShowItemCutinSlot.Show` (0x183ED2CB0): the mask
+          // expands to `width` (default = the sprite's native width) per
+          // `fadestyle` while the backdrop cross-fades. The cutin animation is
+          // NOT ported — the web port downgrades to the photo alpha fade, so
+          // keep the warning visible instead of pretending parity.
           this.warn(
             "unsupported_visual",
             "showitem style=cutin uses the cutin slot expand animation",
@@ -1321,8 +1326,20 @@ export class StoryRuntime {
             line.command,
           );
 
+        // Native `_ShowItem` (0x183E5C290) never guards an empty `image`
+        // (default ""): it still instantiates the slot and plays the
+        // backdrop-only fade. Every shipped sample fills `image`, so the web
+        // port warns and skips instead of reproducing the empty-slot fade.
         const image = toString(this.exactArg(args, "image"));
-        if (!image) return "continue";
+        if (!image) {
+          this.warn(
+            "invalid_parameter",
+            "showitem: image is empty",
+            line.lineNumber,
+            line.command,
+          );
+          return "continue";
+        }
 
         const resolved = this.resolveImageKey(image);
         if (!resolved) {
@@ -1336,6 +1353,8 @@ export class StoryRuntime {
         // slot's serialized defaults are _defaultFadeTime 0.5 and
         // _defaultBlackAlpha 0.4; offsetx/offsety default to a hardcoded 0.
         await this.renderer.showItem({
+          // The clamp is a web-only guard; native `GetFloat("black", 0.4)`
+          // applies no range constraint.
           blackAlpha: clamp(toNumber(this.exactArg(args, "black"), 0.4), 0, 1),
           block: true,
           fadeMs: Math.max(

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -4,7 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import { PixiStoryRenderer } from "../src/widgets/StoryPlayer/engine/renderer";
 
 import type { Context } from "../src/widgets/StoryPlayer/context";
-import type { GridBackgroundInput } from "../src/widgets/StoryPlayer/engine/types";
+import type {
+  GridBackgroundInput,
+  ShowItemInput,
+} from "../src/widgets/StoryPlayer/engine/types";
 
 function createContext(): Context {
   return {
@@ -51,6 +54,50 @@ function createCharacterRenderer(): any {
   renderer.tween = vi.fn(async () => {});
   return renderer;
 }
+
+function createShowItemInput(
+  overrides: Partial<ShowItemInput> = {},
+): ShowItemInput {
+  return {
+    blackAlpha: 0.4,
+    block: true,
+    fadeMs: 500,
+    key: "item_a",
+    offsetX: 0,
+    offsetY: 0,
+    ...overrides,
+  };
+}
+
+interface ManualTween {
+  complete: () => void;
+  durationMs: number;
+  step: (progress: number) => void;
+}
+
+function createManualTweens(): {
+  tween: ReturnType<typeof vi.fn>;
+  tweens: ManualTween[];
+} {
+  const tweens: ManualTween[] = [];
+  const tween = vi.fn(
+    (durationMs: number, step: (progress: number) => void, done?: () => void) =>
+      new Promise<void>((resolve) => {
+        tweens.push({
+          complete: () => {
+            step(1);
+            done?.();
+            resolve();
+          },
+          durationMs,
+          step,
+        });
+      }),
+  );
+  return { tween, tweens };
+}
+
+const flushAsync = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 describe("PixiStoryRenderer", () => {
   it("dims unfocused characters with tint without making them transparent", () => {
@@ -602,5 +649,103 @@ describe("PixiStoryRenderer", () => {
 
     expect(root.position.x - 640).toBe(-160);
     expect(360 - root.position.y).toBe(0);
+  });
+
+  it("replaces the item slot by fading the old root out with the new command's fadetime", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const { tween, tweens } = createManualTweens();
+    renderer.tween = tween;
+    renderer.textureForImageKey = vi.fn(
+      async () => new Texture({ label: "item" }),
+    );
+
+    // Direct-show branch (`_slotInUse == null`): only the fade-in plays.
+    const firstCall = renderer.showItem(createShowItemInput());
+    await flushAsync();
+    expect(tweens.map((entry) => entry.durationMs)).toEqual([500]);
+    tweens[0].complete();
+    await firstCall;
+    const firstRoot = renderer.itemLayer.children[0];
+    expect(firstRoot.alpha).toBe(1);
+
+    // Replacement branch: the old root fades out with the NEW command's
+    // fadetime first, then the new picture fades in (both stages block).
+    const secondCall = renderer.showItem(
+      createShowItemInput({ fadeMs: 300, key: "item_b" }),
+    );
+    await flushAsync();
+    expect(tweens.map((entry) => entry.durationMs)).toEqual([500, 300]);
+    tweens[1].step(0.5);
+    expect(firstRoot.alpha).toBeCloseTo(0.5);
+    tweens[1].complete();
+    await flushAsync();
+    expect(firstRoot.parent).toBeNull();
+    expect(tweens.map((entry) => entry.durationMs)).toEqual([500, 300, 300]);
+    tweens[2].complete();
+    await secondCall;
+    expect(renderer.itemLayer.children).toHaveLength(1);
+    expect(renderer.itemLayer.children[0]).not.toBe(firstRoot);
+  });
+
+  it("takes the direct-show branch once the previous root left the layer", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const { tween, tweens } = createManualTweens();
+    renderer.tween = tween;
+    renderer.textureForImageKey = vi.fn(
+      async () => new Texture({ label: "item" }),
+    );
+
+    const firstCall = renderer.showItem(createShowItemInput());
+    await flushAsync();
+    tweens[0].complete();
+    await firstCall;
+    // hideitem / scene reset already detached the root: `_slotInUse` is
+    // effectively cleared, so no fade-out stage may run.
+    renderer.itemLayer.children[0].removeFromParent();
+
+    const secondCall = renderer.showItem(
+      createShowItemInput({ fadeMs: 300, key: "item_b" }),
+    );
+    await flushAsync();
+    expect(tweens.map((entry) => entry.durationMs)).toEqual([500, 300]);
+    tweens[1].complete();
+    await secondCall;
+    expect(renderer.itemLayer.children).toHaveLength(1);
+  });
+
+  it("keeps an animtext root on the shared item layer when swapping items", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.textureForImageKey = vi.fn(
+      async () => new Texture({ label: "item" }),
+    );
+    // animtext renders into the same layer but is a separate native panel;
+    // swapping the show-item slot must not sweep it away.
+    const animTextRoot = new Container();
+    renderer.itemLayer.addChild(animTextRoot);
+
+    await renderer.showItem(createShowItemInput({ fadeMs: 0 }));
+    await renderer.showItem(createShowItemInput({ fadeMs: 0, key: "item_b" }));
+
+    expect(animTextRoot.parent).toBe(renderer.itemLayer);
+    expect(renderer.itemLayer.children).toHaveLength(2);
+  });
+
+  it("plays the backdrop-only fade when the item texture fails to load", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const { tween, tweens } = createManualTweens();
+    renderer.tween = tween;
+    renderer.textureForImageKey = vi.fn(async () => null);
+
+    // `AVGShowItemSlot.Show` skips only the sprite assignment on a failed
+    // load; the slot still fades in and blocks for fadetime.
+    const call = renderer.showItem(createShowItemInput());
+    await flushAsync();
+    expect(renderer.itemLayer.children).toHaveLength(1);
+    const root = renderer.itemLayer.children[0];
+    expect(root.children).toHaveLength(1);
+    expect(tweens.map((entry) => entry.durationMs)).toEqual([500]);
+    tweens[0].complete();
+    await call;
+    expect(root.alpha).toBe(1);
   });
 });

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -764,6 +764,31 @@ describe("StoryRuntime", () => {
     ]);
   });
 
+  it("warns and skips a showitem without an image", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext(['[showitem(style="photo")]', '[name="A"]ok']),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    // Native `_ShowItem` has no empty-image guard (it would still fade in a
+    // backdrop-only slot); every shipped sample fills `image`, so the web port
+    // warns and skips instead of reproducing the empty-slot fade.
+    expect(renderer.showItemCalls).toEqual([]);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        command: "showitem",
+        detail: "showitem: image is empty",
+        type: "invalid_parameter",
+      }),
+    ]);
+  });
+
   it("treats a bracketed key=value tag as an empty dialog line", async () => {
     const renderer = new FakeRenderer();
     const warnings: RuntimeWarning[] = [];


### PR DESCRIPTION
# fix(story-player): showitem 单槽替换链与失败路径对齐 native

本 PR 修复 StoryPlayer 对 AVG `showitem` 命令移植中的行为差异（P1×1 + P2×3，另补 2 处 provenance 注释）。依据是对明日方舟官服客户端（2.7.61 / build 2761，Unity IL2CPP）GameAssembly.dll 的 IDA 反编译复核，关键结论如下，自包含不依赖外部文档。

## 背景：native 的 showitem 机制（2.7.61 逆向结论）

- `Torappu.AVG.AVGShowItemPanel._ExecuteShowItem` @ `0x183E5BE10`：单 slot（`_slotInUse`）模型。无活动 slot 走直显分支（`_ShowItem`）；**有活动 slot 走替换分支**：把 `_Reset + _ShowItem` 闭包（`<_ExecuteShowItem>b__0` @ `0x183E62FB0`）作为 onFinish 传给**旧 slot 的 `Hide(新 command, onFinish)`**，即旧图按**新 command 的 `fadetime`** 淡出 → `_Reset` @ `0x183E5C1B0` 销毁旧 slot → 新图淡入。两条分支都硬编码阻塞（executor 不读 `block`），替换时阻塞时长 = 旧淡出 + 新淡入之和。
- `_ShowItem` @ `0x183E5C290`：`style` 默认 `photo`，`_slotStyles` 场景只注册 photo/cutin，未注册 style → LogError（`[AVG] Can not find show item style "<style>"`）+ `FinishCommand` 放行、不渲染。`image` 默认空串且**无判空**——空 image 仍实例化 slot、跳过贴图、播黑底淡入并阻塞。
- `AVGShowItemSlot.Show`（基类）@ `0x183ED3E80`：资产加载失败 sprite 为 null 时**只跳过贴图赋值**，仍存回调并继续子类动画 → `OnAnimEnd` → `FinishCommand`（阻塞 fadetime），即失败路径照播"黑底淡入"。
- `AVGShowItemPhotoSlot.Show` @ `0x183ED3790`：读 `fadetime`（序列化默认 0.5）/`offsetx`/`offsety`（硬编码默认 0）/`black`（序列化默认 0.4，无范围约束），canvasGroup alpha 0→1 线性淡入（SetIgnoreTimeScale）。
- `AVGShowItemCutinSlot.Show` @ `0x183ED2CB0`：mask 按 `fadestyle` 展开（`width` 默认 = SetNativeSize 后的图片原生宽）+ 黑底 DOFade。
- `AVGShowItemPanel` 与 animtext 是**相互独立的 native panel**，showitem 不影响 animtext。

## 修复内容

### 1. 单槽替换路径无旧图淡出（P1，review 差异 #1）

- **native 行为**：`_slotInUse != null` 时旧图按新 command 的 `fadetime` 淡出 → 销毁 → 新图淡入，两段串行阻塞。
- **前端原行为**：`PixiStoryRenderer.showItem()` 直接 `itemLayer.removeChildren()` 立即移除旧图，只播新图淡入（原注释声称保留了替换链，不实）。
- **修复**：`showItem()` 用 `showItemRoot`（`_slotInUse` 的 PIXI 句柄）跟踪当前槽位 root；替换时先对旧 root 播 `alpha→0`（时长 = **新** command 的 fadeMs，起始 alpha 等比），完成后移除，再加载纹理、新 root 淡入，整条链 `block` 时全程 await。旧 root 已不在层上（hideitem / 场景 reset 清场）时跳过淡出段，对齐 native 已清空的 `_slotInUse` 直显分支。

### 2. `image` 缺失时静默跳过（P2，review 差异 #2）

- **native 行为**：`image=""` 无判空，仍播空槽黑底淡入并阻塞；真实样本 image 100% 必填。
- **前端原行为**：静默 `return "continue"`，无 warn。
- **修复**：补 `warn("invalid_parameter", "showitem: image is empty")`。不复刻空槽淡入动画（成本取舍，生产语料 0 命中），注释写明取舍。

### 3. 资产加载失败不播空槽动画（P2，review 差异 #3）

- **native 行为**：`LoadAsset` 失败 → sprite null → 基类 Show 只跳过贴图，子类照常播黑底淡入 → 阻塞 fadetime。
- **前端原行为**：renderer 纹理加载失败直接 return，不播任何动画（warn 仍由 `textureForImageKey` 发出）。
- **修复**：纹理为 null 时仍建 backdrop-only root（无 sprite/边框）并播淡入、阻塞，对齐基类 Show 语义。

### 4. 与 animtext 共用渲染层（P2，review 差异 #5）

- **native 行为**：`AVGShowItemPanel` 与 animtext 是独立 panel，showitem 不影响 animtext。
- **前端原行为**：`AnimTextPanel` 与 item 共用 `itemLayer`，`showItem` 的 `removeChildren()` 会连带移除正在显示的 animtext。
- **修复**：`showItem` 不再整层 `removeChildren()`，只操作 `showItemRoot` 跟踪的单个槽位 root；animtext root 不受槽位替换影响。

### 5. 注释补全（review 差异 #4/#6，顺手项）

- cutin 分支注释明确"cutin slot 的 mask 展开动画（`AVGShowItemCutinSlot.Show` @ `0x183ED2CB0`）未移植，web 降级为 photo alpha 淡入"，不再沿用 photo 注释（实际降级行为不变）。
- `black` 的 `clamp(0,1)` 注明为 web 防御，native `GetFloat("black", 0.4)` 无范围约束。

未改动项：#7（offset 作用域近似）、#8（LEGACY 布局视觉近似）、#9（未注册 style 的日志文案）按 review 结论维持现状。

## 验证用剧情文件

生产剧情语料位于本地 `torappu/storage/asset/gamedata/latest/story`：

- **修复 1（替换链）**：`activities/act4fun/level_act4fun_07_end.txt` 171-193 行 —— 12 条连续 `ShowItem`（`item_36_eu2/eu4/eu5/eu2/eu6/eu7/eu3/eu2/eu4/eu2/eu6/eu3`，fadetime 0.1~0.3）中间无 `hideitem`，每个相邻对都触发单槽替换：旧图按新 fadetime 淡出 → 新图淡入（修复前旧图瞬间消失）。
- **修复 1（hideitem 清场后的直显分支回归）**：`obt/roguelike/ro5/level_rogue5_ending_5.txt` 59-67 行 —— `ShowItem(item_rogue5_2, fadetime=1)` → `hideitem` → `ShowItem(item_rogue5_1, fadetime=0.7)` → `hideitem`，第 65 行应走直显分支（无旧图淡出段，总时长 = 0.7s 淡入）。
- **修复 2（空 image warn）**：语料 0 命中（生产数据 `image` 100% 必填），前瞻对齐，由单测锁定：`tests/runtime.spec.ts` `warns and skips a showitem without an image`。
- **修复 3（失败空槽淡入）**：语料 0 命中（PRTS 镜像资源完整时无失败样本），前瞻对齐，由单测锁定：`tests/renderer.spec.ts` `plays the backdrop-only fade when the item texture fails to load`。
- **修复 4（animtext 保护）**：生产语料中 animtext 与 showitem 无同框样本（`activities/act49side/level_act49side_01_end.txt` / `level_act49side_st01.txt` 两命令均间隔百行以上），前瞻对齐，由单测锁定：`tests/renderer.spec.ts` `keeps an animtext root on the shared item layer when swapping items`；替换链本体另由 `replaces the item slot by fading the old root out with the new command's fadetime` / `takes the direct-show branch once the previous root left the layer` 锁定。

## 测试

- `pnpm test`：20 个文件 **227 用例全部通过**（基线 222 + 本 PR 新增 5）。
- `pnpm exec vue-tsc -b` 通过。
- `pnpm exec eslint`（全部改动文件）通过。
