### PR TITLE
fix(story-player): stopmusic 淡出期间 musicvolume 取消停止并接管渐变

### DIFF
--- a/src/widgets/StoryPlayer/engine/audio.ts
+++ b/src/widgets/StoryPlayer/engine/audio.ts
@@ -21,6 +21,15 @@ export class HtmlStoryAudio implements StoryAudio {
   private readonly context: Context;
   private destroyed = false;
   private musicAudio: ActivePlayback | null = null;
+  /**
+   * Native provenance: `_ExecuteStopMusicCommand` fades the MUSIC channel but
+   * keeps it registered in `AudioManager.m_channels` until the fade ends, so
+   * a musicvolume/playmusic landing inside the fade window still resolves the
+   * channel and `AudioChannel.TweenVolume` clears `m_stopWhenTweenEnd` — the
+   * pending stop is cancelled. Holds the fading playback while it is still
+   * addressable; `null` once the fade completes or is superseded.
+   */
+  private musicPendingStop: ActivePlayback | null = null;
   private musicRequestId = 0;
   /**
    * Native provenance: `Torappu.AVG.CommonExecutors._ExecutePlayMusicCommand`,
@@ -34,6 +43,14 @@ export class HtmlStoryAudio implements StoryAudio {
    *
    */
   private musicBaseVolume = 1;
+  /**
+   * Native provenance: `AudioChannel.TweenVolume` (`0x183edef70`) replaces the
+   * whole tween state (start/target volume, start/end time) and clears
+   * `m_stopWhenTweenEnd`, so the newest fade command supersedes any in-flight
+   * fade — including one that was going to stop the channel. Modeled by
+   * invalidating the previous fade's token per playback.
+   */
+  private readonly fadeTokens = new WeakMap<ActivePlayback, object>();
   private readonly soundBaseVolumes = new Map<string, number>();
   private readonly soundRequestIds = new Map<string, number>();
   private readonly soundCache = new Map<string, Sound>();
@@ -48,6 +65,7 @@ export class HtmlStoryAudio implements StoryAudio {
 
     this.stopPlayback(this.musicAudio);
     this.musicAudio = null;
+    this.musicPendingStop = null;
 
     for (const sound of this.soundChannels.values()) this.stopPlayback(sound);
     this.soundChannels.clear();
@@ -65,6 +83,10 @@ export class HtmlStoryAudio implements StoryAudio {
     const identity = `${introUrl ?? ""}\n${mainUrl}`;
     this.musicBaseVolume = input.volume;
     if (this.musicAudio?.identity === identity) {
+      // Native provenance: `_PlayAudio` (a) fast path — `set_volume` retargets
+      // the same playing channel instantly and drops a mid-fade stop request
+      // (`m_stopWhenTweenEnd` is cleared by the replaced tween).
+      this.cancelPendingMusicStop(this.musicAudio);
       this.setVolume(this.musicAudio, input.volume);
       return;
     }
@@ -115,8 +137,14 @@ export class HtmlStoryAudio implements StoryAudio {
     const current = this.musicAudio;
     if (!current) return;
 
-    this.musicAudio = null;
-    await this.fadeAndStop(current, fadeMs);
+    // Native provenance: the fading MUSIC channel stays registered (see
+    // `musicPendingStop`), so keep it addressable until the fade either
+    // completes (channel stops and is released) or is superseded.
+    this.musicPendingStop = current;
+    const stopped = await this.fadeAndStop(current, fadeMs);
+    if (this.musicPendingStop !== current) return; // taken over by a newer fade
+    this.musicPendingStop = null;
+    if (stopped && this.musicAudio === current) this.musicAudio = null;
   }
 
   async playSound(input: PlaySoundInput): Promise<void> {
@@ -210,9 +238,16 @@ export class HtmlStoryAudio implements StoryAudio {
     // `AudioChannel.TweenVolume`. MUSIC base volume outlives a playback instance,
     // so retain it while PIXI is still loading.
     this.musicBaseVolume = volume;
-    if (!this.musicAudio) return;
+    const current = this.musicAudio;
+    if (!current) return;
 
-    await this.fadeVolume(this.musicAudio, volume, fadeMs);
+    // Native: the MUSIC channel is still resolvable during a stopmusic fade
+    // (`GetMusicChannel` hits `m_channels`); `TweenVolume` clears
+    // `m_stopWhenTweenEnd`, cancelling the pending stop, and retargets the
+    // tween from the current mid-fade volume — the track keeps playing.
+    this.cancelPendingMusicStop(current);
+
+    await this.fadeVolume(current, volume, fadeMs);
   }
 
   private async createPlayback(
@@ -234,6 +269,20 @@ export class HtmlStoryAudio implements StoryAudio {
     targetVolume: number,
     durationMs: number,
   ): Promise<void> {
+    await this.runFade(
+      playback,
+      targetVolume,
+      durationMs,
+      this.beginFade(playback),
+    );
+  }
+
+  private async runFade(
+    playback: ActivePlayback,
+    targetVolume: number,
+    durationMs: number,
+    token: object,
+  ): Promise<void> {
     const startVolume = this.getVolume(playback);
     if (durationMs <= 0) {
       this.setVolume(playback, targetVolume);
@@ -244,7 +293,7 @@ export class HtmlStoryAudio implements StoryAudio {
 
     await new Promise<void>((resolve) => {
       const tick = () => {
-        if (this.destroyed) {
+        if (this.destroyed || !this.ownsFade(playback, token)) {
           resolve();
           return;
         }
@@ -283,12 +332,41 @@ export class HtmlStoryAudio implements StoryAudio {
     this.claimPlayback(music, instance, this.musicAudio === music);
   }
 
+  /**
+   * Fade to silence, then stop — unless a newer fade (a musicvolume retarget
+   * or a same-track playmusic fast path) took over the playback mid-fade.
+   * Native provenance: `AudioChannel.Update` only stops the channel when the
+   * tween ends with `m_stopWhenTweenEnd` still set.
+   */
   private async fadeAndStop(
     playback: ActivePlayback,
     durationMs: number,
-  ): Promise<void> {
-    await this.fadeVolume(playback, 0, durationMs);
+  ): Promise<boolean> {
+    const token = this.beginFade(playback);
+    await this.runFade(playback, 0, durationMs, token);
+    if (this.destroyed || !this.ownsFade(playback, token)) return false;
     this.stopPlayback(playback);
+    return true;
+  }
+
+  /**
+   * Cancel a pending stopmusic fade on `playback` and retire its fade loop.
+   * Native provenance: `AudioChannel.TweenVolume` clears `m_stopWhenTweenEnd`.
+   */
+  private cancelPendingMusicStop(playback: ActivePlayback): void {
+    if (this.musicPendingStop !== playback) return;
+    this.musicPendingStop = null;
+    this.beginFade(playback);
+  }
+
+  private beginFade(playback: ActivePlayback): object {
+    const token = {};
+    this.fadeTokens.set(playback, token);
+    return token;
+  }
+
+  private ownsFade(playback: ActivePlayback, token: object): boolean {
+    return this.fadeTokens.get(playback) === token;
   }
 
   private soundChannelName(channel: string): string {

--- a/tests/audio.spec.ts
+++ b/tests/audio.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HtmlStoryAudio } from "../src/widgets/StoryPlayer/engine/audio";
 
@@ -80,6 +80,41 @@ async function flush(): Promise<void> {
 
 const context = { linkMap: {}, script: [] } satisfies Context;
 
+/** Drive `requestAnimationFrame`-based fades manually with a fake clock. */
+function useManualFadeClock(): { frame: (ms: number) => void } {
+  const frames: FrameRequestCallback[] = [];
+  let clock = 0;
+  vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation(
+    (callback) => {
+      frames.push(callback);
+      return frames.length;
+    },
+  );
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+  return {
+    /** Advance one animation frame worth of fade time. */
+    frame(ms: number): void {
+      clock += ms;
+      const pending = frames.slice();
+      frames.length = 0;
+      for (const callback of pending) callback(clock);
+    },
+  };
+}
+
+async function playMusicTrack(
+  audio: HtmlStoryAudio,
+  volume = 1,
+): Promise<FakeInstance> {
+  void audio.playMusic({ crossfadeMs: 0, delayMs: 0, key: "k", volume });
+  await flush();
+  const sound = settleLoad();
+  await flush();
+  const instance = sound.settlePlay();
+  await flush();
+  return instance;
+}
+
 describe("HtmlStoryAudio", () => {
   beforeEach(() => {
     loads.length = 0;
@@ -143,5 +178,84 @@ describe("HtmlStoryAudio", () => {
 
     await audio.stopSound("c", 0);
     expect(instance.stopped).toBe(1);
+  });
+});
+
+describe("HtmlStoryAudio musicvolume during a stopmusic fade", () => {
+  beforeEach(() => {
+    loads.length = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("cancels the pending stop and retargets the fade (TweenVolume clears m_stopWhenTweenEnd)", async () => {
+    const { frame } = useManualFadeClock();
+    const audio = new HtmlStoryAudio(context);
+    const instance = await playMusicTrack(audio, 1);
+
+    void audio.stopMusic(1000);
+    await flush();
+    frame(500); // halfway down the fade to silence
+    expect(instance.volume).toBeCloseTo(0.5);
+
+    const retargeted = audio.setMusicVolume(0.8, 400);
+    frame(400); // retargeted tween reaches the new volume
+    frame(600); // the retired stop-fade loop must never write again
+    await retargeted;
+    await flush();
+
+    expect(instance.stopped).toBe(0);
+    expect(instance.volume).toBeCloseTo(0.8);
+
+    // The channel was never released, so later volume commands still hit it.
+    await audio.setMusicVolume(0.2, 0);
+    expect(instance.volume).toBe(0.2);
+  });
+
+  it("still stops the music when nothing interrupts the fade", async () => {
+    const { frame } = useManualFadeClock();
+    const audio = new HtmlStoryAudio(context);
+    const instance = await playMusicTrack(audio, 1);
+
+    void audio.stopMusic(1000);
+    await flush();
+    frame(500);
+    frame(500);
+    await flush();
+
+    expect(instance.stopped).toBe(1);
+    expect(instance.volume).toBe(0);
+
+    // Channel released: a later musicvolume is a silent no-op (native
+    // GetMusicChannel returns null once the channel stopped).
+    await audio.setMusicVolume(0.7, 0);
+    expect(instance.volume).toBe(0);
+    expect(instance.stopped).toBe(1);
+  });
+
+  it("retargets instantly on a same-track playmusic inside the fade (_PlayAudio fast path)", async () => {
+    const { frame } = useManualFadeClock();
+    const audio = new HtmlStoryAudio(context);
+    const instance = await playMusicTrack(audio, 1);
+
+    void audio.stopMusic(1000);
+    await flush();
+    frame(500);
+    expect(instance.volume).toBeCloseTo(0.5);
+
+    await audio.playMusic({
+      crossfadeMs: 0,
+      delayMs: 0,
+      key: "k",
+      volume: 0.9,
+    });
+    frame(1000); // the retired stop-fade loop must never write again
+    await flush();
+
+    expect(instance.stopped).toBe(0);
+    expect(instance.volume).toBe(0.9);
+    expect(loads).toHaveLength(0); // fast path: no reload, track keeps playing
   });
 });


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `musicvolume` 命令移植中的唯一可修复行为差异（P1×1，跨命令共性「停止不可取消」）。依据是对明日方舟官服客户端（2.7.61 / build 2761，Unity IL2CPP）GameAssembly.dll 的 IDA 反编译复核，关键结论已在下文直接给出，不依赖外部文档。

## 背景：native 的 musicvolume 与停止取消机制（2.7.61 逆向结论）

- `Torappu.AVG.CommonExecutors._ExecuteMusicVolumeCommand`（VA `0x183e6e080`）：读 `volume`（默认 1.0）与 `fadetime`（默认 0.0，秒）→ `AudioManager.GetMusicChannel()`（VA `0x18197e0a0`，按名 `"MUSIC"` 解析 channel）→ channel 非空才调 `AudioChannel.TweenVolume(volume, fadetime, 0.0, linear)`；channel 为 null 时**静默 no-op**；随后同步回调 finishCb（**永远非阻塞**）。不读 `delay`/`block`，ease 硬编码 linear，音量不 clamp。
- `AudioChannel.TweenVolume`（VA `0x183edef70`）**整体替换 tween 状态**：`m_tweenStartVolume = m_currentBaseVolume`（起点重置为当前 mid-tween 音量）、`m_tweenTargetVolume = target`、**`m_stopWhenTweenEnd = 0`**（第 3 条语句，`0x183edefd2`）、起止时间基于 `Time.unscaledTime`。
- `AudioChannel.Update`（VA `0x183edf060`）三段推进并在 tween 结束时锁定终态；仅当 `m_stopWhenTweenEnd` 仍为 1 才在 fade 结束时停播回收 channel，`volume=0` 的 musicvolume 只是静音、BGM 继续播。
- 关键交互（2.7.61 复证）：`stopmusic(fadetime>0.01)` 淡出途中，MUSIC channel 仍在 `AudioManager.m_channels` 且 `isPlaying` 为 true → `GetMusicChannel` 仍能命中 → 此时来的 `musicvolume` 经 `TweenVolume` 清掉 `m_stopWhenTweenEnd`，**停止被取消**，BGM 从当前淡出音量转向新目标音量继续播。淡出中途再次 `musicvolume` 同理：tween 字段整体替换、起点重置为当前音量。

## 修复内容

### 1. `stopmusic` 淡出期间的 `musicvolume` 应取消停止（P1，差异清单 #1）

- **native 行为**：淡出中的 MUSIC channel 仍可按名命中；`TweenVolume` 清 `m_stopWhenTweenEnd`，停止被取消，BGM 向新目标音量渐变、继续播。
- **前端行为（修复前）**：`stopMusic` 一进来就把 `musicAudio` 置 null → 淡出窗口内 `setMusicVolume` 只更新 `musicBaseVolume` 即 return（no-op），旧实例继续淡到 0 并停止。
- **修复**（`engine/audio.ts`）：
  - `stopMusic` 淡出期间**保留 `musicAudio` 可寻址引用**并挂 `musicPendingStop` 标志（对应 channel 留在 `m_channels`）；fade 正常跑完且未被取消时才 stop 并释放引用；
  - `setMusicVolume` 命中处于 pending stop 的实例时清标志并接管 tween（对应 `TweenVolume` 清 `m_stopWhenTweenEnd`），渐变起点即当前 mid-fade 音量（对应 `m_tweenStartVolume = m_currentBaseVolume`）；
  - 新增 per-playback fade token（`WeakMap`）：任何新 fade 整体取代旧 fade 的 rAF 循环，对应 native tween 字段整体替换语义；`fadeAndStop` 仅在「自己的 fade 正常结束且未被取代」时才 stop（对应 `Update` 只在 `m_stopWhenTweenEnd` 仍置位时回收 channel）。

### 2. 顺带：同曲 `playmusic` 短路分支补取消（防御性，避免修复 1 引入回归）

修复 1 让淡出中的实例重新对 `playMusic` 的同曲 identity 短路可见；若不在短路处取消 pending stop，会出现「瞬时跳新音量 → 旧停止淡出循环继续拉回 0 并停播」的回归。native `_PlayAudio` (a) 短路路径本就 `set_volume` 瞬时跳新音量并取消淡出停止（`m_stopWhenTweenEnd` 被 replaced tween 清除），故短路分支同步调用取消逻辑。此项同时是 impl-review-stopmusic/playmusic 差异清单中同机制条目（由并行 PR 处理完整语义）的公共地基。

### 未修条目（review 差异清单维持现状）

- #2（P3）无 BGM 时的持久音量记账：保留 `musicBaseVolume` 落账（支撑 PIXI 异步加载窗口场景），无实际影响；
- #3（P3）极短 fade 阈值（10ms 特判）：听感无差别，不改；
- #4（P3）rAF 后台标签页暂停 vs `Time.unscaledTime`：web 固有，可接受。

## 验证用剧情文件

生产剧情语料（本地 `torappu/storage/asset/gamedata/latest/story`）。`stopmusic` 为非阻塞命令，其后**紧邻**（中间只隔非阻塞命令）的 `musicvolume` 才必然落在淡出窗口内。全语料扫描（`stopmusic(fadetime>0)` 后 6 行内出现 `musicvolume`，剔除中间夹阻塞命令或换曲 `playMusic` 的序列）仅两处干净命中：

- `activities/act43side/level_act43side_07_end.txt` 271-272 行：`[stopmusic(fadetime=2)]` 下一行紧跟 `[musicvolume(volume=0.2, fadetime=2)]` —— gap 最小的直接命中：修复后停止被取消，BGM 不再淡到 0 停播，而是从当前淡出音量转向 0.2 继续播。
- `obt/main/level_main_15-16_beg.txt` 91-93 行：`[stopmusic(fadetime=0.5)]` → `[StopSound(channel="d", fadetime=0.5)]`（非阻塞）→ `[musicvolume(volume=0.2, fadetime=2)]` —— 0.5s 短淡出窗口内的命中。

其余近似序列（如 `activities/act15mini/level_act15mini_st01.txt` 625/630 行、`activities/act19side/level_act19side_03_beg.txt` 393/397 行、`obt/main/level_main_09-07_beg.txt` 212/218 行）中间夹了阻塞的 `[Blocker(fadetime≥1, block=true)]` / `[Delay]` 或换曲 `[playMusic]`，`musicvolume` 到达时淡出已结束或通道已被替换，不在本修复的窗口内。

窗口内的其余交互分支（同曲 `playmusic` 短路取消淡出、无打断时正常停止并释放通道）语料 0 命中，属前瞻对齐，由单测锁定：`tests/audio.spec.ts` 的 `HtmlStoryAudio musicvolume during a stopmusic fade` 三个用例（取消停止并重定向渐变 / 无打断时正常停止且之后 no-op / 同曲 playmusic 短路瞬时重定向）。

## 测试

- `pnpm test`：20 个文件 225 个用例全部通过（基线 222 + 新增 3）。
- `pnpm exec vue-tsc -b` 通过。
- `pnpm exec eslint src/widgets/StoryPlayer/engine/audio.ts tests/audio.spec.ts` 通过。

注：`stopMusic`/`playMusic` 的完整对齐（如 crossfade 时序、同曲续播的其余细节）由并行的 stopmusic/playmusic PR 负责；本 PR 只动 audio.ts 中与「淡出期间可寻址 + 音量命令取消停止」直接相关的最小部分。
