### PR TITLE
fix(story-player): playmusic crossfade 改为串行两段并修正 delay 语义

### DIFF
--- a/src/widgets/StoryPlayer/engine/audio.ts
+++ b/src/widgets/StoryPlayer/engine/audio.ts
@@ -62,23 +62,47 @@ export class HtmlStoryAudio implements StoryAudio {
     if (!mainUrl) return;
 
     const introUrl = input.intro ? this.resolveAudioUrl(input.intro) : null;
-    const identity = `${introUrl ?? ""}\n${mainUrl}`;
+    // Native provenance: `IAudioInfo.IsSameAudio` (interface thunk, slot 0)
+    // compares the (intro, loop) asset-name pair with
+    // `StringComparison.OrdinalIgnoreCase`, so the same-track short-circuit is
+    // case-insensitive. The resolved URL pair is the web-side identity
+    // stand-in, hence the lowercase normalization.
+    const identity = `${(introUrl ?? "").toLowerCase()}\n${mainUrl.toLowerCase()}`;
     this.musicBaseVolume = input.volume;
     if (this.musicAudio?.identity === identity) {
       this.setVolume(this.musicAudio, input.volume);
       return;
     }
 
+    // Native provenance: `AudioManager._PlayAudio<MusicParam>` (2.7.61 build
+    // 2761, VA 0x18458cc30) performs the channel switch synchronously: the
+    // outgoing MUSIC channel is removed from the channel map, renamed to
+    // `<name>_CROSSFADING_<id>`, and `Stop(crossfade, linear)` starts its
+    // fade-out immediately over [0, crossfade]; the incoming channel starts
+    // silent and `TweenVolume(volume, crossfade, delay + crossfade, linear)`
+    // fades it in over [delay+crossfade, delay+2*crossfade]. The two fades are
+    // strictly sequential (total delay + 2*crossfade) and `delay` never
+    // postpones the outgoing fade-out. Detaching `musicAudio` up front is the
+    // web stand-in for the native channel rename: commands landing while the
+    // successor is still loading target the successor's booked volume, not the
+    // already-fading outgoing track.
     const requestId = ++this.musicRequestId;
-    if (input.delayMs > 0)
-      await new Promise((resolve) => setTimeout(resolve, input.delayMs));
+    const previous = this.musicAudio;
+    const crossfade = previous !== null && input.crossfadeMs > 10;
+    if (previous) {
+      this.musicAudio = null;
+      if (crossfade) void this.fadeAndStop(previous, input.crossfadeMs);
+      else this.stopPlayback(previous);
+    }
+
+    const startDelayMs = input.delayMs + (crossfade ? input.crossfadeMs : 0);
+    if (startDelayMs > 0)
+      await new Promise((resolve) => setTimeout(resolve, startDelayMs));
     if (this.destroyed || requestId !== this.musicRequestId) return;
 
     const next = await this.createPlayback(introUrl ?? mainUrl, identity);
     if (!next || this.destroyed || requestId !== this.musicRequestId) return;
 
-    const previous = this.musicAudio;
-    const crossfade = previous !== null && input.crossfadeMs > 10;
     this.musicAudio = next;
     const instance = await this.playPlayback(next, {
       complete: introUrl
@@ -101,13 +125,10 @@ export class HtmlStoryAudio implements StoryAudio {
       instance,
       this.musicAudio === next,
     );
+    // Fade-in leg of the sequential crossfade: playback just started silent
+    // after the (delay+crossfade) wait, ramp to the booked volume from here.
     if (claimed && crossfade)
       void this.fadeVolume(next, this.musicBaseVolume, input.crossfadeMs);
-
-    if (previous) {
-      if (crossfade) void this.fadeAndStop(previous, input.crossfadeMs);
-      else this.stopPlayback(previous);
-    }
   }
 
   async stopMusic(fadeMs: number): Promise<void> {

--- a/tests/audio.spec.ts
+++ b/tests/audio.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HtmlStoryAudio } from "../src/widgets/StoryPlayer/engine/audio";
 
@@ -34,10 +34,12 @@ class FakeInstance {
 class FakeSound {
   readonly instances: FakeInstance[] = [];
   private pending: Deferred<FakeInstance> | null = null;
+  private pendingOptions: { volume?: number } | undefined;
 
-  play(): Promise<FakeInstance> {
+  play(options?: { volume?: number }): Promise<FakeInstance> {
     const pending = defer<FakeInstance>();
     this.pending = pending;
+    this.pendingOptions = options;
     return pending.promise;
   }
 
@@ -46,6 +48,8 @@ class FakeSound {
     if (!pending) throw new Error("play() was not called");
     this.pending = null;
     const instance = new FakeInstance();
+    if (this.pendingOptions?.volume !== undefined)
+      instance.volume = this.pendingOptions.volume;
     this.instances.push(instance);
     pending.resolve(instance);
     return instance;
@@ -79,6 +83,20 @@ async function flush(): Promise<void> {
 }
 
 const context = { linkMap: {}, script: [] } satisfies Context;
+
+/** Start a non-crossfading music track and hand back its live fake instance. */
+async function startTrack(
+  audio: HtmlStoryAudio,
+  key: string,
+): Promise<FakeInstance> {
+  void audio.playMusic({ crossfadeMs: 0, delayMs: 0, key, volume: 1 });
+  await flush();
+  const sound = settleLoad();
+  await flush();
+  const instance = sound.settlePlay();
+  await flush();
+  return instance;
+}
 
 describe("HtmlStoryAudio", () => {
   beforeEach(() => {
@@ -143,5 +161,126 @@ describe("HtmlStoryAudio", () => {
 
     await audio.stopSound("c", 0);
     expect(instance.stopped).toBe(1);
+  });
+
+  it("short-circuits the same track regardless of URL letter case", async () => {
+    const audio = new HtmlStoryAudio(context);
+    void audio.playMusic({
+      crossfadeMs: 0,
+      delayMs: 0,
+      key: "https://example.com/Audio/Bgm.ogg",
+      volume: 0.5,
+    });
+
+    await flush();
+    const sound = settleLoad();
+    await flush();
+    const instance = sound.settlePlay();
+    await flush();
+    expect(instance.volume).toBe(0.5);
+
+    void audio.playMusic({
+      crossfadeMs: 400,
+      delayMs: 0,
+      key: "https://example.com/audio/bgm.OGG",
+      volume: 0.8,
+    });
+    await flush();
+
+    // Same asset pair under OrdinalIgnoreCase: instant volume set, no reload,
+    // no outgoing fade (native `_PlayAudio` branch (a)).
+    expect(instance.volume).toBe(0.8);
+    expect(loads.length).toBe(0);
+    expect(instance.stopped).toBe(0);
+  });
+
+  describe("playMusic crossfade scheduling", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({
+        toFake: ["performance", "requestAnimationFrame", "setTimeout", "Date"],
+      });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("runs the outgoing fade immediately and the incoming fade after delay+crossfade", async () => {
+      const audio = new HtmlStoryAudio(context);
+      const first = await startTrack(audio, "a");
+      expect(first.stopped).toBe(0);
+
+      const switching = audio.playMusic({
+        crossfadeMs: 400,
+        delayMs: 1000,
+        key: "b",
+        volume: 1,
+      });
+      await flush();
+
+      // Outgoing fade-out spans [0, crossfade] and starts at once; the delay
+      // never postpones it (native `Stop(crossfade, linear)` on the renamed
+      // `_CROSSFADING_` channel).
+      vi.advanceTimersByTime(200);
+      expect(first.volume).toBeGreaterThan(0);
+      expect(first.volume).toBeLessThan(1);
+
+      // Incoming track waits out delay + crossfade before it even loads:
+      // fade-in spans [delay+crossfade, delay+2*crossfade].
+      expect(loads.length).toBe(0);
+
+      vi.advanceTimersByTime(201);
+      await flush();
+      expect(first.volume).toBe(0);
+      expect(first.stopped).toBe(1);
+
+      vi.advanceTimersByTime(999);
+      await flush();
+      expect(loads.length).toBe(1);
+      const secondSound = settleLoad();
+      await flush();
+      const second = secondSound.settlePlay();
+      await flush();
+      expect(second.volume).toBe(0);
+
+      // First 16ms frame past t=1800 lands at 1808 (frames sit on 16ms
+      // boundaries), so advance past it to complete the fade-in.
+      vi.advanceTimersByTime(500);
+      expect(second.volume).toBeCloseTo(1);
+      expect(second.stopped).toBe(0);
+
+      await switching;
+    });
+
+    it("cuts the outgoing track immediately when crossfade is at or below the 10ms threshold", async () => {
+      const audio = new HtmlStoryAudio(context);
+      const first = await startTrack(audio, "a");
+
+      const switching = audio.playMusic({
+        crossfadeMs: 0,
+        delayMs: 500,
+        key: "b",
+        volume: 0.7,
+      });
+      await flush();
+
+      // Native branch (c): `Stop(~0)` is an immediate cut, not postponed by
+      // the incoming track's delay.
+      expect(first.stopped).toBe(1);
+      expect(loads.length).toBe(0);
+
+      vi.advanceTimersByTime(500);
+      await flush();
+      expect(loads.length).toBe(1);
+      const secondSound = settleLoad();
+      await flush();
+      const second = secondSound.settlePlay();
+      await flush();
+
+      // No fade-in: the incoming track starts directly at its volume.
+      expect(second.volume).toBeCloseTo(0.7);
+
+      await switching;
+    });
   });
 });


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `playmusic` 命令移植中的可修复行为差异(3 项)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的 IDA 反编译复核,关键结论在下文直接给出,不依赖外部文档。

## 背景:native 的 playmusic 换曲机制(2.7.61 / build 2761 IDA 复核)

- executor `Torappu.AVG.CommonExecutors._ExecutePlayMusicCommand`(VA `0x183e6e1e0`):读 `key`/`volume`/`delay`/`intro`/`crossfade` 五参数(`crossfade` 默认 `0.40000001`,即 2.7.61 的 `DEFAULT.crossFadeDuration=0.4`),末尾**同步调 finishCb**,永不阻塞命令循环。
- 下游 `AudioManager._PlayAudio<MusicParam>`(VA `0x18458cc30`)四分支:
  - **(a) 同曲短路**:`!forceReplay && IAudioInfo.IsSameAudio`(接口 thunk slot 0,按 `(intro, loop)` 资产名二元组、`OrdinalIgnoreCase` 比较)→ `AudioChannel.set_volume`(VA `0x183edff50`)瞬时写音量并清淡出 tween,直接返回。
  - **(b) 换曲 crossfade>0.01**:旧 channel 从 channel map 摘除、改名 `原名_CROSSFADING_<id>`(2.7.61 实测后缀,2.7.51 为 `_<id>`),随即 `Stop(crossfade, linear)` 启动淡出——**淡出区间 `[0, crossfade]`,不受 delay 影响**;新 channel 以音量 0 起播并 `TweenVolume(volume, crossfade, delay + crossfade, linear)`——**起播与淡入区间 `[delay+crossfade, delay+2*crossfade]`**。两段淡变**严格串行不重叠**,换曲总时长 `delay + 2*crossfade`。
  - **(c) 换曲 crossfade≤0.01**:旧曲 `Stop(≈0)` 瞬停,新曲直接给 `volume`,无 fade-in。
  - **(d) channel 首次出现**:同 (c) 直接给 volume。
- `delay` 语义:crossfade 分支新曲起播/淡入被推迟 `delay + crossfade`;非 crossfade 分支 delay 仅推迟引擎层起播;两种情况下**旧曲淡出/瞬停都在命令执行时立即发生**。

## 修复内容

### 1. crossfade 从「并行重叠」改为「严格串行两段」(P1,差异清单 #1)

- **native 行为**:旧曲 `[0, crossfade]` 淡出 → 新曲 `[delay+crossfade, delay+2*crossfade]` 起播+淡入,总时长 `delay+2*crossfade`,换曲有明确先后。
- **前端问题**:`engine/audio.ts` 的 `playMusic` 中新曲加载起播后立即从 0 淡入 `crossfadeMs`,旧曲同时 `fadeAndStop`,两曲混叠。
- **修复**:旧曲的淡出(或 crossfade≤10ms 时的瞬停)提前到命令执行时立即启动;新曲在 crossfade 分支推迟 `delayMs + crossfadeMs` 后才加载起播(以音量 0 起播),随后用 `crossfadeMs` 线性淡入到目标音量。两段淡变不再重叠。

### 2. `delay` 不再推迟旧曲淡出;新曲起播补上 `+crossfade`(P2,差异清单 #3)

- **native 行为**:旧曲淡出立即开始,不受 delay 影响;crossfade 分支新曲起播/淡入延迟为 `delay + crossfade`;非 crossfade 分支 delay 仅推迟引擎层起播。
- **前端问题**:`delayMs` 推迟的是整条流水线——包括旧曲淡出的启动。
- **修复**:随修复 1 一并落地——旧曲处理移到 delay 等待之前立即执行;新曲等待时长改为 `delayMs + (crossfade ? crossfadeMs : 0)`,非 crossfade 分支维持仅 `delayMs`(对应 native (c)/(d))。

### 3. 同曲短路判据改为大小写不敏感(P2,差异清单 #4)

- **native 行为**:`IsSameAudio` 按 `(intro, loop)` 资产名二元组做 `StringComparison.OrdinalIgnoreCase` 比较。
- **前端问题**:比较解析后的 URL 字符串对,大小写敏感。
- **修复**:identity(intro+loop 解析后 URL 对)统一 `toLowerCase()` 后比较,对齐 OrdinalIgnoreCase。

### 跳过项(与 review 结论一致)

- **#2(P1)stopmusic 淡出期间同曲 playmusic 应取消停止**:修复点在 `stopMusic` 淡出期间保留 channel 引用(impl-review-stopmusic 差异 #1),属 stopmusic 命令范围且与并行修复耦合,本 PR 不动 `stopMusic`。
- **#5(P2)缺资产/key 空的前端 warn**:review 结论「前端诊断增强,可保留」。
- **#6/#9(P3)负值钳位与 volume 不 clamp**:review 结论「行为等价/一致,无需改」。
- **#7(P3)intro→loop 预载消除一帧间隙 / #8(P3)rAF 后台暂停**:可选优化与 web 环境固有,不在本次最小 diff 范围。

改动收敛在 `playMusic` 一条路径内;`stopMusic`/`setMusicVolume`/`playSound` 等共享函数未动。`musicAudio` 在换曲加载窗口前置空是对 native「旧 channel 摘除改名、新 channel 同步入 map」的 web 对应(期间 musicvolume 落到已记账的 `musicBaseVolume`,stopmusic 通过 requestId 取消挂起播放),已在代码注释中标明 provenance。

## 验证用剧情文件

生产剧情文件位于本地 `torappu/storage/asset/gamedata/latest/story`(命令名在语料中混用 `PlayMusic`/`playMusic`/`playmusic` 拼写,解析层统一小写):

- **修复 1 + 2(串行 crossfade + delay 语义)**:`obt/main/level_main_01-07_end.txt`
  - 第 2 行 `[PlayMusic(intro="$chernormal_intro", key="$chernormal_loop", volume=0.8, crossfade=1.5, delay=0.5)]`:首个音乐,无旧曲 → crossfade 不生效,delay 仅推迟新曲起播。
  - 第 89 行 `[PlayMusic(intro="$calamity_intro", key="$calamity_loop", volume=0.8, crossfade=1.5, delay=0.5)]`:chernormal→calamity 换曲 → 旧曲淡出应立即开始(0–1.5s),新曲 2.0s 才起播、2.0–3.5s 淡入,总时长 3.5s。
- **修复 1(无 delay 的串行换曲)**:`obt/main/level_main_00-07_end.txt` 第 49 行 `[PlayMusic(intro="$calamity_intro", key="$calamity_loop", volume=1, crossfade=1.5)]`:escape→calamity 换曲 → 旧曲淡出 [0, 1.5s]、新曲淡入 [1.5s, 3s],期间不应出现两曲同时可闻。
- **修复 3(大小写不敏感同曲短路)**:语料 0 命中(音频键均为 `$xxx` 变量,拼写大小写一致)——前瞻对齐,由单测锁定:`tests/audio.spec.ts` 的 `short-circuits the same track regardless of URL letter case`。

## 测试

- `pnpm test`:20 个文件 225 个用例全部通过(基线 222 + 新增 3:同曲大小写短路、串行 crossfade 时序(旧曲立即淡出/新曲 delay+crossfade 后静音起播再淡入)、crossfade≤10ms 瞬切不受 delay 推迟)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint src/widgets/StoryPlayer/engine/audio.ts tests/audio.spec.ts`:通过。
