### PR TITLE
fix(story-player): hidecgitem 淡出对齐 native InSine 缓动与淡出期间持续驱动

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1198,7 +1198,7 @@ export class PixiStoryRenderer implements StoryRenderer {
   async clearCgItems(
     key?: string,
     fadeMs = 130,
-    ease = "Linear",
+    ease = "InSine",
     block = false,
   ): Promise<void> {
     await this.cgItemPanel.hide(key, fadeMs, ease, block);

--- a/src/widgets/StoryPlayer/engine/rendering/panels/CgItemPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/CgItemPanel.ts
@@ -31,12 +31,18 @@ function easeProgress(raw: number, ease: string): number {
     case "inoutquad": {
       return raw < 0.5 ? 2 * raw * raw : 1 - (-2 * raw + 2) ** 2 / 2;
     }
+    case "insine": {
+      return 1 - Math.cos((raw * Math.PI) / 2);
+    }
     case "outquad": {
       return 1 - (1 - raw) * (1 - raw);
     }
     // `AVGShowItemCgSlot.Show` / `.Hide` read the curve with
-    // `GetEnum<Ease>(param, "ease", Ease.Linear, ignoreCase: false)`, which
-    // also returns that fallback for any name it cannot parse.
+    // `GetEnum<Ease>(param, "ease", (Ease)1, ignoreCase: false)`: the default
+    // is DOTween `Ease` enum value 1 = InSine (`Ease.Linear` is 0), and the
+    // parser returns that same default for any name it cannot resolve. The
+    // Web port maps only corpus-attested names and keeps a linear fallback
+    // for the rest (hidecgitem lines never write `ease` explicitly).
     default: {
       return raw;
     }
@@ -203,8 +209,20 @@ export class CgItemPanel {
     if (this.states.size === 0) return;
     if (key) {
       const state = this.states.get(key);
+      // Native divergence: with `block=true` and a missing key the native
+      // executor returns true while nobody ever calls `FinishCommand`
+      // (`_ClearItemByKey` returns silently), so the panel stays suspended
+      // until skip/`ForceCommandEnd` rescues it -- a native defect, not
+      // behaviour worth reproducing. The Web port releases immediately.
       if (!state) return;
-      const sessionId = ++state.sessionId;
+      // Native provenance: the hide path performs no DOKill -- base
+      // `AVGShowItemSlot.Hide` (0x183ed3cf0) only stores the callback -- so
+      // the show-side sequence keeps driving position/scale while the fade
+      // runs and until the completing `Dispose` destroys the slot. Do NOT
+      // bump `sessionId` here (that would freeze those writes); only snapshot
+      // it so the completion callback stays inert when a newer `show` has
+      // replaced the slot mid-fade (replacement bumps the id in `dispose`).
+      const sessionAtHide = state.sessionId;
       const startAlpha = state.root.alpha;
       const task = this.tween(
         fadeMs,
@@ -212,7 +230,7 @@ export class CgItemPanel {
           state.root.alpha = lerp(startAlpha, 0, easeProgress(raw, ease));
         },
         () => {
-          if (state.sessionId === sessionId) this.dispose(key);
+          if (state.sessionId === sessionAtHide) this.dispose(key);
         },
       );
       if (block) await task;
@@ -229,7 +247,13 @@ export class CgItemPanel {
         (raw) => {
           state.root.alpha = lerp(startAlpha, 0, easeProgress(raw, ease));
         },
-        () => state.root.destroy({ children: true }),
+        () => {
+          // During the fade show-side writes keep running (native drives the
+          // slots until `Dispose`); once the fade completes, bump the session
+          // to stop writes into the destroyed sprite.
+          state.sessionId += 1;
+          state.root.destroy({ children: true });
+        },
       );
     }
     // `_ExecuteHideCgItem` completes clear-all immediately even if `block=true`.

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1441,8 +1441,11 @@ export class StoryRuntime {
             0,
             Math.round(toNumber(this.exactArg(args, "fadetime"), 0.13) * 1000),
           ),
-          // `AVGShowItemCgSlot.Hide` uses the same `Ease.Linear` fallback.
-          toString(this.exactArg(args, "ease"), "Linear"),
+          // `AVGShowItemCgSlot.Hide` (0x183ed14a0) reads the curve with
+          // `GetEnum<Ease>(param, "ease", (Ease)1, ignoreCase: false)`: the
+          // default is DOTween `Ease` enum value 1 = InSine (`1-cos(t*pi/2)`,
+          // `Ease.Linear` is 0). All 140 corpus hidecgitem lines omit `ease`.
+          toString(this.exactArg(args, "ease"), "InSine"),
           toBoolean(this.exactArg(args, "block"), false),
         );
         return "continue";

--- a/tests/cgItemPanel.spec.ts
+++ b/tests/cgItemPanel.spec.ts
@@ -1,4 +1,4 @@
-import { Container, Texture } from "pixi.js";
+import { Container, type Sprite, Texture } from "pixi.js";
 import { describe, expect, it } from "vitest";
 
 import { CgItemPanel } from "../src/widgets/StoryPlayer/engine/rendering/panels/CgItemPanel";
@@ -37,6 +37,28 @@ async function tweenImmediately(
 ): Promise<void> {
   update(1);
   complete?.();
+}
+
+// Manual tween driver: index-ordered steps advanced by the test.
+function manualTween() {
+  const steps: Array<{
+    complete: () => void;
+    resolve: () => void;
+    update: (progress: number) => void;
+  }> = [];
+  const tween = (
+    _durationMs: number,
+    update: (progress: number) => void,
+    complete?: () => void,
+  ): Promise<void> =>
+    new Promise((resolve) => {
+      steps.push({
+        complete: complete ?? ((): void => {}),
+        resolve,
+        update,
+      });
+    });
+  return { steps, tween };
 }
 
 describe("CgItemPanel", () => {
@@ -81,5 +103,95 @@ describe("CgItemPanel", () => {
     await panel.hide(undefined, 130, "Linear", true);
     expect(panel.targets("")).toEqual([]);
     expect(layer.children).toHaveLength(0);
+  });
+
+  it("fades with the native InSine default curve, not linearly", async () => {
+    const layer = new Container();
+    const { steps, tween } = manualTween();
+    const panel = new CgItemPanel(layer, async () => Texture.WHITE, tween);
+    await panel.show(input("a"));
+    const root = panel.targets("a")[0];
+
+    void panel.hide("a", 500, "InSine", false);
+    // InSine(0.5) = 1 - cos(pi/4), so the remaining alpha is cos(pi/4).
+    steps[0].update(0.5);
+    expect(root.alpha).toBeCloseTo(Math.cos(Math.PI / 4), 5);
+    steps[0].update(1);
+    expect(root.alpha).toBeCloseTo(0, 5);
+  });
+
+  it("keeps driving the show tween while a single-key hide fades", async () => {
+    const layer = new Container();
+    const { steps, tween } = manualTween();
+    const panel = new CgItemPanel(layer, async () => Texture.WHITE, tween);
+    await panel.show(
+      input("a", {
+        positionFrom: { x: 0, y: 0 },
+        positionTo: { x: 100, y: 0 },
+        positionDurationMs: 1000,
+      }),
+    );
+    const sprite = panel.targets("a")[0].children[0] as Sprite;
+    steps[0].update(0.25);
+    expect(sprite.position.x).toBe(25);
+
+    // Native `AVGShowItemCgSlot.Hide` has no DOKill: the show sequence keeps
+    // driving the slot while the fade runs.
+    void panel.hide("a", 500, "Linear", false);
+    steps[0].update(0.5);
+    expect(sprite.position.x).toBe(50);
+
+    steps[1].update(1);
+    steps[1].complete();
+    expect(panel.targets("a")).toEqual([]);
+    // dispose() bumped the session: a late show-side tick must not touch the
+    // destroyed sprite (Pixi v8 nulls `position` on destroy, so a surviving
+    // write would throw).
+    expect(() => steps[0].update(0.75)).not.toThrow();
+  });
+
+  it("single-key hide does not dispose a slot replaced mid-fade", async () => {
+    const layer = new Container();
+    const { steps, tween } = manualTween();
+    const panel = new CgItemPanel(layer, async () => Texture.WHITE, tween);
+    await panel.show(input("a"));
+    const oldRoot = panel.targets("a")[0];
+
+    void panel.hide("a", 500, "Linear", false);
+    await panel.show(input("a"));
+    const newRoot = panel.targets("a")[0];
+    expect(newRoot).not.toBe(oldRoot);
+
+    steps[0].update(1);
+    steps[0].complete();
+    expect(panel.targets("a")).toEqual([newRoot]);
+    expect(layer.children).toContain(newRoot);
+  });
+
+  it("clear-all keeps driving during the fade and stops after destroy", async () => {
+    const layer = new Container();
+    const { steps, tween } = manualTween();
+    const panel = new CgItemPanel(layer, async () => Texture.WHITE, tween);
+    await panel.show(
+      input("a", {
+        positionFrom: { x: 0, y: 0 },
+        positionTo: { x: 100, y: 0 },
+        positionDurationMs: 1000,
+      }),
+    );
+    const sprite = panel.targets("a")[0].children[0] as Sprite;
+    steps[0].update(0.5);
+    expect(sprite.position.x).toBe(50);
+
+    await panel.hide(undefined, 500, "Linear", false);
+    steps[0].update(0.75);
+    // Native keeps driving the removed slots until Dispose destroys them.
+    expect(sprite.position.x).toBe(75);
+
+    steps[1].update(1);
+    steps[1].complete();
+    // The fade completion bumped the session: further show-side ticks must
+    // not touch the destroyed sprite (would throw on the nulled position).
+    expect(() => steps[0].update(1)).not.toThrow();
   });
 });

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2851,7 +2851,9 @@ describe("StoryRuntime", () => {
     expect(renderer.clearCgItemCalls).toEqual([
       {
         block: true,
-        ease: "Linear",
+        // `AVGShowItemCgSlot.Hide` defaults `ease` to DOTween `Ease` enum
+        // value 1 = InSine, and this line omits `ease`.
+        ease: "InSine",
         fadeMs: 130,
         key: "cgitem_test_left",
       },


### PR DESCRIPTION
## 背景

对 `hidecgitem` 命令做 native 对齐修复。以下逆向结论来自官服客户端 2.7.61（build 2761）GameAssembly.dll 的 IDA 反编译复核（image base `0x180000000`）：

- `Torappu.AVG.AVGCgItemPanel._ExecuteHideCgItem`（VA `0x183e351e0`）：slot 字典为空时直接 `return false`（在读取 `block` 之前，即便 `block=true` 也不阻塞）；key 为空 → `_ClearAllItems`（`0x183e34da0`：所有 slot 并行淡出、共用同一条命令的 `fadetime`/`ease`，循环后立即 `dict.Clear()` + 立即 `FinishCommand()`，`block=true` 也不等）；key 非空 → 内联 `_ClearItemByKey`（独立版 `0x183e35020`）：查不到 key 静默 no-op，命中则 `slot.Hide(command, onFinish)`，完成回调 `__c__DisplayClass15_0::b__0`（`0x183e62d70`）= 字典 Remove + `Dispose` + `FinishCommand`（阻塞在此刻才解除）。
- `Torappu.AVG.AVGShowItemCgSlot.Hide`（VA `0x183ed14a0`）：只读 `fadetime`（默认为 prefab 序列化值 0.13s）与 `ease`；`ease = GetEnum<Ease>(param, "ease", (Ease)1, ignoreCase: false)` —— 默认值是 DOTween `Ease` 枚举 **1 = InSine**（`1-cos(t·π/2)`），**不是** `Ease.Linear`（Linear = 0）。生产语料中 140 条 `hidecgitem` 全部不写 `ease`，即每条 hide 淡出的真实曲线都是 InSine。
- Hide 路径**没有任何 DOKill**：基类 `AVGShowItemSlot.Hide`（`0x183ed3cf0`）仅存回调；show 侧的位置/缩放 Sequence 在淡出期间继续驱动（CG 边动边淡），直到完成回调里 `SlotInUseItem.Dispose`（`0x183e477c0`）销毁 GameObject。
- `block=true` 且 key 查不到时，executor 返回 `true` 但无人调 `FinishCommand`，panel 会一直挂起直到 skip/`ForceCommandEnd`（`0x183e34820`）兜底 —— 这是 native 的缺陷，不是合理行为。

## 修复内容

对照 impl-review 差异清单，本 PR 处理以下条目：

| # | 严重度 | native 行为 | 前端原行为 | 改法 |
| --- | --- | --- | --- | --- |
| 1 | P1 | `ease` 默认 = `Ease` 枚举 1 = InSine（`1-cos(t·π/2)`）；140 条样本全部不写 ease | 默认 `"Linear"` 线性淡出；`easeProgress` 无 InSine 实现；注释把默认值误标为 `Ease.Linear` | `runtime.ts` hidecgitem 分支默认改 `"InSine"`；`CgItemPanel.easeProgress` 补 `insine` 分支；勘误原注释（`Ease.Linear` 是 0）；`PixiStoryRenderer.clearCgItems` 默认参数同步 |
| 2 | P2 | Hide 路径无 DOKill，淡出期间 show 侧 Sequence 继续驱动位置/缩放（长淡出如 `fadetime=3.5` 下与"原地冻结淡出"视觉可分辨） | 单张 hide `++state.sessionId` 冻结 show tween，CG 原地淡出 | 单张 hide 不再递增 `sessionId`，仅快照（`sessionAtHide`）用于完成回调防陈旧 dispose：淡出期间 show tween 继续写 sprite，完成回调在 sessionId 未变时才 `dispose`（若淡出中被同 key 新 show 替换，替换经 `dispose` 递增 id，旧回调自动失效） |
| 3 | P2 | `block=true` 且 key 查不到 → panel 挂起直到 skip/`ForceCommandEnd` | 立即放行 | 前端行为更合理，保留；在 `CgItemPanel.hide` 补注释标明 native 真实语义（挂起缺陷），避免后续"对齐"时误改 |
| 7 | P3 | 清全部后 show Sequence 继续驱动已从 dict 移除的对象直到 Destroy | `states.clear()` 后 show tween 回调继续写已 destroy 的 sprite（Pixi setter 无害，视觉等价） | 顺手项：clear-all 淡出完成回调里先递增 `sessionId` 再 destroy，停止对已销毁 sprite 的后续写入；淡出期间的写入保持运行（与 native 一致） |

**未修条目**（有意）：
- #4（P2）加载期竞态：与 cgitem 同根因（native dict 在 show 命令进入时已写入，前端 states 在纹理加载后才写入），由 cgitem 分支的 pending 注册方案统一处理。
- #5（P3）ease 名集合与大小写：hidecgitem 样本从不写 `ease`，无实际影响，维持现状（default 线性回落已在注释标明与 native 回落默认的差异）。
- #6（P3）per-story 重置入口：前端为单 story 生命周期模型，`renderer.destroy()` 已瞬清（对齐 `_Reset`），维持现状。

## 验证用剧情文件

语料库：`torappu` gamedata 2.7.61 story 目录。

- `obt/main/level_main_17-17_end.txt:34` — `[hidecgitem(fadetime=5)]`（无 key 清全部 + 5s 长淡出）：验证 #1 默认 InSine 曲线（先慢后快 vs 线性）在长淡出下的形状，以及 #7 clear-all 淡出期间继续驱动/完成后停写。
- `activities/act36side/level_act36side_02_end.txt:444` — `[hidecgitem(image="cgitem_54_i3",fadetime=3.5)]`：3.5s 长淡出单张，验证 #1。
- `activities/act47side/level_act47side_st01.txt:176-177` — cgitem（`pfrom="0,-10",pto="0,-600",pduration=0.5,block=true`）后紧跟 `[hidecgitem(image="cgitem_68_i01_2",block=true)]`：hide 淡出（默认 0.13s）期间 show 侧 0.5s 位移 tween 仍在跑，验证 #2（CG 淡出时继续向下移动而非冻结）；该文件 7 处 `block=true` 单张 hide 同时覆盖"block 等淡出完成"语义。
- `obt/main/level_main_17-01_beg.txt:166` — `[hidecgitem(image="cgitem_70_i02_3", fadetime=1.5)]`：单张中长淡出，验证 #1。
- #3 为纯注释（前端行为有意保留），由 `tests/cgItemPanel.spec.ts` 原有 "hides one key or clears all keys independently of block" 用例与代码注释锁定。

## 测试

- `pnpm test`：226 用例全部通过（基线 222 + 新增 4，见 `tests/cgItemPanel.spec.ts`：`fades with the native InSine default curve, not linearly` / `keeps driving the show tween while a single-key hide fades` / `single-key hide does not dispose a slot replaced mid-fade` / `clear-all keeps driving during the fade and stops after destroy`；另更新 `tests/runtime.spec.ts` 的默认 ease 断言）。
- `pnpm exec vue-tsc -b` 通过。
- `pnpm exec eslint`（改动文件）通过。
