### PR TITLE
fix(story-player): effect 命令告警去重并补 native provenance 注释

### DIFF
--- a/src/widgets/StoryPlayer/engine/preload.ts
+++ b/src/widgets/StoryPlayer/engine/preload.ts
@@ -89,6 +89,14 @@ function addCharacterUrl(urls: Set<string>, rawKey: string): string | null {
  * `AVGCgItemPanel.InternalResRefCollector.GatherResRefs`, and the image /
  * background / character panel collectors.
  *
+ * Deliberately not ported: `AVGBattleEffectPanel`'s collector
+ * `InternalResRefCollector.GatherResRefs` (GameAssembly.dll 2.7.61 / build
+ * 2761, VA 0x183e46d40) routes each `effect`/`bgeffect` `name` through
+ * `ResourceRouter.GetBattleEffectPath` (`AVG/Effects/Battle/<name>` particle
+ * prefabs) into the native story preload. The web player has no such asset
+ * domain and skips those commands with a warning (see
+ * `unsupportedAd8Commands` in runtime.ts), so there is nothing to collect.
+ *
  * Ports which script commands declare image dependencies. A single eager PIXI
  * batch substitutes for native asset-reference collection and loading.
  *

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -159,6 +159,22 @@ const builtinCommandNames = [
   "hidecgitem",
 ] as const;
 
+/**
+ * Parsed-but-unrendered Ad8 particle-effect commands. For `effect` the native
+ * executor never blocks either: every return path of `_ExecuteEffect`
+ * (GameAssembly.dll 2.7.61 / build 2761, VA 0x183e2de80; returns at VA
+ * 0x183e2e681/0x183e2e723) is `return false`, and the dispatch layer
+ * `ExecutorComponent.Execute` (VA 0x183e45b10) treats "no executor" and
+ * "executor returned false" identically — both immediately `FinishCommand()`.
+ * So warn-and-continue is advancement-equivalent to native; the only loss is
+ * the particle visuals (`AVG/Effects/Battle/<name>` ParticleEffect prefabs), a
+ * deliberate web omission. `effect` has no cross-command side effects (no
+ * decision value, no signal), so skipping it can never change which branch a
+ * story takes. Warnings fire once per command name (see the `default` branch
+ * of `executeBuiltinCommand`): production scripts use `[Effect(...)]` up to 65
+ * times in one file (obt/main/level_main_14-10_beg.txt), and per-line console
+ * noise would drown real diagnostics.
+ */
 const unsupportedAd8Commands = new Set(["bgeffect", "effect"]);
 
 interface InterruptibleWait {
@@ -357,6 +373,8 @@ export class StoryRuntime {
   private multilineShownChars = 0;
   private readonly stickerIds = new Set<string>();
   private pendingInputEffect: (() => Promise<void> | void) | null = null;
+  /** unsupportedAd8Commands 的告警去重：每命令名只警告一次 */
+  private readonly warnedUnsupportedCommands = new Set<string>();
 
   constructor(
     context: Context,
@@ -2508,7 +2526,15 @@ export class StoryRuntime {
 
       default: {
         if (unsupportedAd8Commands.has(line.command)) {
-          this.warn("unsupported_command", line.command);
+          // Native provenance (`effect`): see the note on
+          // `unsupportedAd8Commands` — `_ExecuteEffect` always returns false
+          // and `ExecutorComponent.Execute` immediately FinishCommand()s, so
+          // skipping without sleeping, rendering, or leaving state matches
+          // native advancement. Warn once per command name.
+          if (!this.warnedUnsupportedCommands.has(line.command)) {
+            this.warnedUnsupportedCommands.add(line.command);
+            this.warn("unsupported_command", line.command);
+          }
           return "continue";
         }
 

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -865,6 +865,41 @@ describe("StoryRuntime", () => {
     );
   });
 
+  it("warns once per unsupported command name, still advancing every line", async () => {
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[Effect(name="$e_spark_01_mid",x=640,y=360)]',
+        '[Effect(name="$e_bladeline_01_large",layer=1)]',
+        // Corpus sample: activities/act28side/level_act28side_st01.txt:416 —
+        // the only movetime user, whose CamelCase xTo never matches native's
+        // case-sensitive `xto` lookup, so even native performs no move.
+        '[Effect(name="$e_fist_hit_01",x=50,xTo=100,movetime=0.3)]',
+        '[name="A"]ok',
+      ]),
+      new FakeRenderer(),
+      new FakeAudio(),
+      {
+        onWarning: (warning) => warnings.push(warning),
+      },
+    );
+
+    await runtime.start();
+
+    // Native `_ExecuteEffect` (2.7.61, VA 0x183e2de80) always returns false,
+    // so every skipped line advances exactly like native; only the first hit
+    // warns to keep high-frequency scripts from flooding the console.
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(
+      warnings.filter((warning) => warning.type === "unsupported_command"),
+    ).toEqual([
+      expect.objectContaining({
+        detail: "effect",
+        type: "unsupported_command",
+      }),
+    ]);
+  });
+
   it("blocks on video command until playback completes", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(


### PR DESCRIPTION
## 背景

基于官服客户端 2.7.61(build 2761)GameAssembly.dll 的 IDA 反编译复核(逆向笔记见 arknights-rev `docs/impl-review/impl-review-effect-command.md`),`effect` 命令的 native 语义:

- `AVGBattleEffectPanel.GetExecutors`(VA `0x183e2c8c0`)注册 `effect`/`bgeffect`/`imgeffect` 三个 executor;分发层 `ExecutorComponent.Execute`(VA `0x183e45b10`)对「executor 不存在」与「executor 返回 false」处理完全相同——都立即 `FinishCommand()` 放行下一条命令。
- `effect` 的 executor `_ExecuteEffect`(VA `0x183e2de80`)**所有**返回路径都是 `return false`(VA `0x183e2e681`/`0x183e2e723`),即 native 里这条命令永不阻塞;特效经 `AVG/Effects/Battle/<name>`(`GetBattleEffectPath`,VA `0x183e8fe20`)加载 ParticleEffect,`delay` 秒后实例化,按 prefab 自带 duration 自播自毁。
- `effect` 无任何跨命令副作用(不写 decision 值、不产生 signal),跳过它不会让剧情走错分支。

因此前端「解析注册 + warn-only 跳过」与 native 的推进语义**逐点一致、控制流安全**;粒子视觉缺失是已知有意省略(web 无该资产域/ParticleEffect SDK),本次不做渲染补偿。

## 修复内容

按 review 差异清单(P1×1、P2×2、P3×3)逐条处置:

| # | 严重度 | 条目 | 处置 |
| --- | --- | --- | --- |
| 1 | P1 | 粒子特效未渲染 | 接受、降 P3:不实现渲染(native 侧也是外部 SDK 层),在 `unsupportedAd8Commands` 注释中记录该取舍与 native 依据 |
| 2 | P2 | 警告噪音(高频剧本每播放刷数十条 `unsupported_command`) | **修复**:`executeBuiltinCommand` default 分支改为每命令名只警告一次(`warnedUnsupportedCommands` 集合,实例级;runtime 无 seek/restart,单次播放生命周期内去重安全),推进语义不变 |
| 3 | P2 | 资产加载失败语义 | 无需处理:前端不加载无从失败,注释记录 native 是 LogError 后放行不阻塞 |
| 4 | P3 | 预载缺失 | 记录:`preload.ts` 的 `addScriptImageUrls` provenance 注释补记 native `GatherResRefs`(VA `0x183e46d40`)会收集 `AVG/Effects/Battle/<name>`,web 有意不收集 |
| 5 | P3 | 重置/销毁语义 | 无需处理:前端无状态天然等价(2.7.61 `OnReset` VA `0x183e2cab0` 已含 `ClearAllChildren`,历史文档「清不掉」论断失效,由 review 文档记录) |
| 6 | P3 | `delay` 生成延迟 | 视觉省略的子集,随 #1 接受 |

改动文件:
- `src/widgets/StoryPlayer/engine/runtime.ts` — 告警去重(行为改动)+ `unsupportedAd8Commands`/default 分支的 Native provenance 注释(VA 见上)
- `src/widgets/StoryPlayer/engine/preload.ts` — 预载有意省略的记录性注释
- `tests/runtime.spec.ts` — 新增「每命令名只警告一次且逐行推进」单测

`unsupportedAd8Commands` 为 effect/bgeffect 共享表,本次只加注释、不改集合成员(最小 diff)。

## 验证用剧情文件

语料根 `/home/xwbx/Documents/torappu/storage/asset/gamedata/latest/story/`,`[Effect(` 共 1027 处 / 231 个文件:

- `obt/main/level_main_14-10_beg.txt`(全语料最密,单文件 65 处)— 验证告警去重:65 条 effect 仅 1 条 `unsupported_command` 警告
- `activities/act28side/level_act28side_st01.txt:416` — 唯一 `movetime` 样本(CamelCase `xTo`,native 大小写敏感查不到 `xto` → 移动不发生),验证跳过不影响后续推进
- `obt/main/level_main_17-09_end.txt:571` — `flip=2` 样本(2.7.61 `_TryParseRotation` VA `0x183e2f260`:`flip==2 → x += 180`),纯视觉参数
- `obt/main/level_main_11-15_beg.txt:378` — `y = ,` 畸形空值样本,验证 parser 不崩、跳过照常

## 测试

- `pnpm test`:223 用例全绿(基线 222 + 新增 1)
- `pnpm exec vue-tsc -b`:通过
- `pnpm exec eslint` 改动文件:通过
- `STORY_CORPUS_ROOT=... pnpm test:story-log` 全语料 Log All 回归:2/2 通过(与独立 oracle 全路径对拍一致,确认去重不影响任何分支/文本可见性)
