### PR TITLE
fix(story-player): stopsound 淡出期间保留 sound channel，支持 soundvolume 取消与新 playsound 接管

### DIFF
--- a/src/widgets/StoryPlayer/engine/audio.ts
+++ b/src/widgets/StoryPlayer/engine/audio.ts
@@ -11,6 +11,13 @@ function nowMs(): number {
   return Date.now();
 }
 
+/**
+ * Native port: `AudioChannel.Stop` (VA 0x183ededf0, 2.7.61) takes the
+ * `_Stop()` branch when `fabs(fadetime) <= 0.01` seconds; anything longer
+ * tweens the volume to zero first (tween branch sets `m_stopWhenTweenEnd`).
+ */
+const stopChannelInstantThresholdMs = 10;
+
 interface ActivePlayback {
   identity: string;
   instance: IMediaInstance | null;
@@ -38,6 +45,15 @@ export class HtmlStoryAudio implements StoryAudio {
   private readonly soundRequestIds = new Map<string, number>();
   private readonly soundCache = new Map<string, Sound>();
   private readonly soundChannels = new Map<string, ActivePlayback>();
+  /**
+   * Web adaptation: per-channel epoch for `avgsound_` volume tweens. Bumping
+   * it supersedes an in-flight rAF fade loop, standing in for the native
+   * DOTween replacement in `AudioChannel.TweenVolume` (VA 0x183edef70) /
+   * `AudioChannel.Stop` — which is how a `soundvolume` landing during a
+   * stopsound fade cancels the stop (`m_stopWhenTweenEnd` is cleared).
+   *
+   */
+  private readonly soundFadeEpochs = new Map<string, number>();
 
   constructor(context: Context) {
     this.context = context;
@@ -53,6 +69,7 @@ export class HtmlStoryAudio implements StoryAudio {
     this.soundChannels.clear();
     this.soundBaseVolumes.clear();
     this.soundRequestIds.clear();
+    this.soundFadeEpochs.clear();
   }
 
   async playMusic(input: PlayMusicInput): Promise<void> {
@@ -140,6 +157,11 @@ export class HtmlStoryAudio implements StoryAudio {
 
     const prev = this.soundChannels.get(channel);
     if (prev) {
+      // Native port: `_ExecutePlaySoundCommand` -> `AudioChannel.PlayAudio`
+      // stops the previous instance of the channel immediately (`Stop(0)` ->
+      // `_Stop()`), so a new sound never overlaps a fading old one. The epoch
+      // bump also retires the old instance's in-flight stopsound fade loop.
+      this.bumpSoundFadeEpoch(channel);
       this.stopPlayback(prev);
       this.soundChannels.delete(channel);
     }
@@ -187,8 +209,41 @@ export class HtmlStoryAudio implements StoryAudio {
     const sound = this.soundChannels.get(channelName);
     if (!sound) return;
 
+    // Native port: `AudioChannel.Stop` (VA 0x183ededf0, 2.7.61). With
+    // `fabs(fadetime) <= 0.01` it calls `_Stop()` right away; a longer fade
+    // tweens volume to 0 with `m_stopWhenTweenEnd = 1`, and the channel stays
+    // registered in `AudioManager.m_channels` (still playing) until the tween
+    // completes — only then is it removed next `Update`. Keeping the map
+    // entry during the fade matches native: a `soundvolume` on the channel
+    // cancels the stop (`TweenVolume` clears `m_stopWhenTweenEnd`), and a
+    // following `playsound` cuts the fading instance short in `PlayAudio`.
+    if (fadeMs <= stopChannelInstantThresholdMs) {
+      this.bumpSoundFadeEpoch(channelName);
+      this.soundChannels.delete(channelName);
+      this.stopPlayback(sound);
+      return;
+    }
+
+    const epoch = this.bumpSoundFadeEpoch(channelName);
+    await this.fadeVolume(
+      sound,
+      0,
+      fadeMs,
+      () => this.soundFadeEpochs.get(channelName) !== epoch,
+    );
+    // The fade was cancelled by a soundvolume takeover, or the map entry was
+    // replaced by a new playsound (its instance was stopped there); keep the
+    // channel alive either way.
+    if (
+      this.destroyed ||
+      this.soundFadeEpochs.get(channelName) !== epoch ||
+      this.soundChannels.get(channelName) !== sound
+    )
+      return;
+
     this.soundChannels.delete(channelName);
-    await this.fadeAndStop(sound, fadeMs);
+    this.soundFadeEpochs.delete(channelName);
+    this.stopPlayback(sound);
   }
 
   async setSoundVolume(
@@ -202,7 +257,19 @@ export class HtmlStoryAudio implements StoryAudio {
     const sound = this.soundChannels.get(channelName);
     if (!sound) return;
 
-    await this.fadeVolume(sound, volume, fadeMs);
+    // Native port: `AudioChannel.TweenVolume` (VA 0x183edef70, 2.7.61) clears
+    // `m_stopWhenTweenEnd` as its third statement, so a `soundvolume` landing
+    // during a stopsound fade-out cancels the stop and the channel keeps
+    // playing toward the new volume (stopsound != soundvolume(0)). The epoch
+    // bump supersedes any older tween on this channel, matching the native
+    // tween replacement semantics.
+    const epoch = this.bumpSoundFadeEpoch(channelName);
+    await this.fadeVolume(
+      sound,
+      volume,
+      fadeMs,
+      () => this.soundFadeEpochs.get(channelName) !== epoch,
+    );
   }
 
   async setMusicVolume(volume: number, fadeMs: number): Promise<void> {
@@ -233,6 +300,10 @@ export class HtmlStoryAudio implements StoryAudio {
     playback: ActivePlayback,
     targetVolume: number,
     durationMs: number,
+    // Web adaptation: native volume tweens replace each other via DOTween;
+    // this optional probe lets a newer tween retire an in-flight rAF loop
+    // without touching the still-playing instance.
+    isCancelled?: () => boolean,
   ): Promise<void> {
     const startVolume = this.getVolume(playback);
     if (durationMs <= 0) {
@@ -244,7 +315,7 @@ export class HtmlStoryAudio implements StoryAudio {
 
     await new Promise<void>((resolve) => {
       const tick = () => {
-        if (this.destroyed) {
+        if (this.destroyed || isCancelled?.()) {
           resolve();
           return;
         }
@@ -293,6 +364,13 @@ export class HtmlStoryAudio implements StoryAudio {
 
   private soundChannelName(channel: string): string {
     return `avgsound_${channel}`;
+  }
+
+  /** Invalidate all in-flight volume tweens for the channel, return the new epoch. */
+  private bumpSoundFadeEpoch(channelName: string): number {
+    const epoch = (this.soundFadeEpochs.get(channelName) ?? 0) + 1;
+    this.soundFadeEpochs.set(channelName, epoch);
+    return epoch;
   }
 
   private getVolume(playback: ActivePlayback): number {

--- a/tests/audio.spec.ts
+++ b/tests/audio.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HtmlStoryAudio } from "../src/widgets/StoryPlayer/engine/audio";
 
@@ -78,6 +78,36 @@ async function flush(): Promise<void> {
   for (let index = 0; index < 8; index += 1) await Promise.resolve();
 }
 
+/** Drive a full playSound handshake and return its playing instance. */
+async function startSound(
+  audio: HtmlStoryAudio,
+  volume = 1,
+  /** A prior load is cached by URL, so a same-key replay reuses its FakeSound. */
+  reuse?: FakeSound,
+): Promise<{ instance: FakeInstance; sound: FakeSound }> {
+  void audio.playSound({
+    channel: "c",
+    delayMs: 0,
+    key: "k",
+    loop: true,
+    volume,
+  });
+  await flush();
+  const sound = reuse ?? settleLoad();
+  await flush();
+  const instance = sound.settlePlay();
+  await flush();
+  return { instance, sound };
+}
+
+/** Advance fake rAF frames (~16ms each), draining microtasks in between. */
+async function advanceFrames(frames: number): Promise<void> {
+  for (let index = 0; index < frames; index += 1) {
+    vi.advanceTimersByTime(16);
+    await flush();
+  }
+}
+
 const context = { linkMap: {}, script: [] } satisfies Context;
 
 describe("HtmlStoryAudio", () => {
@@ -142,6 +172,90 @@ describe("HtmlStoryAudio", () => {
     expect(instance.stopped).toBe(0);
 
     await audio.stopSound("c", 0);
+    expect(instance.stopped).toBe(1);
+  });
+});
+
+describe("HtmlStoryAudio stopsound fade (native AudioChannel.Stop tween branch)", () => {
+  beforeEach(() => {
+    loads.length = 0;
+    vi.useFakeTimers({
+      toFake: ["requestAnimationFrame", "cancelAnimationFrame", "performance"],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the channel registered during the fade and removes it when done", async () => {
+    const audio = new HtmlStoryAudio(context);
+    const { instance } = await startSound(audio);
+
+    void audio.stopSound("c", 1000);
+    await flush();
+    // Native: the channel stays in m_channels (still playing) while the
+    // stop tween runs; only the tween end triggers _Stop + removal.
+    expect(instance.stopped).toBe(0);
+
+    await advanceFrames(5);
+    expect(instance.volume).toBeGreaterThan(0);
+    expect(instance.volume).toBeLessThan(1);
+    expect(instance.stopped).toBe(0);
+
+    await advanceFrames(60);
+    expect(instance.stopped).toBe(1);
+
+    // The channel entry is gone after the fade: a second stop is a no-op.
+    await audio.stopSound("c", 0);
+    expect(instance.stopped).toBe(1);
+  });
+
+  it("soundvolume during the fade cancels the stop and keeps playing", async () => {
+    const audio = new HtmlStoryAudio(context);
+    const { instance } = await startSound(audio);
+
+    void audio.stopSound("c", 1000);
+    await advanceFrames(10);
+    expect(instance.volume).toBeGreaterThan(0);
+    expect(instance.volume).toBeLessThan(1);
+
+    // Native: TweenVolume clears m_stopWhenTweenEnd, cancelling the stop.
+    await audio.setSoundVolume("c", 0.6, 0);
+    await advanceFrames(70);
+    expect(instance.stopped).toBe(0);
+    expect(instance.volume).toBeCloseTo(0.6);
+
+    // The channel is still resolvable through the same name afterwards.
+    await audio.stopSound("c", 0);
+    expect(instance.stopped).toBe(1);
+  });
+
+  it("a new playsound during the fade cuts the fading instance short", async () => {
+    const audio = new HtmlStoryAudio(context);
+    const first = await startSound(audio);
+
+    void audio.stopSound("c", 1000);
+    await advanceFrames(10);
+
+    // Native: PlayAudio stops the previous channel instance immediately
+    // (Stop(0) -> _Stop()); the new sound owns the channel alone.
+    const second = await startSound(audio, 1, first.sound);
+    expect(first.instance.stopped).toBe(1);
+    expect(second.instance.stopped).toBe(0);
+
+    // The stale stop tween must not silence or unregister the new instance.
+    await advanceFrames(70);
+    expect(second.instance.stopped).toBe(0);
+    expect(second.instance.volume).toBe(1);
+  });
+
+  it("fadetime <= 0.01s stops instantly without a tween", async () => {
+    const audio = new HtmlStoryAudio(context);
+    const { instance } = await startSound(audio);
+
+    // Native: fabs(fadetime) <= 0.01 takes the _Stop() branch directly.
+    await audio.stopSound("c", 10);
     expect(instance.stopped).toBe(1);
   });
 });


### PR DESCRIPTION
## 背景：native 的 stopsound 语义（2.7.61 逆向结论）

以下结论来自对官服客户端（2.7.61 / build 2761，Unity IL2CPP）GameAssembly.dll 的 IDA 反编译复核：

- executor `Torappu.AVG.CommonExecutors::_ExecuteStopSoundCommand`（VA `0x183e6ef80`）：`key` 默认 null、`channel` 默认取 key 值、`fadetime` 默认 0.0；channel 名经 `_GenAVGSoundChannelName`（`String.Format("avgsound_{0}", …)`，VA `0x183e6f410`）拼接后交给 `AudioManager.StopChannel(name, fadetime)`（VA `0x181980410`），channel 不存在时静默 no-op，非阻塞、同步回调 finishCb，并从 `m_allSoundChannels` 跟踪集合移除。
- 关键在 `AudioChannel.Stop`（VA `0x183ededf0`）：native 把停止建模为**可取消的延迟回收**——
  - `fabs(fadetime) <= 0.01` 秒：走 `_Stop()` 瞬停；
  - 更长 fadetime：tween 音量到 0（linear）并置 `m_stopWhenTweenEnd = 1`，**淡出期间 channel 仍留在 `AudioManager.m_channels`、`isPlaying` 仍为 true**，直到 tween 完成才 `_Stop()` 并在下一帧 `Update` 中移除还池；
  - `AudioChannel.TweenVolume`（VA `0x183edef70`）第 3 条语句清 `m_stopWhenTweenEnd`——即淡出途中来一条 `soundvolume` 会**取消这次停止**，channel 改向新音量渐变继续播（`stopsound` ≠ `soundvolume(volume=0)`）；
  - 淡出途中来同 channel 的 `playsound`：`PlayAudio` 内 `Stop(0)` → `_Stop()` 瞬停旧实例让位，新音效独占 channel，不重叠。

前端原先在提交淡出的同一刻就 `soundChannels.delete`，导致淡出期间 `soundvolume` 无法作用到该实例、紧接的同 channel `playsound` 与仍在淡出的旧实例重叠。

## 修复内容

改动收敛在 `src/widgets/StoryPlayer/engine/audio.ts`（sound 侧独立实现，不动 music 通道体系）：

| # | 严重度 | 差异 | native 行为 | 前端行为（修复前） | 改法 |
| --- | --- | --- | --- | --- | --- |
| 1 | P1 | 淡出期间的 `soundvolume` | channel 仍在 `m_channels`，`TweenVolume` 清 `m_stopWhenTweenEnd`，停止被取消，音效向新音量渐变继续播 | `soundChannels` 已 delete，`setSoundVolume` 只更新 baseVolumes 即 return，淡出继续到 0 并停止 | 淡出期间保留 Map entry；新增按 channel 的 `soundFadeEpochs` 计数（对应 native DOTween 的 tween 替换语义），`setSoundVolume` 自增 epoch 即清掉停止标志并接管 tween，channel 继续播 |
| 2 | P2 | `stopsound` 后紧接同 channel `playsound` | 旧 channel 在 `PlayAudio` 里被瞬停（`Stop(0)` → `_Stop()`）并让位，新音效独占 | 旧实例仍在淡出（已从 Map 摘除），新旧音效重叠 fadetime 秒 | 同 #1 摘除延迟到 fade 完成；`playSound` 替换 prev 时瞬停旧实例并自增 epoch 退役其淡出循环；stale 的 stop tween 醒来后发现 entry 已被替换即放弃，不误删/误停新实例 |
| 3 | P2 | 极短 fade 阈值 | `fabs(fadetime) <= 0.01s` 走 `_Stop()` 瞬停 | `fadeMs <= 0` 才瞬停；`0 < fadeMs <= 10` 走一帧 rAF 淡变 | 阈值改为 `fadeMs <= 10`（`stopChannelInstantThresholdMs`），逐字对齐 |

未动的条目（review 结论为等价/合理适配）：`key` 默认 null vs `""`（终态名同为 `"avgsound_"`，行为等价）；`soundRequestIds` 取消 pending 加载（web 适配，保留）；fade 驱动 rAF 时钟（web 固有差异，可接受）。

`fadeVolume` 增加了可选的 `isCancelled` 探针参数（不传时行为不变，music 侧调用不受影响），是 native「新 tween 替换旧 tween」的 web 等价物；所有 volume tween 写入点（`stopSound`/`setSoundVolume`/`playSound` 替换 prev）均持有自己的 epoch，实现替换语义。

## 验证用剧情文件

生产剧情语料（本地 `torappu/storage/asset/gamedata/latest/story`）扫描结果：`stopsound(fadetime>0.01)` 后**下一条同 channel 命令是 `playsound`」共 114 处命中，「是 `soundvolume`」共 1 处：

- **修复 2（淡出途中同 channel playsound 接管）**：`obt/main/level_main_11-05_beg.txt:360→365` —— `[stopsound(channel="n",fadetime=1)]` 后仅隔 `[delay(time=0.51)]` 就 `[PlaySound(key="$d_avg_walk_stage",channel="n")]`，新 playsound 在 fade 进行中（约 t=0.5s）到达，旧脚步声应被瞬停让位而非重叠淡出。同型密集样本：`obt/main/level_main_11-17_beg.txt:85→89`、`91→94`（连续两轮 stopsound→PlaySound 同 channel "a"）。
- **修复 1（淡出期间 soundvolume 取消停止）**：语料唯一同 channel 序列 `obt/main/level_main_14-16_beg.txt:634→644`（`stopsound(c, fadetime=1)` → … → `SoundVolume(volume=0.6, channel="c", fadetime=2)`）中间隔 `[Delay(time=1.5)]` + 点击对白 + blocker，实际时序下 soundvolume 落在 fade 完成之后，native 中同为对已移除 channel 的 no-op——**取消窗口行为属前瞻对齐，由单测锁定**：`tests/audio.spec.ts` 用例 "soundvolume during the fade cancels the stop and keeps playing"。
- **修复 3（≤0.01s 瞬停阈值）**：全语料 769 处带 fadetime 的 stopsound 均无 `fadetime<=0.01` 的非零取值（`fadetime=0` 缺省瞬停随处可见且两侧已一致）——**阈值边界由单测锁定**：用例 "fadetime <= 0.01s stops instantly without a tween"；另 "keeps the channel registered during the fade and removes it when done" 锁定修复 1/2 的保留-移除生命周期，"a new playsound during the fade cuts the fading instance short" 锁定修复 2。

## 测试

- `pnpm test`：20 个文件 **226 个用例全部通过**（基线 222 + 本 PR 新增 4 个 audio 用例）。
- `pnpm exec vue-tsc -b`：通过。
- `pnpm exec eslint src/widgets/StoryPlayer/engine/audio.ts tests/audio.spec.ts`：通过。
