### PR TITLE
fix(story-player): hideitem 结束/跳段清理道具槽并不波及同层 animtext

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -219,6 +219,14 @@ export class PixiStoryRenderer implements StoryRenderer {
   private imageSprite: Sprite | null = null;
   private imageRotateSessionId = 0;
   private readonly itemLayer = this.layers.items;
+  /**
+   * Native port: the renderer-side handle on `Torappu.AVG.AVGShowItemPanel`'s
+   * single `_slotInUse` gameObject. Keeping an explicit reference (instead of
+   * fading every child of itemLayer) matters because the web AnimTextPanel
+   * mounts its stamps on the same layer while native animtext is a separate
+   * panel that hideitem never touches.
+   */
+  private showItemRoot: Container | null = null;
   private readonly onWarning?: (detail: string) => void;
   private readonly sceneLayer = this.layers.scene;
   private readonly uiLayer = this.layers.ui;
@@ -399,6 +407,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.imageSprite = null;
     this.imageLayer.removeChildren();
     this.itemLayer.removeChildren();
+    this.showItemRoot = null;
     for (const state of this.cutinStates.values()) state.sprite.destroy();
     this.cutinStates.clear();
     this.cutinStoredPositions.clear();
@@ -1125,6 +1134,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     // replaces the first rather than stacking on it. See the command evidence
     // above; PIXI children are only the storage adaptation.
     this.itemLayer.removeChildren();
+    this.showItemRoot = null;
 
     const sprite = new Sprite(texture);
     sprite.anchor.set(0.5);
@@ -1180,6 +1190,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     content.addChild(sprite);
     root.addChild(content);
     this.itemLayer.addChild(root);
+    this.showItemRoot = root;
 
     if (input.fadeMs <= 0) return;
 
@@ -1204,30 +1215,44 @@ export class PixiStoryRenderer implements StoryRenderer {
     await this.cgItemPanel.hide(key, fadeMs, ease, block);
   }
 
-  async clearItems(fadeMs = 0, block = false): Promise<void> {
-    const roots = [...this.itemLayer.children];
-    if (roots.length === 0) return;
+  /**
+   * Port of `Torappu.AVG.AVGShowItemPanel._ExecuteHideItem` dispatching to the
+   * slot's `Hide` (GameAssembly 2.7.61: panel @ 0x183E5BCE0, photo slot
+   * `AVGShowItemPhotoSlot.Hide` @ 0x183ED35E0, cutin slot
+   * `AVGShowItemCutinSlot.Hide` @ 0x183ED2A60). Native photo Hide DOTween-fades
+   * the canvas group to 0 over `fadetime`; cutin Hide instead collapses the
+   * mask via DOSizeDelta plus a parallel black fade -- the web port approximates
+   * both with the shared alpha fade (no shipped sample uses cutin). Only the
+   * show-item root is touched: native animtext is a separate panel, and the
+   * stamps sharing this layer must survive a hideitem. Native photo Hide
+   * unconditionally resets alpha to 1 before fading; the web fade starts from
+   * the root's current alpha, which is equivalent whenever showitem's blocking
+   * fade-in finished first and only diverges if it was interrupted.
+   */
+  async clearItems(fadeMs = 0, hasSlot = false): Promise<void> {
+    const root = this.showItemRoot;
+    if (!root) return;
 
     if (fadeMs <= 0) {
-      for (const root of roots) root.removeFromParent();
+      root.removeFromParent();
+      this.showItemRoot = null;
       return;
     }
 
-    const startAlphas = roots.map((root) => root.alpha);
+    const startAlpha = root.alpha;
     const run = this.tween(
       fadeMs,
       (progress) => {
-        const nextAlpha = 1 - progress;
-        for (const [index, root] of roots.entries()) {
-          root.alpha = startAlphas[index]! * nextAlpha;
-        }
+        root.alpha = startAlpha * (1 - progress);
       },
       () => {
-        for (const root of roots) root.removeFromParent();
+        if (this.showItemRoot !== root) return;
+        root.removeFromParent();
+        this.showItemRoot = null;
       },
     );
 
-    if (block) await run;
+    if (hasSlot) await run;
     else void run;
   }
 

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -552,6 +552,9 @@ export class StoryRuntime {
         shouldResume = true;
       } else {
         this.cursor = this.lines.length;
+        // Skipping past the last anchor ends the story, and the native reset
+        // path tears a live show-item slot down on the way out.
+        this.resetItemSlot();
       }
     }
 
@@ -666,6 +669,22 @@ export class StoryRuntime {
     this.pendingInputEffect = null;
   }
 
+  /**
+   * Native port: `Torappu.AVG.AVGShowItemPanel.OnReset` → `_Reset`
+   * (GameAssembly 2.7.61 @ 0x183E5C1B0). Story end and reset both funnel
+   * through the native reset path: a live `_slotInUse` gameObject is
+   * destroyed without delay and the reference cleared, so the item image and
+   * its black backdrop never outlive the story. Native also runs this after a
+   * skip cut the story short, hence the skipNode call site.
+   */
+  private resetItemSlot(): void {
+    // Native `_Reset` only acts while `_slotInUse` is non-null; after a
+    // hideitem (or a first reset) the slot is already gone.
+    if (!this.itemSlotInUse) return;
+    this.itemSlotInUse = false;
+    void this.renderer.clearItems(0);
+  }
+
   private async processLoop(): Promise<void> {
     if (this.processing) return;
 
@@ -679,6 +698,9 @@ export class StoryRuntime {
         if (this.cursor >= this.lines.length) {
           this.renderer.clearAnimTexts();
           this.renderer.clearAvgDisplays();
+          // Native end-of-story reset destroys a lingering show-item slot
+          // (AVGShowItemPanel._Reset) instead of leaving the item on screen.
+          this.resetItemSlot();
           this.state = "finished";
           return;
         }
@@ -1351,6 +1373,17 @@ export class StoryRuntime {
       }
 
       case "hideitem": {
+        // Native port: Torappu.AVG.AVGShowItemPanel._ExecuteHideItem
+        // (GameAssembly 2.7.61 @ 0x183E5BCE0). The executor reads no story
+        // parameter for gating (`block` is ignored); no live slot returns
+        // false, a live slot always returns true and blocks until the slot's
+        // Hide tween completes (_Reset + FinishCommand). `fadetime` comes from
+        // the slot's own serialized default (0.5s). Known deviation from
+        // native: the Unity-side gate is the `_slotInUse` object reference,
+        // which showitem sets even when the image asset fails to load (an
+        // empty slot still fades in, blocks, and later fades out); the web
+        // flag is only raised after a rendered showitem, so a failed showitem
+        // turns the following hideitem into a non-blocking no-op.
         const hadItem = this.itemSlotInUse;
         this.itemSlotInUse = false;
         await this.renderer.clearItems(

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -523,7 +523,13 @@ export interface StoryRenderer {
   ) => Promise<void> | void;
   clearImage: (fadeMs?: number, block?: boolean) => Promise<void> | void;
   clearLargeImage: (fadeMs?: number, block?: boolean) => Promise<void> | void;
-  clearItems: (fadeMs?: number, block?: boolean) => Promise<void> | void;
+  /**
+   * `hasSlot` mirrors whether `Torappu.AVG.AVGShowItemPanel._slotInUse` was
+   * live (i.e. whether `_ExecuteHideItem` blocks). Deliberately not named
+   * `block`: the native executor never reads the story command's `block`
+   * parameter, and the flag only encodes "a slot exists".
+   */
+  clearItems: (fadeMs?: number, hasSlot?: boolean) => Promise<void> | void;
   clearSticker: (id?: string, fadeMs?: number) => Promise<void> | void;
   clearStickers: (fadeMs?: number) => Promise<void> | void;
   clearSpellStickers: () => Promise<void> | void;

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -603,4 +603,34 @@ describe("PixiStoryRenderer", () => {
     expect(root.position.x - 640).toBe(-160);
     expect(360 - root.position.y).toBe(0);
   });
+
+  it("clearItems removes only the show-item root and leaves animtext stamps alone", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    // Native hideitem only fades the show-item slot; animtext is a separate
+    // panel, but the web port mounts both on itemLayer, so clearItems must
+    // track the slot root explicitly instead of fading the whole layer.
+    const itemRoot = new Container();
+    const stamp = new Container();
+    renderer.itemLayer.addChild(stamp);
+    renderer.itemLayer.addChild(itemRoot);
+    renderer.showItemRoot = itemRoot;
+
+    await renderer.clearItems(0);
+
+    expect(itemRoot.parent).toBeNull();
+    expect(renderer.showItemRoot).toBeNull();
+    expect(stamp.parent).toBe(renderer.itemLayer);
+  });
+
+  it("clearItems with no live slot leaves the layer untouched", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const stamp = new Container();
+    renderer.itemLayer.addChild(stamp);
+    renderer.showItemRoot = null;
+
+    await renderer.clearItems(0);
+    await renderer.clearItems(500, true);
+
+    expect(stamp.parent).toBe(renderer.itemLayer);
+  });
 });

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -53,7 +53,7 @@ class FakeRenderer implements StoryRenderer {
   characterCalls: CharacterSlotInput[] = [];
   characterCutinCalls: CharacterCutinInput[] = [];
   clearedSlots: Array<{ fadeMs?: number; slot?: string }> = [];
-  clearItemsCalls: Array<{ block: boolean; fadeMs: number }> = [];
+  clearItemsCalls: Array<{ fadeMs: number; hasSlot: boolean }> = [];
   clearCgItemCalls: Array<{
     block: boolean;
     ease: string;
@@ -145,8 +145,8 @@ class FakeRenderer implements StoryRenderer {
     this.gridBackgroundClearCalls.push({ block, fadeMs });
   }
 
-  clearItems(fadeMs = 0, block = false): void {
-    this.clearItemsCalls.push({ block, fadeMs });
+  clearItems(fadeMs = 0, hasSlot = false): void {
+    this.clearItemsCalls.push({ fadeMs, hasSlot });
   }
 
   clearCgItems(
@@ -1160,9 +1160,61 @@ describe("StoryRuntime", () => {
     ]);
     // hideitem does not read `block` either: it blocks whenever a slot was in
     // use, which it is here because the preceding showitem filled it.
-    expect(renderer.clearItemsCalls).toEqual([{ block: true, fadeMs: 500 }]);
+    expect(renderer.clearItemsCalls).toEqual([{ fadeMs: 500, hasSlot: true }]);
     expect(warnings).toEqual([]);
     expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("destroys a lingering show-item slot when playback reaches the story end", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[showitem(image="item_act12side_1")]',
+        '[name="A"]the end',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // The script never runs hideitem; the item stays on screen through the
+    // last dialogue line...
+    expect(renderer.clearItemsCalls).toEqual([]);
+    expect(runtime.getState()).toBe("waiting_input");
+
+    await runtime.advance();
+
+    // ...and the end-of-story reset (native AVGShowItemPanel.OnReset →
+    // _Reset) tears it down without a fade.
+    expect(runtime.getState()).toBe("finished");
+    expect(renderer.clearItemsCalls).toEqual([{ fadeMs: 0, hasSlot: false }]);
+  });
+
+  it("destroys a lingering show-item slot when a skip ends the story", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[skipnode(mode="skip")]',
+        '[showitem(image="item_act12side_1")]',
+        '[name="A"]skipped',
+        '[skipnode(mode="skip")]',
+        '[name="B"]unreachable',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.clearItemsCalls).toEqual([]);
+
+    await runtime.skipNode();
+
+    // Skipping past the last anchor ends the story, and the native reset
+    // path destroys a live show-item slot on the way out.
+    expect(runtime.getState()).toBe("finished");
+    expect(renderer.clearItemsCalls).toEqual([{ fadeMs: 0, hasSlot: false }]);
   });
 
   it("places a single character in the middle slot without ever blocking", async () => {


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `hideitem`/`showitem` 道具槽生命周期移植中的行为差异（P1×1、P2×2 修复，P2×1 + P3×1 注明近似）。依据是对明日方舟官服客户端（2.7.61 / build 2761，Unity IL2CPP）GameAssembly.dll 的 IDA 反编译复核，关键结论已在下文直接给出，不依赖外部文档。

## 背景：native 的道具槽机制（2.7.61 逆向结论）

- `Torappu.AVG.AVGShowItemPanel._ExecuteHideItem` @ `0x183E5BCE0`：executor **不读任何 story 参数**做门控（`block` 被忽略）；`_slotInUse` 为 Unity-null 时早退返回 `false`（不阻塞），有活动 slot 时调 `slot.Hide(command, onFinish)` 并返回 `true`——**恒阻塞**直到 Hide tween 完成。`fadetime` 从 slot 自身的序列化默认值取（photo slot `_defaultFadeTime` = 0.5s）。
- 闭包 `<_ExecuteHideItem>b__7_0` @ `0x183E5BCC0`：tween 完成后直调 `_Reset` + `ExecutorComponent.FinishCommand`。
- `AVGShowItemPanel._Reset` @ `0x183E5C1B0`：`_slotInUse != null` 时对 slot 的 gameObject **无 delay Destroy** 并置空引用；`OnReset`（调基类 + `_Reset`）负责**剧情结束/reset 时的清理**——道具图与黑底不会残留到下一幕。
- `AVGShowItemPhotoSlot.Hide` @ `0x183ED35E0`：读 `fadetime`（默认 0.5）→ `_canvasGroup.alpha` 无条件置 1 → `DOFade(0, fadetime)`（线性）→ `OnComplete(OnAnimEnd)`。
- `AVGShowItemCutinSlot.Hide` @ `0x183ED2A60`：`fadestyle != fade` 时用 `DOSizeDelta(mask → 0)` 收缩 + 并行 `DOFade(_black, 0)`；`fade` 时与 photo 相同的 alpha 淡出。
- animtext（`AVGDisplayableExecutor._ExecuteAnimatedText`）与 showitem 是**相互独立的 panel**，hideitem 不影响 animtext。

## 修复内容

### 1. 播放结束/跳段不清理道具图（P1，差异清单 #1）

- **native 行为**：剧情结束/reset → `OnReset → _Reset` 无 delay 销毁 slot（黑底 + 图消失）；skip 打断后同样由 reset 收尾。
- **前端问题**：`processLoop` 播完只清 animtext/avgdisplay，`skipNode` 只清 interludes/spellStickers；`itemLayer` 的道具图 + 黑底残留到组件卸载。
- **修复**：`runtime.ts` 新增 `resetItemSlot()`（对应 `OnReset → _Reset`，含与 native 一致的"仅 `_slotInUse` 非空才行动"幂等判断），在 `processLoop` 收尾（`state = "finished"`）与 `skipNode` 跳过最后一个锚点（目标为结尾）两处调用，无 fade 立即清空并复位 `itemSlotInUse`。

### 2. `clearItems` 淡出波及同层 animtext（P2，差异清单 #4）

- **native 行为**：animtext 与 showitem 是独立 panel，hideitem 只淡出 show item slot。
- **前端问题**：web 端 `AnimTextPanel` 的 stamp 与 showitem root 共用 `itemLayer`，`clearItems` 淡出整层 children 会把 animtext 一并移除。
- **修复**：`PixiStoryRenderer` 显式跟踪 `showItemRoot`（renderer 侧对应 native 单个 `_slotInUse` 引用），`clearItems` 只淡出/移除该 root，同层 stamp 不受影响；tween 完成回调校验引用未被替换后才置空，避免与 showitem 替换链竞争误清新 slot。

### 3. `clearItems` 形参 `block` 改名 `hasSlot`（顺手项，来自 review 注释核对表）

- 该形参语义是"是否有活动 slot（→ 是否阻塞）"，命名 `block` 易误读为 story 命令的 `block` 参数（native executor 不读该参数）。`types.ts` 接口、Pixi 实现、FakeRenderer 与断言全部同步改名。

### 4. 注明已知近似（P2 #2、P2 #3、P3 #5，不改行为）

- **#2 状态源**：native 门控是 `_slotInUse` 对象引用，showitem 在图片资产加载失败时仍实例化 slot（空槽仍淡入并阻塞，后续 hideitem 仍淡出阻塞）；web 端 `itemSlotInUse` 仅在渲染成功后置位，失败的 showitem 使后续 hideitem 成为不阻塞的 no-op。已作为 Known deviation 写入 `runtime.ts` hideitem 分支注释（与 showitem 失败路径的修整联动，本 PR 不动 showitem 渲染失败语义）。
- **#3 cutin 淡出**：native cutin slot 的 Hide 用 `DOSizeDelta` 收缩 + 黑底淡出；web 端统一 alpha 淡出近似。已写入 `clearItems` 注释（全部生产语料 0 个 cutin showitem）。
- **#5 淡出起点**：native photo Hide 无条件 `alpha = 1` 再淡出；web 端从当前 alpha 淡到 0，正常流程（showitem 阻塞淡入完成后）等价，仅 skip 打断 showitem 淡入时不同。已写入 `clearItems` 注释。
- 差异清单 #6（`fadetime=0` 完成时机）与 #7（`block=true` 写法被忽略）两侧等价/一致，维持现状。

## 验证用剧情文件

生产剧情语料（本地 `torappu/storage/asset/gamedata/latest/story`，共 40 个含 showitem 命令的文件）：

- **修复 1（播放结束清理，主路径）**：`obt/guide/train/tr_01.txt` 第 2 行 `[ShowItem(image="item_medic", fadetime=0.1)]`——全文件无 hideitem，修复前播完道具图残留，修复后结束即清。
- **修复 1（播放结束清理，收尾赠礼场景）**：`activities/a001/level_a001_06_end.txt` 第 184 行 `[showitem(image="item_act1_1")]`——剧情结尾纪念品展示，之后无 hideitem。
- **修复 1（trailing showitem）+ hideitem 回归**：`activities/act4fun/level_act4fun_07_end.txt` 第 171/173 行 showitem、第 194 行 `[hideitem(fadetime=0)]`、第 211 行最后一个 `[ShowItem]` 在最后一个 hideitem 之后——验证结束清理覆盖"最后一个 showitem 无人收尾"的变体，且 194 行正常 hideitem 路径不回归。
- **修复 1（skip 跳结尾清理）**：语料 0 命中（无文件同时含 showitem 与 skip 锚点）——前瞻对齐，由单测锁定：`tests/runtime.spec.ts`「destroys a lingering show-item slot when a skip ends the story」。
- **修复 2（hideitem 不波及 animtext）**：语料 0 命中（无文件满足 showitem < animtext < hideitem 共存）——前瞻对齐，由单测锁定：`tests/renderer.spec.ts`「clearItems removes only the show-item root and leaves animtext stamps alone」与「clearItems with no live slot leaves the layer untouched」。
- **hideitem 既有门控回归**：`tests/runtime.spec.ts`「shows and hides story items with legacy defaults」（fadeMs=500 + hasSlot=true 阻塞语义断言已同步新形参名）。

## 测试

- `pnpm test`：20 个文件 **226 用例全部通过**（基线 222 + 新增 4：runtime 2 个结束/跳段清理用例、renderer 2 个 clearItems 隔离用例）。
- `pnpm exec vue-tsc -b`：通过。
- `pnpm exec eslint`（全部改动文件）：通过。
