### PR TITLE
fix(story-player): playsound 延迟窗口通道替换时序与结束残留 loop 音效淡出

### DIFF
--- a/src/widgets/StoryPlayer/engine/audio.ts
+++ b/src/widgets/StoryPlayer/engine/audio.ts
@@ -133,16 +133,25 @@ export class HtmlStoryAudio implements StoryAudio {
     this.soundRequestIds.set(channel, requestId);
     this.soundBaseVolumes.set(channel, input.volume);
 
-    if (input.delayMs > 0)
-      await new Promise((resolve) => setTimeout(resolve, input.delayMs));
-    if (this.destroyed || this.soundRequestIds.get(channel) !== requestId)
-      return;
-
+    // Native provenance: `AudioManager._PlayAudio<SoundParam>` (2.7.61 VA
+    // 0x18458dac0) runs synchronously inside `_ExecutePlaySoundCommand`: the
+    // replayed channel takes its name immediately (forceReplay, no IsSameAudio
+    // short-circuit) and the previous sound on it is hard-stopped at once
+    // (crossFade forced to 0), while `delay` only defers the engine-level
+    // audible start. Stop the outgoing instance before the delay wait so the
+    // channel swap is not postponed by `delay`; a soundvolume/stopsound
+    // landing inside the delay window then resolves to this new request
+    // instead of the outgoing instance.
     const prev = this.soundChannels.get(channel);
     if (prev) {
       this.stopPlayback(prev);
       this.soundChannels.delete(channel);
     }
+
+    if (input.delayMs > 0)
+      await new Promise((resolve) => setTimeout(resolve, input.delayMs));
+    if (this.destroyed || this.soundRequestIds.get(channel) !== requestId)
+      return;
 
     const sound = await this.createPlayback(url, url);
     if (
@@ -189,6 +198,27 @@ export class HtmlStoryAudio implements StoryAudio {
 
     this.soundChannels.delete(channelName);
     await this.fadeAndStop(sound, fadeMs);
+  }
+
+  /**
+   * Native provenance: `Torappu.AVG.CommonExecutors.OnReset` → `_ResetAudio`
+   * (2.7.61 VA 0x183e6d2a0 / 0x183e6fb70). Story teardown iterates every
+   * channel playsound registered — the `m_allSoundChannels` HashSet (offset
+   * 0x38) equivalent is `soundChannels`, minus entries stopsound already
+   * removed — stops each with the serialized `_soundDefaultFadeTime` (offset
+   * 0x2C), then clears. One-shot channels self-recycle on completion, so in
+   * practice this fades out residual loop sounds. Pending delayed playsound
+   * requests are cancelled too: native stops their already-created delayed
+   * channel the same way. `destroy()` keeps its hard stop as the
+   * widget-teardown fallback.
+   */
+  async stopAllSounds(fadeMs: number): Promise<void> {
+    this.soundRequestIds.clear();
+    this.soundBaseVolumes.clear();
+
+    const sounds = [...this.soundChannels.values()];
+    this.soundChannels.clear();
+    await Promise.all(sounds.map((sound) => this.fadeAndStop(sound, fadeMs)));
   }
 
   async setSoundVolume(

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -102,6 +102,15 @@ const QUICK_AUTO_SPEEDS: readonly AutoSpeed[] = [
   },
 ];
 const TYPE_WRITER_ORIGIN_DELAY_MS = 40;
+/**
+ * Native provenance: `Torappu.AVG.CommonExecutors._soundDefaultFadeTime`
+ * (serialized float, field offset 0x2C) — the fade duration `OnReset` →
+ * `_ResetAudio` uses when the story ends and every residual loop sound
+ * channel is stopped in bulk (2.7.61 VA 0x183e6d2a0 / 0x183e6fb70). The
+ * serialized value lives in Unity asset data rather than the assembly, so
+ * this port fixes 0.4s as a sanctioned fixed default.
+ */
+const SOUND_RESET_FADE_MS = 0.4 * 1000;
 
 const builtinCommandNames = [
   "endtip",
@@ -563,7 +572,7 @@ export class StoryRuntime {
     if (shouldResume) {
       this.state = "running";
     } else if (!hadActiveProcessLoop) {
-      this.state = "finished";
+      this.onStoryFinished();
     }
 
     // Establish the destination state before releasing a blocking executor.
@@ -666,6 +675,19 @@ export class StoryRuntime {
     this.pendingInputEffect = null;
   }
 
+  /**
+   * Native provenance: `Torappu.AVG.CommonExecutors.OnReset` → `_ResetAudio`
+   * (2.7.61 VA 0x183e6d2a0 / 0x183e6fb70): story termination fades out every
+   * residual loop sound channel (see `stopAllSounds` in audio.ts) with the
+   * serialized `_soundDefaultFadeTime` instead of leaving it playing until
+   * widget teardown. Fire-and-forget — native OnReset does not block the
+   * finished transition, and one-shot channels have already self-recycled.
+   */
+  private onStoryFinished(): void {
+    this.state = "finished";
+    void this.audio.stopAllSounds(SOUND_RESET_FADE_MS);
+  }
+
   private async processLoop(): Promise<void> {
     if (this.processing) return;
 
@@ -679,7 +701,7 @@ export class StoryRuntime {
         if (this.cursor >= this.lines.length) {
           this.renderer.clearAnimTexts();
           this.renderer.clearAvgDisplays();
-          this.state = "finished";
+          this.onStoryFinished();
           return;
         }
 
@@ -2105,7 +2127,11 @@ export class StoryRuntime {
 
       case "playsound": {
         // Native port: Torappu.AVG.CommonExecutors._ExecutePlaySoundCommand.
-        // Channel defaults to key; the call is non-blocking.
+        // Channel defaults to key; the call is non-blocking. Native also
+        // suppresses non-loop sounds when executeMode is Reader/Pure (its
+        // text-only review modes) while loop sounds still play; this player
+        // only has the Normal mode, so that branch is unreachable and
+        // intentionally omitted.
         const key = toString(this.exactArg(args, "key"));
         if (!key) {
           this.warn("parse", "playsound key is empty");

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -598,6 +598,7 @@ export interface StoryAudio {
     volume: number,
     fadeMs: number,
   ) => Promise<void>;
+  stopAllSounds: (fadeMs: number) => Promise<void>;
   stopMusic: (fadeMs: number) => Promise<void>;
   stopSound: (channel: string, fadeMs: number) => Promise<void>;
 }

--- a/tests/audio.spec.ts
+++ b/tests/audio.spec.ts
@@ -144,4 +144,94 @@ describe("HtmlStoryAudio", () => {
     await audio.stopSound("c", 0);
     expect(instance.stopped).toBe(1);
   });
+
+  it("stops the previous instance before waiting out the delay window", async () => {
+    vi.useFakeTimers();
+    try {
+      const audio = new HtmlStoryAudio(context);
+      void audio.playSound({
+        channel: "c",
+        delayMs: 0,
+        key: "k",
+        loop: true,
+        volume: 1,
+      });
+
+      await flush();
+      const first = settleLoad();
+      await flush();
+      const firstInstance = first.settlePlay();
+      await flush();
+      expect(firstInstance.stopped).toBe(0);
+
+      const second = audio.playSound({
+        channel: "c",
+        delayMs: 5000,
+        key: "k2",
+        loop: true,
+        volume: 1,
+      });
+
+      // Native `_PlayAudio<SoundParam>` is synchronous: forceReplay replaces
+      // the channel immediately and `delay` only defers the audible start, so
+      // the outgoing instance must be stopped before the delay elapses.
+      expect(firstInstance.stopped).toBe(1);
+      await flush();
+      // Still inside the delay window: no load for the new key has started.
+      expect(loads.length).toBe(0);
+
+      vi.advanceTimersByTime(5000);
+      await flush();
+      const secondSound = settleLoad();
+      await flush();
+      const secondInstance = secondSound.settlePlay();
+      await flush();
+      await second;
+
+      expect(secondInstance.stopped).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops residual loop channels and cancels pending delayed plays on reset", async () => {
+    vi.useFakeTimers();
+    try {
+      const audio = new HtmlStoryAudio(context);
+      void audio.playSound({
+        channel: "c",
+        delayMs: 0,
+        key: "k",
+        loop: true,
+        volume: 1,
+      });
+
+      await flush();
+      const sound = settleLoad();
+      await flush();
+      const instance = sound.settlePlay();
+      await flush();
+      expect(instance.stopped).toBe(0);
+
+      const delayed = audio.playSound({
+        channel: "d",
+        delayMs: 60_000,
+        key: "k2",
+        loop: true,
+        volume: 1,
+      });
+
+      await audio.stopAllSounds(0);
+      expect(instance.stopped).toBe(1);
+
+      vi.advanceTimersByTime(60_000);
+      await flush();
+      await delayed;
+
+      // The reset cancelled the delayed request, so its load never started.
+      expect(loads.length).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -334,6 +334,7 @@ class FakeAudio implements StoryAudio {
     [];
   stopMusicCalls: number[] = [];
   stopSoundCalls: Array<{ channel: string; fadeMs: number }> = [];
+  stopAllSoundsCalls: number[] = [];
 
   async playMusic(input: PlayMusicInput): Promise<void> {
     this.playMusicCalls.push(input);
@@ -357,6 +358,10 @@ class FakeAudio implements StoryAudio {
 
   async stopMusic(fadeMs: number): Promise<void> {
     this.stopMusicCalls.push(fadeMs);
+  }
+
+  async stopAllSounds(fadeMs: number): Promise<void> {
+    this.stopAllSoundsCalls.push(fadeMs);
   }
 
   async stopSound(channel: string, fadeMs: number): Promise<void> {
@@ -2506,6 +2511,29 @@ describe("StoryRuntime", () => {
       { channel: "", fadeMs: 0, volume: 0.2 },
     ]);
     expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("fades out residual loop sounds when the story ends", async () => {
+    const audio = new FakeAudio();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[playsound(key="s",volume=1.5,delay=0.3,loop=true)]',
+        '[name="A"]ok',
+      ]),
+      new FakeRenderer(),
+      audio,
+    );
+
+    await runtime.start();
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(audio.stopAllSoundsCalls).toEqual([]);
+
+    await runtime.advance();
+
+    expect(runtime.getState()).toBe("finished");
+    // Fixed stand-in for the serialized `_soundDefaultFadeTime` (0.4s) used
+    // by native `CommonExecutors.OnReset` → `_ResetAudio`.
+    expect(audio.stopAllSoundsCalls).toEqual([400]);
   });
 
   it("maps subtitle show and clear commands", async () => {


### PR DESCRIPTION
本 PR 修复 StoryPlayer `playsound` 命令移植中 review 定位的可修复差异（P2×1 项代码修复 + P3×1 项代码修复 + 1 项注释补全）。依据是对明日方舟官服客户端（2.7.61 / build 2761，Unity IL2CPP）GameAssembly.dll 的 IDA 反编译复核，关键结论在下文直接给出，不依赖外部文档。

## 背景：native 的 playsound 机制（2.7.61 逆向结论）

- executor 为 `Torappu.AVG.CommonExecutors::_ExecutePlaySoundCommand`（VA `0x183e6e540`）：读 `key`/`channel`/`volume`/`delay`/`loop` 五参数，`channel` 缺省取 `key` 值；channel 名经 `_GenAVGSoundChannelName`（VA `0x183e6f410`）固定为 `"avgsound_<channel>"`；finishCb 同步调用（非阻塞）。
- 下游 `AudioManager._PlayAudio<SoundParam>`（VA `0x18458dac0`）**同步执行**：`forceReplay=true` 跳过同曲短路，新 channel 立即创建并占名，同 channel 旧音效瞬停（executor 恒以 `SetCommonAudioParam(..., crossFade=0, ...)` 覆盖，无淡入）；`delay` 只是引擎层起播延迟——channel 已存在、占名已完成，声音延后 `delay` 秒才出。
- 剧情结束时 `CommonExecutors.OnReset`（VA `0x183e6d2a0`）→ `_ResetAudio`（VA `0x183e6fb70`）：遍历 `m_allSoundChannels` HashSet（offset `0x38`；playsound 播放后 Add、stopsound 显式停后 Remove）逐个 `AudioManager.StopChannel(name, _soundDefaultFadeTime)` 后 `Clear()`——残留 loop 音效按固定默认 fade 淡出停，而非播到播放器销毁瞬停。
- native 另有 Reader/Pure 执行模式抑制（`executeMode ∈ {Reader, Pure} && !loop` → 不播，finishCb 仍调用）；web 播放器只有 Normal 模式，该分支不可触发。

## 修复内容

（差异清单原文：严重度 / native 行为 / 前端行为 → 改法）

### 1. `delay` 窗口内的 channel 替换时序（P2 #1）

- native：`_PlayAudio` 同步执行：立即创建新 channel 占名、旧音效瞬停；`delay` 只是引擎层起播延迟（声音延后出）。
- 前端（修复前）：`delayMs > 0` 时先 await 再瞬停 prev → 旧音效多播约 `delay` 秒；且 delay 窗口内 `soundvolume` 会命中旧实例（native 命中新 channel）。
- 改法：`engine/audio.ts` `playSound` 把「瞬停旧实例 + 登记新请求占位 channel」提到 delay 等待之前，`delay` 只推迟起播（load/play 移到等待之后）。delay 窗口内落进的 `soundvolume`/`stopsound` 现在解析到新请求（base volume 在起播时生效 / 取消 pending），与 native「channel 已占名」语义对齐。

### 2. 剧情结束的残留 loop 清理（P3 #4）

- native：`OnReset` → `_ResetAudio` 遍历 `m_allSoundChannels` 以 `_soundDefaultFadeTime` 淡出停，再 `Clear`。
- 前端（修复前）：runtime 不做音频清理；loop 音效一直播到外部 `HtmlStoryAudio.destroy()`（瞬停）。
- 改法：`StoryAudio` 接口新增 `stopAllSounds(fadeMs)`（`HtmlStoryAudio` 实现：淡出停全部 sound channel、清空请求/音量表并取消 pending 延迟播放——对应 native 停掉「已创建但起播延迟中」的 channel；`destroy()` 保留硬停作销毁兜底）。`engine/runtime.ts` 在剧情终止路径（脚本自然播完、skipNode 整段跳完）调用，fade 取固定 0.4s——native 的 `_soundDefaultFadeTime` 是 Unity 序列化字段（offset `0x2C`），序列化值不在程序集内无法从 DLL 还原，故按 review 结论采用固定默认。

### 3. Reader/Pure 抑制注释补全（P3 #3，顺手注释）

web 播放器只有 Normal 模式，该分支不可触发、有意省略；已在 `runtime.ts` playsound 分支注释中说明 native 存在此分支，未来若加"回顾/纯净"模式需补。

### 按建议不改的条目

- P2 #2（缺资产/空 key 处理）：前端 `warn("parse")`/`warn("missing_asset")` 是诊断增强，review 建议保留。
- P3 #5（`delay` 负值钳位 `Math.max(0,·)`）：行为等价（native 负值即"立即"）。
- P3 #6（`requestId` 防加载乱序）：web 异步加载的合理适配，review 建议保留。

说明：`engine/audio.ts` 为 music 族命令共享文件，本次 diff 只动 sound 侧（`playSound` 内部顺序 + 新增 `stopAllSounds`），未触及任何共享函数。

## 验证用剧情文件

生产剧情语料（本地 `torappu/storage/asset/gamedata/latest/story`）：

- 修复 1（delay 窗口替换时序）：`activities/act10mini/level_act10mini_st03.txt` 342-344 行——`$d_gen_explo_n`（channel 默认 = key）以 `delay=0.05`/`delay=0.1` 连发复播，旧爆炸声应立即让位而非多播 0.05/0.1 秒；`activities/act21mini/level_act21mini_st06.txt` 838-839 行——`channel="b"` 以 `delay=0.5`→`delay=0.9` 复播。全语料同 channel 延迟复播共 644 处。
- 修复 2（结束残留 loop 淡出）：`obt/main/level_main_08-15_end.txt` 5 行——`$burningloop1` `loop=true` 起播后全篇从未 `stopsound`，应随剧情结束淡出而非播到播放器销毁；`activities/act13side/level_act13side_st02.txt` 82 行——`bgs` loop 被 `soundvolume(volume=0)` 静音但从未 `stopsound`（soundvolume 不解除 channel 注册），结束时仍会被淡出停掉。全语料此类未停 loop channel 共 46 个。
- 修复 3（注释）：不涉及运行时行为，由代码注释体现。

## 测试

- `pnpm test`：20 个文件 225 个用例全部通过（基线 222 + 新增 3：`tests/audio.spec.ts` delay 窗口旧实例瞬停时序、`stopAllSounds` 淡出停并取消 pending；`tests/runtime.spec.ts` 剧情结束触发 `stopAllSounds(400)`）。
- `pnpm exec vue-tsc -b`：通过。
- `pnpm exec eslint`（改动文件）：通过。
