### PR TITLE
fix(story-player): cgitem 默认 InSine 缓动与纹理加载不阻塞剧情推进

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/panels/CgItemPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/CgItemPanel.ts
@@ -12,7 +12,7 @@ type Tween = (
 interface CgItemState {
   root: Container;
   sessionId: number;
-  sprite: Sprite;
+  sprite: Sprite | null;
 }
 
 function lerp(from: number, to: number, progress: number): number {
@@ -24,21 +24,36 @@ function colorChannel(value: number): number {
 }
 
 function easeProgress(raw: number, ease: string): number {
+  // Native provenance: `Torappu.AVG.AVGShowItemCgSlot.Show` (0x183ed1810,
+  // 2.7.61/build 2761) reads the curve with
+  // `GetEnum<Ease>(param, "ease", (Ease)1, ignoreCase: false)`. In DOTween's
+  // public `Ease` enum `Linear = 0` and `InSine = 1`, so the call-site default
+  // -- which `GetEnum` also returns for names it cannot parse -- is InSine
+  // (`1 - cos(t*pi/2)`), not Linear. Production scripts almost never write
+  // `ease` (169/172 corpus cgitem lines), so this default drives nearly every
+  // Ken Burns move. `hidecgitem` passes its own explicit default from
+  // runtime.ts, which keeps that command's behaviour under its own review.
+  // Web adaptation: matching stays case-insensitive (native `ignoreCase:
+  // false`); corpus values use canonical casing, so the fold never triggers
+  // in production.
   switch (ease.toLowerCase()) {
+    case "insine": {
+      return 1 - Math.cos((raw * Math.PI) / 2);
+    }
     case "inquad": {
       return raw * raw;
     }
     case "inoutquad": {
       return raw < 0.5 ? 2 * raw * raw : 1 - (-2 * raw + 2) ** 2 / 2;
     }
+    case "linear": {
+      return raw;
+    }
     case "outquad": {
       return 1 - (1 - raw) * (1 - raw);
     }
-    // `AVGShowItemCgSlot.Show` / `.Hide` read the curve with
-    // `GetEnum<Ease>(param, "ease", Ease.Linear, ignoreCase: false)`, which
-    // also returns that fallback for any name it cannot parse.
     default: {
-      return raw;
+      return 1 - Math.cos((raw * Math.PI) / 2);
     }
   }
 }
@@ -74,122 +89,147 @@ export class CgItemPanel {
   ) {}
 
   async show(input: CgItemInput): Promise<void> {
-    const texture = await this.loadTexture(input.assetKey);
-    if (!texture) {
-      this.onWarning?.(`cgitem asset is missing: ${input.assetKey}`);
-      return;
-    }
-
+    // Native provenance: `Torappu.AVG.AVGCgItemPanel._ShowItem` (0x183e35d80,
+    // 2.7.61/build 2761) instantiates the new slot, instantly `Dispose()`s the
+    // previous same-key entry (no fade), and writes the new entry into
+    // `m_slotsInUseDict` BEFORE any sprite work. Its `_LoadSprite` is a
+    // synchronous cached load (assets are preloaded via
+    // `InternalResRefCollector.GatherResRefs`), so the executor never waits
+    // on I/O. The web port mirrors the command-side ordering -- dispose old,
+    // register the placeholder root -- and only then starts the asynchronous
+    // texture load, so uncached assets stay off the command critical path
+    // (block=false returns before the bytes arrive) and a `hidecgitem`
+    // arriving mid-load still finds the key instead of leaking the sprite.
     this.dispose(input.key);
     const root = new Container();
-    const sprite = new Sprite(texture);
-    sprite.anchor.set(0.5);
-    sprite.setSize(texture.width, texture.height);
     root.position.set(STORY_WIDTH / 2, STORY_HEIGHT / 2);
-    root.addChild(sprite);
     this.layer.addChild(root);
-    const state = { root, sessionId: 1, sprite };
+    const state: CgItemState = { root, sessionId: 1, sprite: null };
     this.states.set(input.key, state);
     const sessionId = state.sessionId;
 
-    if (input.width > 0 && input.height > 0)
-      sprite.setSize(input.width, input.height);
+    const completion = this.loadTexture(input.assetKey).then((texture) => {
+      // The slot was replaced, hidden, or cleared while the texture was in
+      // flight: drop the frames instead of resurrecting a destroyed root.
+      if (this.states.get(input.key) !== state) return;
+      if (state.sessionId !== sessionId) return;
+      if (!texture) {
+        // Web adaptation: native would keep an empty registered slot; the
+        // frontend undoes the pending registration so a failed load leaves
+        // no invisible target behind (the missing asset is already warned).
+        this.onWarning?.(`cgitem asset is missing: ${input.assetKey}`);
+        this.dispose(input.key);
+        return;
+      }
 
-    const runs: Promise<void>[] = [];
-    const run = (
-      delayMs: number,
-      durationMs: number,
-      update: (progress: number) => void,
-    ) => {
-      const totalMs = Math.max(0, delayMs) + Math.max(0, durationMs);
-      runs.push(
-        this.tween(totalMs, (raw) => {
-          if (state.sessionId !== sessionId) return;
-          const elapsed = raw * totalMs;
-          const local =
-            durationMs <= 0
-              ? 1
-              : Math.max(0, Math.min(1, (elapsed - delayMs) / durationMs));
-          update(easeProgress(local, input.ease));
-        }),
-      );
-    };
+      const sprite = new Sprite(texture);
+      state.sprite = sprite;
+      sprite.anchor.set(0.5);
+      sprite.setSize(texture.width, texture.height);
+      root.addChild(sprite);
 
-    // `Torappu.AVG.AVGShowItemCgSlot.Show` drives Transform.localPosition and
-    // `_GenPosByRaw` keeps the raw y sign. PIXI uses sprite.position as the
-    // coordinate-system adaptation, so do not inherit sticker's UI-y inversion.
-    if (input.positionFrom && input.positionTo) {
-      if (input.positionDurationMs > 0) {
-        sprite.position.set(input.positionFrom.x, input.positionFrom.y);
-        run(input.positionDelayMs, input.positionDurationMs, (progress) =>
-          sprite.position.set(
-            lerp(input.positionFrom!.x, input.positionTo!.x, progress),
-            lerp(input.positionFrom!.y, input.positionTo!.y, progress),
-          ),
+      if (input.width > 0 && input.height > 0)
+        sprite.setSize(input.width, input.height);
+
+      const runs: Promise<void>[] = [];
+      const run = (
+        delayMs: number,
+        durationMs: number,
+        update: (progress: number) => void,
+      ) => {
+        const totalMs = Math.max(0, delayMs) + Math.max(0, durationMs);
+        runs.push(
+          this.tween(totalMs, (raw) => {
+            if (state.sessionId !== sessionId) return;
+            const elapsed = raw * totalMs;
+            const local =
+              durationMs <= 0
+                ? 1
+                : Math.max(0, Math.min(1, (elapsed - delayMs) / durationMs));
+            update(easeProgress(local, input.ease));
+          }),
         );
-      } else {
-        sprite.position.set(input.positionTo.x, input.positionTo.y);
-      }
-    }
+      };
 
-    if (input.scaleFrom !== input.scaleTo) {
-      if (input.scaleDurationMs > 0) {
-        sprite.scale.set(input.scaleFrom);
-        run(input.scaleDelayMs, input.scaleDurationMs, (progress) =>
-          sprite.scale.set(lerp(input.scaleFrom, input.scaleTo, progress)),
-        );
-      } else {
-        sprite.scale.set(input.scaleTo);
+      // `Torappu.AVG.AVGShowItemCgSlot.Show` drives Transform.localPosition and
+      // `_GenPosByRaw` keeps the raw y sign. PIXI uses sprite.position as the
+      // coordinate-system adaptation, so do not inherit sticker's UI-y inversion.
+      if (input.positionFrom && input.positionTo) {
+        if (input.positionDurationMs > 0) {
+          sprite.position.set(input.positionFrom.x, input.positionFrom.y);
+          run(input.positionDelayMs, input.positionDurationMs, (progress) =>
+            sprite.position.set(
+              lerp(input.positionFrom!.x, input.positionTo!.x, progress),
+              lerp(input.positionFrom!.y, input.positionTo!.y, progress),
+            ),
+          );
+        } else {
+          sprite.position.set(input.positionTo.x, input.positionTo.y);
+        }
       }
-    }
 
-    if (input.colorFrom && input.colorTo) {
-      if (input.alphaDurationMs > 0) {
-        sprite.tint = rgb(input.colorFrom);
-        sprite.alpha = input.colorFrom.a;
-        run(input.alphaDelayMs, input.alphaDurationMs, (progress) => {
-          const color = {
-            a: lerp(input.colorFrom!.a, input.colorTo!.a, progress),
-            b: lerp(input.colorFrom!.b, input.colorTo!.b, progress),
-            g: lerp(input.colorFrom!.g, input.colorTo!.g, progress),
-            r: lerp(input.colorFrom!.r, input.colorTo!.r, progress),
-          };
-          sprite.tint = rgb(color);
-          sprite.alpha = color.a;
-        });
-      } else {
-        sprite.tint = rgb(input.colorTo);
-        sprite.alpha = input.colorTo.a;
+      if (input.scaleFrom !== input.scaleTo) {
+        if (input.scaleDurationMs > 0) {
+          sprite.scale.set(input.scaleFrom);
+          run(input.scaleDelayMs, input.scaleDurationMs, (progress) =>
+            sprite.scale.set(lerp(input.scaleFrom, input.scaleTo, progress)),
+          );
+        } else {
+          sprite.scale.set(input.scaleTo);
+        }
       }
-    } else if (input.alphaFrom !== input.alphaTo) {
-      if (input.alphaDurationMs > 0) {
-        sprite.alpha = input.alphaFrom;
-        run(input.alphaDelayMs, input.alphaDurationMs, (progress) => {
-          sprite.alpha = lerp(input.alphaFrom, input.alphaTo, progress);
-        });
-      } else {
-        sprite.alpha = input.alphaTo;
-      }
-    }
 
-    // Native provenance: `AVGShowItemCgSlot.Show` (not the panel) gates its
-    // whole rotation block on `!MathUtil.GT(rfrom, 0)`, i.e. `rfrom <= 0`, so
-    // the default `rfrom = -1` always takes it and an explicit positive `rfrom`
-    // disables rotation entirely. `Transform.Rotate` is relative while
-    // `DORotate(..., RotateMode.Fast)` targets an absolute angle; a fresh
-    // sprite sits at 0, so `+= rfrom` then tween to `rto` reproduces both.
-    if (input.rotationFrom <= 0) {
-      if (input.rotationDurationMs > 0) {
-        sprite.angle += input.rotationFrom;
-        run(0, input.rotationDurationMs, (progress) => {
-          sprite.angle = lerp(input.rotationFrom, input.rotationTo, progress);
-        });
-      } else {
-        sprite.angle += input.rotationTo;
+      if (input.colorFrom && input.colorTo) {
+        if (input.alphaDurationMs > 0) {
+          sprite.tint = rgb(input.colorFrom);
+          sprite.alpha = input.colorFrom.a;
+          run(input.alphaDelayMs, input.alphaDurationMs, (progress) => {
+            const color = {
+              a: lerp(input.colorFrom!.a, input.colorTo!.a, progress),
+              b: lerp(input.colorFrom!.b, input.colorTo!.b, progress),
+              g: lerp(input.colorFrom!.g, input.colorTo!.g, progress),
+              r: lerp(input.colorFrom!.r, input.colorTo!.r, progress),
+            };
+            sprite.tint = rgb(color);
+            sprite.alpha = color.a;
+          });
+        } else {
+          sprite.tint = rgb(input.colorTo);
+          sprite.alpha = input.colorTo.a;
+        }
+      } else if (input.alphaFrom !== input.alphaTo) {
+        if (input.alphaDurationMs > 0) {
+          sprite.alpha = input.alphaFrom;
+          run(input.alphaDelayMs, input.alphaDurationMs, (progress) => {
+            sprite.alpha = lerp(input.alphaFrom, input.alphaTo, progress);
+          });
+        } else {
+          sprite.alpha = input.alphaTo;
+        }
       }
-    }
 
-    const completion = Promise.all(runs).then(() => {});
+      // Native provenance: `AVGShowItemCgSlot.Show` (not the panel) gates its
+      // whole rotation block on `!MathUtil.GT(rfrom, 0)`, i.e. `rfrom <= 0`, so
+      // the default `rfrom = -1` always takes it and an explicit positive `rfrom`
+      // disables rotation entirely. `Transform.Rotate` is relative while
+      // `DORotate(..., RotateMode.Fast)` targets an absolute angle; a fresh
+      // sprite sits at 0, so `+= rfrom` then tween to `rto` reproduces both.
+      if (input.rotationFrom <= 0) {
+        if (input.rotationDurationMs > 0) {
+          sprite.angle += input.rotationFrom;
+          run(0, input.rotationDurationMs, (progress) => {
+            sprite.angle = lerp(input.rotationFrom, input.rotationTo, progress);
+          });
+        } else {
+          sprite.angle += input.rotationTo;
+        }
+      }
+
+      return Promise.all(runs).then(() => {});
+    });
+    // block=true waits for the whole native Sequence (each track's delay +
+    // duration) -- plus the web-only texture wait; block=false mirrors
+    // ExecutorComponent finishing the command immediately.
     if (input.block) await completion;
     else void completion;
   }

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1371,8 +1371,13 @@ export class StoryRuntime {
         const key = id ? `${image}_${id}` : image;
         const style = toString(this.exactArg(args, "style"), "cg");
         if (style === "blocker") {
-          // Native port scope: AVGCgItemPanel._ShowItem's `blocker` branch uses a
-          // scene-resident sprite and deliberately skips m_slotsInUseDict. No
+          // Native port scope: in 2.7.61 `AVGCgItemPanel._ShowItem`
+          // (0x183e35d80) runs its common prefix (instantiate new slot,
+          // dispose the old same-key entry, write m_slotsInUseDict, bind
+          // PostDisplay) for `style="blocker"` as well and only skips the
+          // sprite load, showing the scene-resident blocker prefab instead.
+          // The web player has no such prefab, so the whole command is
+          // deliberately omitted here (corpus usage: 0).
           this.warn(
             "unsupported_command",
             "cgitem style=blocker uses a native-only scene sprite",
@@ -1408,9 +1413,12 @@ export class StoryRuntime {
           block: toBoolean(this.exactArg(args, "block"), false),
           colorFrom: colorFrom && colorTo ? colorFrom : undefined,
           colorTo: colorFrom && colorTo ? colorTo : undefined,
-          // `AVGShowItemCgSlot.Show` defaults `ease` to `Ease.Linear` (= 1),
-          // not to an eased curve.
-          ease: toString(this.exactArg(args, "ease"), "Linear"),
+          // `AVGShowItemCgSlot.Show` (0x183ed1810) reads the curve with
+          // `GetEnum<Ease>(param, "ease", (Ease)1, ignoreCase: false)`.
+          // In DOTween's public `Ease` enum `Linear = 0` and `InSine = 1`,
+          // so the default is InSine (1 - cos(t*pi/2)) -- nearly every
+          // corpus cgitem omits `ease` and therefore eases InSine.
+          ease: toString(this.exactArg(args, "ease"), "InSine"),
           height: Math.trunc(toNumber(this.exactArg(args, "height"), 0)),
           key,
           positionDelayMs: seconds("pdelay"),

--- a/tests/cgItemPanel.spec.ts
+++ b/tests/cgItemPanel.spec.ts
@@ -1,4 +1,4 @@
-import { Container, Texture } from "pixi.js";
+import { Container, Texture, type Sprite } from "pixi.js";
 import { describe, expect, it } from "vitest";
 
 import { CgItemPanel } from "../src/widgets/StoryPlayer/engine/rendering/panels/CgItemPanel";
@@ -37,6 +37,27 @@ async function tweenImmediately(
 ): Promise<void> {
   update(1);
   complete?.();
+}
+
+function deferredTexture() {
+  let resolve!: (texture: Texture | null) => void;
+  const promise = new Promise<Texture | null>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function manualTween() {
+  let update: ((progress: number) => void) | undefined;
+  const tween = (_duration: number, step: (progress: number) => void) => {
+    update = step;
+    return new Promise<void>(() => {});
+  };
+  return { step: (progress: number) => update?.(progress), tween };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 5; index++) await Promise.resolve();
 }
 
 describe("CgItemPanel", () => {
@@ -81,5 +102,125 @@ describe("CgItemPanel", () => {
     await panel.hide(undefined, 130, "Linear", true);
     expect(panel.targets("")).toEqual([]);
     expect(layer.children).toHaveLength(0);
+  });
+
+  it("eases the native default InSine curve and falls back to it for unknown names", async () => {
+    // `AVGShowItemCgSlot.Show` (0x183ed1810) reads ease via
+    // `GetEnum<Ease>(param, "ease", (Ease)1, ignoreCase: false)`: the
+    // call-site default (InSine, DOTween `Linear = 0` / `InSine = 1`) is
+    // also returned for names the parser rejects. Explicit "Linear" must
+    // stay linear because hidecgitem passes that default from runtime.ts.
+    const inSineHalf = 100 * (1 - Math.SQRT1_2);
+    const cases = [
+      { ease: "InSine", expected: inSineHalf },
+      { ease: "NoSuchEase", expected: inSineHalf },
+      { ease: "Linear", expected: 50 },
+    ];
+    for (const { ease, expected } of cases) {
+      const manual = manualTween();
+      const panel = new CgItemPanel(
+        new Container(),
+        async () => Texture.WHITE,
+        manual.tween,
+      );
+      await panel.show(
+        input("a", {
+          ease,
+          positionDurationMs: 1000,
+          positionFrom: { x: 0, y: 0 },
+          positionTo: { x: 100, y: 0 },
+        }),
+      );
+      await flushMicrotasks();
+      manual.step(0.5);
+      const sprite = panel.targets("a")[0]!.children[0] as Sprite;
+      expect(sprite.position.x).toBeCloseTo(expected, 5);
+    }
+  });
+
+  it("returns from a non-blocking show before the texture arrives", async () => {
+    const layer = new Container();
+    const deferred = deferredTexture();
+    const panel = new CgItemPanel(
+      layer,
+      () => deferred.promise,
+      tweenImmediately,
+    );
+
+    let finished = false;
+    const task = panel.show(input("a")).then(() => {
+      finished = true;
+    });
+    await flushMicrotasks();
+
+    expect(finished).toBe(true);
+    expect(panel.targets("a")).toHaveLength(1);
+    expect(panel.targets("a")[0]!.children).toHaveLength(0);
+
+    deferred.resolve(Texture.WHITE);
+    await flushMicrotasks();
+    expect(panel.targets("a")[0]!.children).toHaveLength(1);
+    await task;
+  });
+
+  it("disposes the previous same-key entry before the new texture loads", async () => {
+    const layer = new Container();
+    const first = deferredTexture();
+    const second = deferredTexture();
+    let loader = () => first.promise;
+    const panel = new CgItemPanel(layer, () => loader(), tweenImmediately);
+
+    await panel.show(input("a"));
+    await flushMicrotasks();
+    const oldRoot = panel.targets("a")[0]!;
+
+    loader = () => second.promise;
+    await panel.show(input("a"));
+
+    expect(panel.targets("a")[0]).not.toBe(oldRoot);
+    expect(layer.children).toHaveLength(1);
+
+    first.resolve(Texture.WHITE);
+    await flushMicrotasks();
+    expect(panel.targets("a")[0]!.children).toHaveLength(0);
+
+    second.resolve(Texture.WHITE);
+    await flushMicrotasks();
+    expect(panel.targets("a")[0]!.children).toHaveLength(1);
+  });
+
+  it("lets a hide during the load window cancel the pending sprite", async () => {
+    const deferred = deferredTexture();
+    const panel = new CgItemPanel(
+      new Container(),
+      () => deferred.promise,
+      tweenImmediately,
+    );
+
+    await panel.show(input("a"));
+    expect(panel.targets("a")).toHaveLength(1);
+
+    await panel.hide("a", 130, "Linear", true);
+    expect(panel.targets("a")).toEqual([]);
+
+    deferred.resolve(Texture.WHITE);
+    await flushMicrotasks();
+    expect(panel.targets("a")).toEqual([]);
+  });
+
+  it("warns and drops the pending registration when the texture is missing", async () => {
+    const warnings: string[] = [];
+    const panel = new CgItemPanel(
+      new Container(),
+      async () => null,
+      tweenImmediately,
+      (detail) => warnings.push(detail),
+    );
+
+    await panel.show(input("a"));
+    await flushMicrotasks();
+
+    expect(warnings[0]).toContain("cgitem asset is missing: a");
+    expect(panel.targets("a")).toEqual([]);
   });
 });

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2858,6 +2858,25 @@ describe("StoryRuntime", () => {
     ]);
   });
 
+  it("defaults cgitem ease to InSine like the native GetEnum call-site default", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext(['[cgitem(image="cgitem_test")]']),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.cgItemCalls).toEqual([
+      expect.objectContaining({
+        assetKey: "cgitem_test",
+        ease: "InSine",
+        key: "cgitem_test",
+      }),
+    ]);
+  });
+
   it("maps parameterless hidecgitem to clear-all", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `cgitem` 命令移植中 review 差异清单里的 1 项 P1、3 项 P2 与 1 项 P3 注释修正。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的逆向分析(IDA 反编译复核),关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 cgitem 机制(2.7.61 逆向结论)

- `Torappu.AVG.AVGShowItemCgSlot.Show`(VA `0x183ed1810`)用 `GetEnum<Ease>(param, "ease", (Ease)1, ignoreCase: false)` 读取缓动曲线。DOTween 公开 `Ease` 枚举序 `Linear = 0, InSine = 1, OutSine = 2, ...`,因此调用点默认值是 **InSine**(`1 - cos(t·π/2)`),且 `GetEnum` 对无法解析的名字同样返回该默认值。语料 172 条 cgitem 中仅 3 条显式写 `ease`,其余 169 条全部走默认曲线。
- `Torappu.AVG.AVGCgItemPanel._ShowItem`(VA `0x183e35d80`)顺序:先 Instantiate 新 slot → 立即 `Dispose()` 旧同 key 项(瞬间消失,不淡出)→ 写 `m_slotsInUseDict` → 绑 PostDisplay → 之后才加载 sprite。`_LoadSprite`(VA `0x183e35a60`)是**同步**取缓存(`InternalResRefCollector.GatherResRefs` 预加载保证),executor 不挂起、无回调。即:注册发生在加载之前,替换无空窗,加载不在命令关键路径。
- `blocker` style:2.7.61 中 blocker 同样执行上述公共前段(含写 dict、绑 PostDisplay),仅跳过 sprite 加载(语料 0 次使用)。
- `ExecutorComponent.Execute`(VA `0x183e45b10`):executor 返回 `false`(即 `block=false`)立即 `FinishCommand()`,命令瞬时完成。

## 修复内容

### 1. ease 默认曲线应为 InSine(P1,差异 #1)

- **native 行为**:默认 `Ease` 枚举 `1` = `InSine`;几乎每条 Ken Burns 镜头都走这条曲线。
- **前端行为**:默认 `"Linear"` 线性插值,且 `easeProgress` 未实现 InSine;原注释还把 `Ease.Linear` 误标为 `= 1`。
- **修复**:`runtime.ts` cgitem 分支默认 ease 改为 `"InSine"` 并更正 provenance 注释;`CgItemPanel.easeProgress` 补 `insine` 实现(`1 - cos(t·π/2)`),默认分支(unparseable 名字的 `GetEnum` 回落)也返回 InSine。

### 2. 纹理加载移出命令关键路径(P2,差异 #2)

- **native 行为**:executor 同步完成,`block=false` 时命令瞬时返回,加载不在关键路径(资源已预加载)。
- **前端行为**:`show()` 无条件先 `await loadTexture`(网络/解码),CG 未缓存时剧情推进被卡住。
- **修复**:`CgItemPanel.show()` 重构为"命令侧先行"——同步建占位 root 后立即返回(`block=false`),纹理到位后再建 sprite 并启动各 tween 轨道;`block=true` 仍等待纹理 + 全部轨道(native 等整个 Sequence 的等价物,外加 web 特有的取纹理等待)。

### 3. 同 key 替换的空窗(P2,差异 #3)

- **native 行为**:Instantiate 新 slot 后立即 Dispose 旧 slot(瞬间消失),旧图先走、新图加载后出现。
- **前端行为**:先 `await` 新纹理、加载完成后才 `dispose(key)`,旧图保留到新图就绪。
- **修复**:`dispose(input.key)` 提前到加载之前,对齐"瞬间替换"语义(占位 slot 语义为 review 建议接受项)。

### 4. 加载期竞态残留(P2,差异 #4)

- **native 行为**:dict 在加载之前写入,加载期间到来的 `hidecgitem` 能命中 key。
- **前端行为**:`states` 在加载之后才写入,加载期间 `hidecgitem(key)` 查不到 → no-op,CG 随后出现并残留至 clear-all。
- **修复**:命令进入即写 `states`(pending 注册);纹理到位时校验 map 中的 state 与 sessionId,期间被替换/隐藏/清空则丢弃该帧;加载失败(纹理为 null)时撤销注册并告警(review 建议的两个可选实现之一)。

### 5. ease 名集合小补(P2,差异 #5,低优先项的轻量实现)

- 补 `linear` 显式分支(hidecgitem 从 runtime 传来的显式默认 `"Linear"` 保持线性,该命令的行为归其自身 review 管);`insine` 即第 1 项。语料 cgitem 只用过 `OutQuad`(已支持,保持不变)。大小写仍宽松匹配并在注释标注与 native `ignoreCase: false` 的差异(语料均为规范大小写,生产不触发)。

### 6. blocker 注释更正(P3,差异 #6)

- 原注释声称 blocker "deliberately skips m_slotsInUseDict",与 2.7.61 反编译不符(blocker 也写 dict、绑 PostDisplay,仅跳过 sprite 加载)。保持整条跳过的行为不变(有意省略),仅更正注释说明。

未动条目:差异 #7(畸形 raw 参数,语料 0 次)、#8(浮点近似比较)、#9(空 image,维持前端防御)、#10(PostDisplay 注册,依赖 cameraeffect/focusout 整体决策)均按 review 建议维持现状。

## 验证用剧情文件

语料库根:`/home/xwbx/Documents/torappu/storage/asset/gamedata/latest/story/`

- `obt/main/level_main_15-15_end.txt:393,396,398` — cgitem 不写 `ease` 的 Ken Burns 镜头(验证 #1 默认 InSine;`block` 缺省 false,验证 #2 推进不被加载卡住)。
- `obt/main/level_main_15-15_end.txt:398→400` — 同 key `cgitem_60_i12_3` 重复下发(验证 #3 瞬间替换);`400` show 后 `407` 即 `hidecgitem(image="cgitem_60_i12_3")`(验证 #4 加载期 hide 不再漏掉 CG)。
- `obt/main/level_main_15-16_beg.txt:443,454,458` — 同 key `cgitem_60_i16` 三连发(验证 #3;每条 `block` 缺省 false,验证 #2)。
- `activities/act51side/level_act51side_01_end.txt:662-664` — 显式 `ease="OutQuad"`(回归:显式 OutQuad 曲线保持不变)。
- #5 其余 ease 曲线名:语料 cgitem 0 命中,前瞻对齐,由单测锁定(`tests/cgItemPanel.spec.ts` 的 "eases the native default InSine curve and falls back to it for unknown names")。

## 测试

- `pnpm test`:228 用例全过(基线 222 + 新增 6:`tests/cgItemPanel.spec.ts` 5 条默认曲线/非阻塞返回/瞬间替换/加载期 hide/纹理缺失撤销,`tests/runtime.spec.ts` 1 条默认 ease 映射)。
- `pnpm exec vue-tsc -b`:无错误。
- `pnpm exec eslint`(改动文件):无告警。
