### PR TITLE
fix(story-player): stopmusic 淡出期间保留 BGM 通道使停止可被取消

### DIFF
--- a/src/widgets/StoryPlayer/engine/audio.ts
+++ b/src/widgets/StoryPlayer/engine/audio.ts
@@ -11,10 +11,25 @@ function nowMs(): number {
   return Date.now();
 }
 
+/**
+ * Native provenance: `AudioChannel.Stop` (VA 0x183ededf0, 2.7.61) tweens only
+ * when |fadeDuration| > 0.0099999998 seconds; anything shorter calls `_Stop()`
+ * immediately. Web adaptation: the threshold is applied in whole ms.
+ */
+const STOP_INSTANT_FADE_MS = 10;
+
 interface ActivePlayback {
   identity: string;
   instance: IMediaInstance | null;
   sound: Sound;
+  /**
+   * Generation of the volume tween currently driving this playback. Native
+   * provenance: `AudioChannel` keeps a single tween slot — a new
+   * `TweenVolume`/`set_volume` replaces the running tween instead of stacking
+   * on top of it. Every new fade or instant set bumps the counter; an older
+   * rAF loop aborts as soon as it finds itself stale.
+   */
+  fadeGeneration: number;
 }
 
 export class HtmlStoryAudio implements StoryAudio {
@@ -22,6 +37,18 @@ export class HtmlStoryAudio implements StoryAudio {
   private destroyed = false;
   private musicAudio: ActivePlayback | null = null;
   private musicRequestId = 0;
+  /**
+   * Native provenance: `AudioChannel.Stop` (VA 0x183ededf0, 2.7.61) sets
+   * `m_stopWhenTweenEnd = 1` and leaves the channel registered for the whole
+   * fade — `get_isPlaying` (VA 0x183edf9f0) stays true and only
+   * `AudioManager.Update` recycling a `!isPlaying` channel removes it. Web
+   * adaptation: while this flag is set, `musicAudio` is still handed out so a
+   * `musicvolume` (cancels via `AudioChannel.TweenVolume`, VA 0x183edef70,
+   * which clears the flag) or a same-track `playmusic` (cancels via
+   * `AudioChannel.set_volume`, VA 0x183edff50, which clears the tween so the
+   * flag is never consumed) can still cancel the pending stop.
+   */
+  private musicStopPending = false;
   /**
    * Native provenance: `Torappu.AVG.CommonExecutors._ExecutePlayMusicCommand`,
    * `_ExecuteMusicVolumeCommand`, `_ExecutePlaySoundCommand`,
@@ -48,6 +75,7 @@ export class HtmlStoryAudio implements StoryAudio {
 
     this.stopPlayback(this.musicAudio);
     this.musicAudio = null;
+    this.musicStopPending = false;
 
     for (const sound of this.soundChannels.values()) this.stopPlayback(sound);
     this.soundChannels.clear();
@@ -65,6 +93,12 @@ export class HtmlStoryAudio implements StoryAudio {
     const identity = `${introUrl ?? ""}\n${mainUrl}`;
     this.musicBaseVolume = input.volume;
     if (this.musicAudio?.identity === identity) {
+      // Native provenance: `AudioManager._PlayAudio` same-asset short-circuit
+      // (a) → `AudioChannel.set_volume` (VA 0x183edff50): clears the running
+      // tween, so a stopmusic fade in progress is canceled — the pending-stop
+      // flag is never consumed and the track jumps to the new volume and
+      // keeps playing (no reload, no intro replay).
+      this.musicStopPending = false;
       this.setVolume(this.musicAudio, input.volume);
       return;
     }
@@ -115,8 +149,30 @@ export class HtmlStoryAudio implements StoryAudio {
     const current = this.musicAudio;
     if (!current) return;
 
+    // Native provenance: `AudioManager.StopMusic` (VA 0x181980770) →
+    // `AudioChannel.Stop` (VA 0x183ededf0, 2.7.61): a fade longer than 0.01s
+    // schedules a linear tween to zero with `m_stopWhenTweenEnd = 1` while the
+    // channel STAYS registered (`get_isPlaying` keeps reporting true); only
+    // when the tween finishes uncanceled does `_Stop()` run and
+    // `AudioManager.Update` recycle the channel. The web port keeps
+    // `musicAudio` alive during the fade so `musicvolume` / a same-track
+    // `playmusic` can still cancel the stop (see `musicStopPending`).
+    // |fadetime| <= 0.01 maps to `_Stop()` immediately.
+    if (fadeMs <= STOP_INSTANT_FADE_MS) {
+      this.musicAudio = null;
+      this.musicStopPending = false;
+      this.stopPlayback(current);
+      return;
+    }
+
+    this.musicStopPending = true;
+    const fadedOut = await this.fadeVolume(current, 0, fadeMs);
+    if (!fadedOut || !this.musicStopPending || this.musicAudio !== current)
+      return;
+
+    this.musicStopPending = false;
     this.musicAudio = null;
-    await this.fadeAndStop(current, fadeMs);
+    this.stopPlayback(current);
   }
 
   async playSound(input: PlaySoundInput): Promise<void> {
@@ -207,11 +263,16 @@ export class HtmlStoryAudio implements StoryAudio {
 
   async setMusicVolume(volume: number, fadeMs: number): Promise<void> {
     // Native provenance: `CommonExecutors._ExecuteMusicVolumeCommand` and
-    // `AudioChannel.TweenVolume`. MUSIC base volume outlives a playback instance,
-    // so retain it while PIXI is still loading.
+    // `AudioChannel.TweenVolume`. MUSIC base volume outlives a playback
+    // instance, so retain it while PIXI is still loading.
     this.musicBaseVolume = volume;
     if (!this.musicAudio) return;
 
+    // Native provenance: `AudioChannel.TweenVolume` (VA 0x183edef70) clears
+    // `m_stopWhenTweenEnd` on entry, so a musicvolume landing during a
+    // stopmusic fade cancels the pending stop: the new tween replaces the
+    // fade-to-zero and the track keeps playing toward the new volume.
+    this.musicStopPending = false;
     await this.fadeVolume(this.musicAudio, volume, fadeMs);
   }
 
@@ -223,41 +284,48 @@ export class HtmlStoryAudio implements StoryAudio {
     if (!sound) return null;
 
     return {
+      fadeGeneration: 0,
       identity,
       instance: null,
       sound,
     };
   }
 
+  /**
+   * Tween this playback's volume, replacing any tween already running on it
+   * (native `AudioChannel` keeps a single tween slot). Resolves false when
+   * superseded by a newer fade, an instant `set_volume`, or a stop — the
+   * caller must then leave the playback to whoever superseded it.
+   */
   private async fadeVolume(
     playback: ActivePlayback,
     targetVolume: number,
     durationMs: number,
-  ): Promise<void> {
+  ): Promise<boolean> {
+    const generation = ++playback.fadeGeneration;
     const startVolume = this.getVolume(playback);
     if (durationMs <= 0) {
       this.setVolume(playback, targetVolume);
-      return;
+      return true;
     }
 
     const start = nowMs();
 
-    await new Promise<void>((resolve) => {
+    return await new Promise<boolean>((resolve) => {
       const tick = () => {
-        if (this.destroyed) {
-          resolve();
+        if (this.destroyed || playback.fadeGeneration !== generation) {
+          resolve(false);
           return;
         }
 
         const elapsed = nowMs() - start;
         const progress = Math.min(1, elapsed / durationMs);
-        this.setVolume(
-          playback,
-          startVolume + (targetVolume - startVolume) * progress,
-        );
+        if (playback.instance)
+          playback.instance.volume =
+            startVolume + (targetVolume - startVolume) * progress;
 
         if (progress >= 1) {
-          resolve();
+          resolve(true);
           return;
         }
 
@@ -300,6 +368,10 @@ export class HtmlStoryAudio implements StoryAudio {
   }
 
   private setVolume(playback: ActivePlayback, volume: number): void {
+    // Native provenance: `AudioChannel.set_volume` (VA 0x183edff50) clears
+    // the running tween. Bumping the generation aborts any in-flight rAF
+    // fade loop on this playback.
+    playback.fadeGeneration += 1;
     if (playback.instance) playback.instance.volume = volume;
   }
 
@@ -325,6 +397,8 @@ export class HtmlStoryAudio implements StoryAudio {
   private stopPlayback(playback: ActivePlayback | null): void {
     if (!playback) return;
 
+    // Invalidate any fade loop still targeting this playback (see setVolume).
+    playback.fadeGeneration += 1;
     playback.instance?.stop();
     playback.instance = null;
   }

--- a/tests/audio.spec.ts
+++ b/tests/audio.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HtmlStoryAudio } from "../src/widgets/StoryPlayer/engine/audio";
 
@@ -80,6 +80,21 @@ async function flush(): Promise<void> {
 
 const context = { linkMap: {}, script: [] } satisfies Context;
 
+/** Play a track to completion and hand back its started instance. */
+async function startMusic(
+  audio: HtmlStoryAudio,
+  key = "k",
+  volume = 1,
+): Promise<FakeInstance> {
+  void audio.playMusic({ crossfadeMs: 0, delayMs: 0, key, volume });
+  await flush();
+  const sound = settleLoad();
+  await flush();
+  const instance = sound.settlePlay();
+  await flush();
+  return instance;
+}
+
 describe("HtmlStoryAudio", () => {
   beforeEach(() => {
     loads.length = 0;
@@ -143,5 +158,149 @@ describe("HtmlStoryAudio", () => {
 
     await audio.stopSound("c", 0);
     expect(instance.stopped).toBe(1);
+  });
+});
+
+describe("HtmlStoryAudio stopmusic cancelable stop", () => {
+  /**
+   * Native provenance: `AudioChannel.Stop` (VA 0x183ededf0, 2.7.61) keeps the
+   * MUSIC channel registered for the whole fade (`m_stopWhenTweenEnd = 1`),
+   * so a `musicvolume` (`AudioChannel.TweenVolume` clears the flag) or a
+   * same-track `playmusic` (`AudioChannel.set_volume` clears the tween) can
+   * cancel a pending stop; only an uncanceled fade end releases the channel.
+   */
+  let frames: Array<(time: number) => void>;
+  let fakeNow: number;
+  let rafSpy: ReturnType<typeof vi.spyOn>;
+  let nowSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    loads.length = 0;
+    frames = [];
+    fakeNow = 0;
+    rafSpy = vi
+      .spyOn(globalThis, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        frames.push(callback as FrameRequestCallback);
+        return frames.length;
+      });
+    nowSpy = vi.spyOn(performance, "now").mockImplementation(() => fakeNow);
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+    nowSpy.mockRestore();
+  });
+
+  /** Advance the faked clock by `dt` ms and run one animation frame. */
+  function flushFrame(dt: number): void {
+    fakeNow += dt;
+    const pending = [...frames];
+    frames.length = 0;
+    for (const callback of pending) callback(fakeNow);
+  }
+
+  it("a musicvolume during the stopmusic fade cancels the stop", async () => {
+    const audio = new HtmlStoryAudio(context);
+    const instance = await startMusic(audio);
+
+    void audio.stopMusic(2000);
+    await flush();
+    flushFrame(500);
+    expect(instance.volume).toBeCloseTo(0.75);
+    expect(instance.stopped).toBe(0);
+
+    const volumePromise = audio.setMusicVolume(0.8, 1000);
+    await flush();
+    // The volume tween replaced the fade-to-zero (native single tween slot).
+    flushFrame(1000);
+    await volumePromise;
+    await flush();
+    expect(instance.volume).toBeCloseTo(0.8);
+
+    flushFrame(2000);
+    await flush();
+    expect(instance.stopped).toBe(0);
+    expect(instance.volume).toBeCloseTo(0.8);
+  });
+
+  it("a same-track playmusic during the stopmusic fade cancels the stop without reloading", async () => {
+    const audio = new HtmlStoryAudio(context);
+    const instance = await startMusic(audio);
+
+    void audio.stopMusic(2000);
+    await flush();
+    flushFrame(400);
+    expect(instance.volume).toBeCloseTo(0.8);
+
+    void audio.playMusic({ crossfadeMs: 0, delayMs: 0, key: "k", volume: 0.5 });
+    await flush();
+    // Native `_PlayAudio` short-circuit → `set_volume`: instant jump, the
+    // track keeps playing, and no new load is started.
+    expect(instance.volume).toBe(0.5);
+    expect(loads.length).toBe(0);
+
+    flushFrame(2000);
+    await flush();
+    expect(instance.stopped).toBe(0);
+    expect(instance.volume).toBe(0.5);
+  });
+
+  it("an uncanceled stopmusic fade stops the track and releases the channel", async () => {
+    const audio = new HtmlStoryAudio(context);
+    void audio.playMusic({ crossfadeMs: 0, delayMs: 0, key: "k", volume: 1 });
+    await flush();
+    const sound = settleLoad();
+    await flush();
+    const instance = sound.settlePlay();
+    await flush();
+
+    void audio.stopMusic(2000);
+    await flush();
+    flushFrame(2000);
+    await flush();
+    expect(instance.stopped).toBe(1);
+    expect(instance.volume).toBeCloseTo(0);
+
+    // Channel recycled: a later musicvolume cannot resurrect it, and a
+    // same-track playmusic no longer short-circuits — a fresh playback is
+    // created (served from the sound cache) and `play()` runs again.
+    await audio.setMusicVolume(0.9, 0);
+    expect(instance.volume).toBeCloseTo(0);
+
+    void audio.playMusic({ crossfadeMs: 0, delayMs: 0, key: "k", volume: 1 });
+    await flush();
+    const replayed = sound.settlePlay();
+    await flush();
+    expect(replayed).not.toBe(instance);
+    expect(replayed.stopped).toBe(0);
+  });
+
+  it("treats a fadetime at or below the native 0.01s threshold as an instant stop", async () => {
+    const audio = new HtmlStoryAudio(context);
+    const instance = await startMusic(audio);
+
+    await audio.stopMusic(10);
+    expect(instance.stopped).toBe(1);
+    expect(frames.length).toBe(0);
+  });
+
+  it("a different-track playmusic during the stopmusic fade takes over the old playback", async () => {
+    const audio = new HtmlStoryAudio(context);
+    const instance = await startMusic(audio, "a");
+
+    void audio.stopMusic(2000);
+    await flush();
+    flushFrame(500);
+
+    void audio.playMusic({ crossfadeMs: 0, delayMs: 0, key: "b", volume: 1 });
+    await flush();
+    const sound = settleLoad();
+    await flush();
+    const next = sound.settlePlay();
+    await flush();
+
+    expect(instance.stopped).toBe(1);
+    expect(next.stopped).toBe(0);
   });
 });


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `stopmusic` 命令移植中的行为差异(差异清单 P1×2 + P2×1)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的逆向分析(IDA 反编译复核),关键结论已在下文直接给出,不依赖外部文档。

## 背景:native 的 stopmusic 机制(2.7.61 逆向结论)

- 执行器 `Torappu.AVG.CommonExecutors::_ExecuteStopMusicCommand`(VA `0x183e6ee70`):读 `fadetime`(默认 0.0)→ `AudioManager.StopMusic(fadetime)` → **同步回调 finishCb,永远非阻塞**。
- `AudioManager.StopMusic`(VA `0x181980770`):取 `"MUSIC"` channel,null 时整条命令**静默 no-op**;否则 `AudioChannel.Stop(fadeDuration, linear)`。
- `AudioChannel.Stop`(VA `0x183ededf0`):`fabs(duration) > 0.0099999998` 秒才安排 tween(`m_tweenTargetVolume = 0`,linear),并**强制 `m_stopWhenTweenEnd = 1`**;否则 `_Stop()`(VA `0x183edf660`)瞬停。即 `|fadetime| ≤ 0.01s`(含 0)→ 瞬停。
- **停止是可取消的延迟回收**:淡出期间 channel 一直留在 `m_channels` 字典里,`get_isPlaying`(VA `0x183edf9f0`)保持 true;只有 tween 走完且未被取消时 `_Stop()` 才执行、channel 才被 `AudioManager.Update` 扫描回收。
- 两条取消路径:
  - `AudioChannel.TweenVolume`(VA `0x183edef70`)第 3 条语句即清 `m_stopWhenTweenEnd`——淡出途中来一条 `musicvolume` 会把 pending stop 清掉,转为向新目标音量的普通渐变,曲子继续播;
  - `AudioChannel.set_volume`(VA `0x183edff50`)清 tween 但不清标志(标志永不消费)——淡出途中来一条**同曲** `playmusic`(`AudioManager._PlayAudio` 同资源短路分支 (a))瞬时跳到新音量、取消淡出、intro 不重播、曲子续播。

前端原实现的问题:入口 `engine/runtime.ts` 的 case 语义一致,但 `engine/audio.ts` 的 `stopMusic` 在**提交淡出的同一刻就把 `musicAudio` 置 null**——channel 过早摘除,导致淡出期间的 `musicvolume` 变 no-op(淡出继续到 0 并停)、同曲 `playmusic` 的短路判据失效而完整重新加载重播(intro 段重响,旧实例同时还在淡出)。

## 修复内容

均集中在 `src/widgets/StoryPlayer/engine/audio.ts`(`HtmlStoryAudio`),入口 `runtime.ts` 无需改动。

### 1. 淡出期间的 `musicvolume` 无法取消停止(P1)

- **native 行为**:channel 仍在 `m_channels`,`musicvolume` 命中 → `TweenVolume` 清 `m_stopWhenTweenEnd`,停止被取消,BGM 按新目标音量继续播。
- **前端原行为**:`musicAudio` 已置 null → `setMusicVolume` 只更新 `musicBaseVolume` 即 return,淡出继续到 0 并停。
- **修复**:`stopMusic` 淡出分支不再摘除 `musicAudio`,改为挂 `musicStopPending` 标志;`fadeVolume` 完成且标志未被清、通道未被接管时才置 null 并停播放。`setMusicVolume` 命中通道时清 `musicStopPending` 并接管 tween(转向新目标音量)。

### 2. 淡出期间的同曲 `playmusic` 变成重载重播(P1)

- **native 行为**:`_PlayAudio` 同资源短路分支 (a) → `set_volume` 瞬时跳新音量、清淡出、intro 不重播、曲子续播(即取消停止)。
- **前端原行为**:`musicAudio` 已 null → 同曲 identity 短路失效,完整重新加载重播(intro 重响),旧实例同时还在淡出。
- **修复**:同 #1 保留通道后短路判据自然恢复生效;短路分支内显式清 `musicStopPending` 并 `setVolume` 瞬跳(不重新加载、不重播 intro)。

### 3. 极短 fade 的分支阈值(P2)

- **native 行为**:`fabs(fadetime) ≤ 0.01s`(10ms)走 `_Stop()` 瞬停。
- **前端原行为**:`fadeMs ≤ 0` 才瞬停,`0 < fadeMs ≤ 10` 走一帧 rAF 的极短淡变。
- **修复**:新增 `STOP_INSTANT_FADE_MS = 10`,`stopMusic` 的 `fadeMs <= 10` 走瞬停分支。生产语料中最小非零 fadetime 为 0.1,此项为逐字对齐的前瞻修复。

### 共享影响面说明

`fadeVolume` 从 `Promise<void>` 改为 `Promise<boolean>`,并引入 `fadeGeneration`(对应 native `AudioChannel` 的**单 tween 槽**:新的 `TweenVolume`/`set_volume`/stop 会取代正在运行的淡出循环,旧循环立即中止)。该机制同时被以下共享路径复用,行为变化均为"被取代的淡出提前中止、不再与后来的音量写入互相打架",与 native 单 tween 槽语义一致:

- `playmusic` 换曲 crossfade(对新实例淡入、对旧实例 `fadeAndStop` 淡出);
- `stopsound` / `soundvolume`(`fadeAndStop` / `fadeVolume`)。

`playmusic` / `musicvolume` / `playsound` / `stopsound` 命令本身的参数语义不在本 PR 范围内。

### 按差异清单维持不变的条目

- `musicRequestId++` 取消 pending 加载(P3):web 异步加载竞态适配,保留。
- fade 用 rAF + `performance.now()`(P3):web 固有,可接受。
- `runtime.destroy()` 不主动停 BGM(P3):与 native `CommonExecutors.OnReset`(VA `0x183e6d2a0`)→ `_ResetAudio` 只清 SOUND channel 不停 BGM 的方向一致。

## 验证用剧情文件

生产剧情语料(本地 `torappu/storage/asset/gamedata/latest/story`,全量扫描 6000+ 处 stopmusic):

- **修复 1(musicvolume 取消停止)**:`activities/act43side/level_act43side_07_end.txt` 271-272 行 —— `[stopmusic(fadetime=2)]` 的**下一行**紧接 `[musicvolume(volume=0.2, fadetime=2)]`:musicvolume 确定落在 2 秒淡出内。修复前 BGM 淡到 0 消失;修复后停止被取消,BGM 转向 0.2 音量继续播。同结构案例另有 6 处(如 `obt/main/level_main_15-16_beg.txt` 91-93 行、`activities/act15mini/level_act15mini_st01.txt` 625-630 行)。
- **修复 2(同曲 playmusic 取消停止)**:`obt/main/level_main_09-16_end.txt` 311-314 行 —— `[stopmusic(fadetime=2)]` 后隔 `[Delay(time=1)]`(阻塞 1s < 2s 淡出),`[PlayMusic(intro="$darkness01_intro", key="$darkness01_loop")]` 与行 7 完全同曲,时间上确定落在淡出内:修复前 intro 段重响;修复后取消淡出续播。另见 `obt/memory/story_turdus_1_1.txt` 643-645 行(隔 1 行文本,同曲同 intro 重放)。全语料该模式共 24 处。
- **主路径回归(淡出完成后真正停掉并释放通道)**:`obt/roguelike/ro1/level_rogue1_entry.txt` 35 行 —— 文件末尾 `[stopmusic(fadetime=1)]`,其后无任何 BGM 命令,验证未被取消的淡出走完确实停播且通道释放(后续 musicvolume 不复活旧实例、同曲 playmusic 不再短路)。
- **瞬停与参数忽略**:`obt/main/level_main_06-07_beg.txt` 91 行 `[stopmusic(time=1)]` —— `time` 参数不读、`fadetime` 缺省 0 → 瞬停(native `GetFloat(param, "fadetime", 0.0)` 同样忽略 time)。
- **淡出中异曲 playmusic 接管**:`obt/main/level_main_05-07_beg.txt` 47-51 行 —— `stopmusic(fadetime=1)` 后 4 行内异曲 `PlayMusic(crossfade=1.5)`,验证旧实例被正确接管停止、不残留双声部(单测同步覆盖)。
- **修复 3(≤10ms 阈值)**:语料中 `fadetime ∈ (0, 0.01]` 为 0 命中(最小非零 0.1),**前瞻对齐,由单测锁定**:`tests/audio.spec.ts` 用例 "treats a fadetime at or below the native 0.01s threshold as an instant stop"。

## 测试

- `pnpm test`:20 个文件 **227** 个用例全部通过(基线 222 + 新增 5,新增用例位于 `tests/audio.spec.ts` 的 `HtmlStoryAudio stopmusic cancelable stop` 组:rAF/时钟打桩下分别验证 musicvolume 取消、同曲 playmusic 取消且零重新加载、未取消淡出停播+通道释放、10ms 阈值瞬停、异曲接管)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint src/widgets/StoryPlayer/engine/audio.ts tests/audio.spec.ts`:通过。
