### PR TITLE
fix(story-player): soundvolume 在 stopsound 淡出期间取消停止并接管音量

### DIFF
--- a/src/widgets/StoryPlayer/engine/audio.ts
+++ b/src/widgets/StoryPlayer/engine/audio.ts
@@ -15,6 +15,15 @@ interface ActivePlayback {
   identity: string;
   instance: IMediaInstance | null;
   sound: Sound;
+  /**
+   * Native provenance: `AudioChannel` tween fields (`m_tweenStartVolume` /
+   * `m_tweenTargetVolume` / `m_tweenStartTime` / `m_tweenEndTime`) form a
+   * single tween slot per channel — a new `AudioChannel.TweenVolume` call
+   * replaces the in-flight tween and restarts it from the current
+   * (mid-tween) volume. Web adaptation: token per playback; incrementing it
+   * invalidates older fade loops, which then resolve without further writes.
+   */
+  fadeToken: number;
 }
 
 export class HtmlStoryAudio implements StoryAudio {
@@ -29,13 +38,24 @@ export class HtmlStoryAudio implements StoryAudio {
    * `_ExecuteStopSoundCommand`; downstream `AudioManager` / `AudioChannel`.
    *
    * Ports persistent MUSIC and `avgsound_<channel>` base-volume state so a
-   * following volume/stop command observes an in-flight async web load. PIXI
-   * loading and browser playback are web adaptations of the native backend.
+   * following volume/stop command observes an in-flight async web load, and
+   * models a fading `stopsound` as a cancellable deferred recycle (native
+   * `AudioChannel.m_stopWhenTweenEnd`), so a same-window `soundvolume`
+   * revives the channel instead of only bookkeeping. PIXI loading and
+   * browser playback are web adaptations of the native backend.
    *
    */
   private musicBaseVolume = 1;
   private readonly soundBaseVolumes = new Map<string, number>();
   private readonly soundRequestIds = new Map<string, number>();
+  /**
+   * Native provenance: `AudioChannel.m_stopWhenTweenEnd`. A channel present
+   * in this map has a `stopsound` fade-out still pending; the value tokenizes
+   * the pending stop so a newer stop on the same channel supersedes an older
+   * one. `AudioChannel.TweenVolume` zeroes the flag, which is what lets a
+   * `soundvolume` command cancel a stop that is still fading out.
+   */
+  private readonly soundPendingStops = new Map<string, object>();
   private readonly soundCache = new Map<string, Sound>();
   private readonly soundChannels = new Map<string, ActivePlayback>();
 
@@ -53,6 +73,7 @@ export class HtmlStoryAudio implements StoryAudio {
     this.soundChannels.clear();
     this.soundBaseVolumes.clear();
     this.soundRequestIds.clear();
+    this.soundPendingStops.clear();
   }
 
   async playMusic(input: PlayMusicInput): Promise<void> {
@@ -187,8 +208,27 @@ export class HtmlStoryAudio implements StoryAudio {
     const sound = this.soundChannels.get(channelName);
     if (!sound) return;
 
+    // Native provenance: `AudioChannel.Stop` with |fadetime| > 0.01 keeps the
+    // channel alive in `AudioManager.m_channels` while the fade-out tween runs
+    // (`m_stopWhenTweenEnd = 1`); only when the tween finishes uncanceled does
+    // `AudioManager.Update` stop the channel and drop it from `m_channels`.
+    // Web adaptation: keep the map entry through the fade so a same-window
+    // `soundvolume` can still resolve this channel and cancel the stop; the
+    // token check makes an older stop fade bow out to a newer stop or a
+    // reviving `soundvolume`, and the identity check leaves a replacement
+    // playback (later `playsound` on the same channel) untouched.
+    const stopToken = {};
+    this.soundPendingStops.set(channelName, stopToken);
+    await this.fadeVolume(sound, 0, fadeMs);
+    if (
+      this.soundPendingStops.get(channelName) !== stopToken ||
+      this.soundChannels.get(channelName) !== sound
+    )
+      return;
+
+    this.soundPendingStops.delete(channelName);
+    this.stopPlayback(sound);
     this.soundChannels.delete(channelName);
-    await this.fadeAndStop(sound, fadeMs);
   }
 
   async setSoundVolume(
@@ -202,6 +242,15 @@ export class HtmlStoryAudio implements StoryAudio {
     const sound = this.soundChannels.get(channelName);
     if (!sound) return;
 
+    // Native provenance: `CommonExecutors._ExecuteSoundVolumeCommand` resolves
+    // the channel via `AudioManager.GetChannel` even mid-fade-out (the channel
+    // is still registered), and `AudioChannel.TweenVolume` zeroes
+    // `m_stopWhenTweenEnd` — a soundvolume landing inside a stopsound fade
+    // cancels that stop: the sound revives and tweens to the new volume from
+    // its current (mid-fade) volume. Web adaptation: clearing the pending-stop
+    // marker plus fadeVolume's token replacement stands in for the single
+    // tween slot of the native AudioChannel.
+    this.soundPendingStops.delete(channelName);
     await this.fadeVolume(sound, volume, fadeMs);
   }
 
@@ -226,6 +275,7 @@ export class HtmlStoryAudio implements StoryAudio {
       identity,
       instance: null,
       sound,
+      fadeToken: 0,
     };
   }
 
@@ -234,6 +284,10 @@ export class HtmlStoryAudio implements StoryAudio {
     targetVolume: number,
     durationMs: number,
   ): Promise<void> {
+    // Native provenance: `AudioChannel.TweenVolume` overwrites the tween
+    // fields in place, so the newest call owns the channel's single tween
+    // slot; the in-flight tween stops progressing (see `ActivePlayback.fadeToken`).
+    const token = ++playback.fadeToken;
     const startVolume = this.getVolume(playback);
     if (durationMs <= 0) {
       this.setVolume(playback, targetVolume);
@@ -244,7 +298,7 @@ export class HtmlStoryAudio implements StoryAudio {
 
     await new Promise<void>((resolve) => {
       const tick = () => {
-        if (this.destroyed) {
+        if (this.destroyed || playback.fadeToken !== token) {
           resolve();
           return;
         }

--- a/tests/audio.spec.ts
+++ b/tests/audio.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HtmlStoryAudio } from "../src/widgets/StoryPlayer/engine/audio";
 
@@ -80,6 +80,26 @@ async function flush(): Promise<void> {
 
 const context = { linkMap: {}, script: [] } satisfies Context;
 
+/** Drive `playsound` through the fakes until its instance is live. */
+async function playLoopingSound(
+  audio: HtmlStoryAudio,
+  key: string,
+): Promise<FakeInstance> {
+  void audio.playSound({
+    channel: "c",
+    delayMs: 0,
+    key,
+    loop: true,
+    volume: 1,
+  });
+  await flush();
+  const sound = settleLoad();
+  await flush();
+  const instance = sound.settlePlay();
+  await flush();
+  return instance;
+}
+
 describe("HtmlStoryAudio", () => {
   beforeEach(() => {
     loads.length = 0;
@@ -143,5 +163,102 @@ describe("HtmlStoryAudio", () => {
 
     await audio.stopSound("c", 0);
     expect(instance.stopped).toBe(1);
+  });
+
+  describe("stopsound fade interplay (AudioChannel.m_stopWhenTweenEnd)", () => {
+    beforeEach(() => {
+      // fadeVolume drives both rAF ticks and performance.now(); fake them so
+      // the fade window can be advanced deterministically.
+      vi.useFakeTimers({ toFake: ["performance", "requestAnimationFrame"] });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("revives a stopsound fade-out when soundvolume lands inside the window", async () => {
+      const audio = new HtmlStoryAudio(context);
+      const instance = await playLoopingSound(audio, "k");
+
+      // Native: `AudioChannel.Stop` (fadetime > 0.01) keeps the channel
+      // registered while fading out (`m_stopWhenTweenEnd = 1`).
+      void audio.stopSound("c", 1000);
+      await flush();
+      await vi.advanceTimersByTimeAsync(480);
+
+      expect(instance.stopped).toBe(0);
+      expect(instance.volume).toBeGreaterThan(0);
+      expect(instance.volume).toBeLessThan(1);
+
+      // Native: `AudioChannel.TweenVolume` zeroes `m_stopWhenTweenEnd`, so
+      // the pending stop is cancelled and the sound tweens to the new volume
+      // from its current mid-fade volume instead of stopping.
+      void audio.setSoundVolume("c", 0.8, 200);
+      await flush();
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(instance.stopped).toBe(0);
+      expect(instance.volume).toBeCloseTo(0.8);
+
+      // The revived channel stays resolvable: a later soundvolume (even with
+      // fadetime=0) keeps acting on it.
+      await audio.setSoundVolume("c", 0.3, 0);
+      expect(instance.stopped).toBe(0);
+      expect(instance.volume).toBe(0.3);
+    });
+
+    it("stops and drops the channel once the stopsound fade finishes uncanceled", async () => {
+      const audio = new HtmlStoryAudio(context);
+      const instance = await playLoopingSound(audio, "k");
+
+      void audio.stopSound("c", 400);
+      await flush();
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(instance.volume).toBe(0);
+      expect(instance.stopped).toBe(1);
+
+      // Channel is gone: a later soundvolume is a silent no-op
+      // (native `AudioManager.GetChannel` miss).
+      await audio.setSoundVolume("c", 0.9, 0);
+      expect(instance.volume).toBe(0);
+      expect(instance.stopped).toBe(1);
+    });
+
+    it("lets a newer stopsound supersede an older stop fade", async () => {
+      const audio = new HtmlStoryAudio(context);
+      const instance = await playLoopingSound(audio, "k");
+
+      void audio.stopSound("c", 1000);
+      await flush();
+      await vi.advanceTimersByTimeAsync(500);
+
+      void audio.stopSound("c", 400);
+      await flush();
+      // Still inside the second fade: the superseded stop fade must not have
+      // stopped the instance early.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(instance.stopped).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(instance.stopped).toBe(1);
+    });
+
+    it("does not let a stale stop fade stop a replacement playsound on the channel", async () => {
+      const audio = new HtmlStoryAudio(context);
+      const first = await playLoopingSound(audio, "k1");
+
+      void audio.stopSound("c", 1000);
+      await flush();
+      await vi.advanceTimersByTimeAsync(200);
+
+      // A same-channel playsound takes the channel over; native `_PlayAudio`
+      // stops the old instance instantly.
+      const second = await playLoopingSound(audio, "k2");
+      expect(first.stopped).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(second.stopped).toBe(0);
+    });
   });
 });


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `soundvolume` 命令移植中的 P1 行为差异(1 项)。依据是对明日方舟官服客户端(2.7.61 / build 2761,Unity IL2CPP)GameAssembly.dll 的 IDA 反编译复核,关键结论在下文直接给出,不依赖外部文档。

## 背景:native 的 soundvolume 与停止取消机制(2.7.61 逆向结论)

- 执行器 `Torappu.AVG.CommonExecutors::_ExecuteSoundVolumeCommand`(VA `0x183e6e920`):只读 `channel`(默认 null,**不读 `key`**)、`volume`(默认 1.0)、`fadetime`(默认 0.0);拼 `avgsound_{channel}`(`_GenAVGSoundChannelName`,VA `0x183e6f410`,与 `playsound`/`stopsound` 共用);经 `AudioManager.GetChannel`(VA `0x18197db90`)解析,channel 不存在时**静默 no-op 无日志**;命中则 `AudioChannel.TweenVolume(volume, fadetime, 0.0, linear)`(delay 硬编码 0、ease 硬编码 linear);随后同步回调 `finishCb`——永远非阻塞。
- `AudioChannel.TweenVolume`(VA `0x183edef70`):tween 字段整体替换(`m_tweenStartVolume = m_currentBaseVolume`、`m_tweenTargetVolume = volume`、起止时刻 = `unscaledTime` / `+fadetime`),并**清零 `m_stopWhenTweenEnd`**(`0x183edefd2`)。即每个 channel 只有**一个 tween 槽位**:后到的 `TweenVolume` 顶掉在飞的 tween,并从当前(渐变中)音量重新起算。
- `AudioChannel.Stop`(VA `0x183ededf0`):`|fadetime| > 0.01` 时不瞬停,而是 tween 到 0 并置 `m_stopWhenTweenEnd = 1`;淡出期间 channel 仍留在 `AudioManager.m_channels`、`isPlaying` 仍 true,直到 tween 结束且未被取消才 `_Stop()`,由 `AudioManager.Update` 移除还池。
- 关键交互(即本 PR 修复点):`stopsound(fadetime>0)` 淡出途中来 `soundvolume` → `GetChannel` 仍命中 → `TweenVolume` 清 `m_stopWhenTweenEnd` → **停止被取消**,音效不停播,从当前音量向新目标音量渐变;之后 `soundvolume(volume>0)` 还能把音量拉回。`soundvolume(volume=0)` 则只是可恢复的静音,与 `stopsound` 的生命周期不同(不回收 channel)。

前端原有实现中与 native 一致、本 PR 不动的部分:参数表(只读 `channel`、`volume` 默认 1、`fadetime` 默认 0 且不乘加速比)、`avgsound_` 前缀、channel 不存在静默 no-op、非阻塞、音量不 clamp、`volume=0` 只静音不停播。

## 修复内容

### 1. `stopsound` 淡出期间的 `soundvolume` 退化为只记账(P1)

- **native 行为**:淡出中的 channel 仍可按名命中;`TweenVolume` 清 `m_stopWhenTweenEnd`,停止被取消,音效向新音量渐变继续播。
- **前端行为(修复前)**:`stopSound` 在提交淡出的同一刻就 `soundChannels.delete`,`soundvolume` 在此窗口只更新 baseVolumes 即 return,旧实例继续淡到 0 并停止。
- **修复**(`src/widgets/StoryPlayer/engine/audio.ts`):
  - `stopSound` 淡出期间**保留 Map entry**,以 `soundPendingStops`(channel → stop token)表示 native 的 `m_stopWhenTweenEnd = 1`;fade 结束时仅当该 token 仍持有本 channel 且 entry 未被替换,才 stop + delete(对应 tween 完成未取消时的 `_Stop()` + `AudioManager.Update` 移除还池);
  - `setSoundVolume` 命中 channel 时**清掉 pending stop 标志**并接管渐变(对应 `TweenVolume` 清 `m_stopWhenTweenEnd`),音效从当前(淡出中)音量向新音量渐变、不再停止;
  - `fadeVolume` 增加 per-playback `fadeToken`:新 fade 使在飞的 fade 循环立即失效,对应 native 单 tween 槽位「后到顶掉在飞」的语义(顺带修正了同实例上两个并发 fade 循环互相打架的问题)。

review 差异清单中的其余条目按建议**不动**:P3「channel 不存在时先记账」(无实际影响,保留)、「极短 fade 阈值」(听感无差别)、「fade 驱动时钟 rAF vs `Time.unscaledTime`」(web 固有)。

**与并行 PR 的关系**:`engine/audio.ts` 的 `stopSound` 为共享函数,本 PR 为使 `soundvolume` 的 P1 可观察,实现了 stopsound 侧 review(impl-review-stopsound §差异#1)所述同一机制(淡出期间保留 entry + pending stop 标志、`setSoundVolume` 接管);若 stopsound/playsound 的并行修复 PR 也改到此函数,两份 review 给出的设计一致,由合并者取其一收敛即可。

## 验证用剧情文件

语料库(`torappu/storage/asset/gamedata/latest/story`)全量扫描:`stopsound(fadetime>0)` 后同 channel 出现 `soundvolume` 的生产文件共 8 对,但**无任何一对保证落在淡出窗口内**——命令间的阻塞等待(`[Delay]`/`[Blocker]` 等)或对白点击间隔均超过 fadetime。最接近的样本:

- `obt/memory/story_swllow_1_1.txt:478`(`[StopSound(channel="d", fadetime=1)]`)→ `:521`(`[SoundVolume(volume=0, channel="d",fadetime=1)]`):两命令之间**零阻塞等待**、仅 23 行对白,高速连点/快速跳过时 `soundvolume` 会落入 1s 淡出窗口,触发「取消停止、按新音量渐变」;
- `obt/main/level_main_14-16_beg.txt:634`(`[stopsound(channel="c", fadetime=1)]`)→ `:644`(`[SoundVolume(volume=0.6, channel="c",fadetime=2)]`):中间有 `[Delay(time=1.5)]` 等约 1.6s 阻塞,正常速度下淡出已完成、`soundvolume` 应为静默 no-op——可作「窗口外不复活已停 channel」的对照样本;
- `activities/act44side/level_act44side_05_end.txt:427`(`[StopSound(channel="sn", fadetime=2)]`)→ `:439`(`[SoundVolume(volume=1, channel="sn",fadetime=2)]`):同类对照(阻塞 > 3s > 2s 淡出)。

结论:本修复属**前瞻对齐,由单测锁定**(`tests/audio.spec.ts` → `stopsound fade interplay (AudioChannel.m_stopWhenTweenEnd)` 组):

- `revives a stopsound fade-out when soundvolume lands inside the window`——P1 主行为(旧实现下失败);
- `stops and drops the channel once the stopsound fade finishes uncanceled`——未取消时照常停(对照);
- `lets a newer stopsound supersede an older stop fade`——token 顶替(连续两条 stopsound);
- `does not let a stale stop fade stop a replacement playsound on the channel`——淡出中同 channel `playsound` 换代后不被旧停止误杀(旧实现下失败)。

## 测试

- `pnpm test`:20 个文件 226 个用例全部通过(基线 222 + 新增 4)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint src/widgets/StoryPlayer/engine/audio.ts tests/audio.spec.ts`:通过。
