### PR TITLE
fix(story-player): camerashake duration 接入 animateRatio 并补全 provenance 注释

### DIFF
--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -2189,18 +2189,24 @@ export class StoryRuntime {
       }
 
       case "camerashake": {
-        // Native port: Torappu.AVG.AVGCameraEffect._ExecuteCameraShake. Duration,
+        // Native port: Torappu.AVG.AVGCameraEffect._ExecuteCameraShake. Duration
+        // defaults to -1 and falls back to 10s with infinite loops; `fadetime`
+        // is never read. Duration is scaled by AVGController.animateRatio
+        // before anything else (2.7.61 GameAssembly @ 0x183E32E52): the scaled
+        // value drives the loops sign test (scaled >= 0 ? 1 : -1), the 10.0s
+        // fallback, and DOTween's waypoint count. Native then short-circuits on
+        // MathUtil.IsZero(scaled) (0x183E32EFD), so quick-play speeds
+        // (animateRatio = 0) skip the shake entirely; the renderer's
+        // durationMs <= 0 skip reproduces that without blocking.
+        const scaledDuration =
+          toNumber(this.exactArg(args, "duration"), -1) *
+          this.getCurrentSpeed().animateRatio;
         await this.renderer.shakeCamera({
           block: toBoolean(this.exactArg(args, "block"), false),
           durationMs:
-            toNumber(this.exactArg(args, "duration"), -1) < 0
-              ? 10_000
-              : Math.max(
-                  0,
-                  toNumber(this.exactArg(args, "duration"), 0) * 1000,
-                ),
+            scaledDuration < 0 ? 10_000 : Math.max(0, scaledDuration * 1000),
           fadeOut: toBoolean(this.exactArg(args, "fadeout"), false),
-          infinite: toNumber(this.exactArg(args, "duration"), -1) < 0,
+          infinite: scaledDuration < 0,
           randomness: toNumber(this.exactArg(args, "randomness"), 90),
           stop: toBoolean(this.exactArg(args, "stop"), false),
           vibrato: Math.trunc(toNumber(this.exactArg(args, "vibrato"), 10)),

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1587,6 +1587,79 @@ describe("StoryRuntime", () => {
     expect(runtime.getState()).toBe("waiting_input");
   });
 
+  it("scales camerashake duration by animateRatio before the infinite sign test", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext(["[camerashake(duration=2,block=true)]", '[name="A"]done']),
+      renderer,
+      new FakeAudio(),
+      { animateRatio: 0.25 },
+    );
+
+    await runtime.start();
+
+    // Native computes scaled = animateRatio * duration once (0x183E32E52);
+    // loops/durationMs/waypoint count all derive from the scaled value.
+    expect(renderer.shakeCalls).toEqual([
+      {
+        block: true,
+        durationMs: 500,
+        fadeOut: false,
+        infinite: false,
+        randomness: 90,
+        stop: false,
+        vibrato: 10,
+        xStrength: 1,
+        yStrength: 0,
+      },
+    ]);
+  });
+
+  it("skips camerashake entirely at animateRatio 0 like native IsZero", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        "[camerashake(duration=2,block=true)]",
+        "[camerashake(duration=0.5)]",
+        '[name="A"]done',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { animateRatio: 0 },
+    );
+
+    await runtime.start();
+
+    // animateRatio 0 collapses every duration (including the -1 default) to
+    // ±0; native MathUtil.IsZero(scaled) returns without shaking or blocking,
+    // and the renderer's durationMs <= 0 skip mirrors that.
+    expect(renderer.shakeCalls).toEqual([
+      {
+        block: true,
+        durationMs: 0,
+        fadeOut: false,
+        infinite: false,
+        randomness: 90,
+        stop: false,
+        vibrato: 10,
+        xStrength: 1,
+        yStrength: 0,
+      },
+      {
+        block: false,
+        durationMs: 0,
+        fadeOut: false,
+        infinite: false,
+        randomness: 90,
+        stop: false,
+        vibrato: 10,
+        xStrength: 1,
+        yStrength: 0,
+      },
+    ]);
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
   it("maps blocker RGBA endpoints, styles, and native zero-duration blocking", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `camerashake` 命令移植 review 中要求修复的差异（P2×1：duration 未乘 animateRatio；P3×1：注释截断）。依据是对明日方舟官服客户端（2.7.61 / build 2761，Unity IL2CPP）GameAssembly.dll 的 IDA 反编译复核，关键结论在下文直接给出，不依赖外部文档。

## 背景：native 的 camerashake 时长缩放（2.7.61 / build 2761 IDA 反编译复核）

- `Torappu.AVG.AVGCameraEffect._ExecuteCameraShake`（VA `0x183E32B50`）读取 `duration`（float，默认 **-1.0**）后**先乘 `AVGController.animateRatio`** 得 `scaled`（`0x183E32E52`），后续全部基于 `scaled`：
  - hotfix `NeedSkipAnimation` 缺省时等价 `MathUtil.IsZero(scaled)` → 直接 `return 0`，不抖动也不阻塞（`0x183E32EFD`）；
  - `effectiveDuration = scaled >= 0 ? scaled : 10.0`（`0x183E32EFE`-`0x183E32F0A`）；
  - `SetLoops(scaled >= 0 ? 1 : -1)`：duration 缺省/负值 → 10 秒无限循环；
  - DOTween Shake 路径节点数 `count = max(2, (int)(vibrato * effectiveDuration))` 同样用缩放后值（`DOTween::Shake` 核心 `0x184109370`）。
- 推论：quick-play 等加速档 `animateRatio = 0` 时，任何 duration（含 -1 缺省）都缩放为 ±0，命中 IsZero 短路，camerashake 整体跳过（`-1 * 0 = -0`，`-0 >= 0` 成立、IsZero 成立）。
- `fadetime` 参数全程不被读取（2.7.61 明文字符串确认）。

## 修复内容

| 差异清单条目 | 改法 |
| --- | --- |
| P2 #1 `duration` 未乘 `animateRatio` | `engine/runtime.ts` camerashake 分支改为 `scaledDuration = toNumber(duration, -1) * getCurrentSpeed().animateRatio`，`durationMs`（缩放后毫秒；`scaled < 0` 仍兜底 `10_000`）与 `infinite`（scaled 符号判定）均基于缩放后值——与 `calculateFadeMs` 家族 / `delay` 命令同源的缩放机制。quick-play（animateRatio=0）下 durationMs=0，由 renderer 既有的 `durationMs <= 0` 跳过路径复刻 native IsZero 短路（不抖、block 不阻塞）。 |
| P3 #5 注释截断 | `runtime.ts` 原注释 `"..._ExecuteCameraShake. Duration,"` 句子不完整，补全为完整 native provenance：duration 缺省 -1 兜底 10s 无限循环、fadetime 不读取、animateRatio 先缩放（含 VA `0x183E32E52` / `0x183E32EFD`）及 IsZero 短路语义。 |

其余 P3 条目（#2 逐轴幅度精确系数、#3 无限 shake 阻塞解除面、#4 IsZero epsilon 语义）按 review 结论**维持现状不改**（结构等价/观察面相同/视觉等价）。

## 验证用剧情文件

语料根 `gamedata/story/`（全语料 14145 处 camerashake，14105 处带正 duration 走缩放分支，40 处缺省 duration 走无限分支）：

- `obt/guide/beg/0_welcome_to_guide.txt:122` — `[CameraShake(duration=0.5, xstrength=3, ystrength=4, vibrato=30, randomness=90, block=true)]`：正 duration 缩放分支。默认速度（animateRatio=1）行为不变（500ms 有限抖动、block 阻塞至周期结束）；quick-play 下按 native IsZero 跳过且不阻塞。
- `obt/main/level_main_10-15_beg.txt:59` — `[CameraShake(xstrength=5, ystrength=3, vibrato=30, randomness=90)]`：duration 缺省 → `-1` → 10s 无限循环分支。默认速度不变；quick-play 下同样归零跳过（native `scaled = -1 * 0 = -0` → IsZero）。

## 测试

- `pnpm test`：**224 passed**（基线 222 + 新增 2）：
  - 新增 `tests/runtime.spec.ts` `scales camerashake duration by animateRatio before the infinite sign test`：animateRatio=0.25 时 `duration=2` → `durationMs=500`、`infinite=false`；
  - 新增 `tests/runtime.spec.ts` `skips camerashake entirely at animateRatio 0 like native IsZero`：animateRatio=0 时 `durationMs=0`、`infinite=false`（含 `block=true` 不阻塞）；
  - 既有 `maps camerashake to native defaults and parameters`（默认参数映射、缺省 → 10s 无限）保持通过。
- `pnpm exec vue-tsc -b` 通过；`pnpm exec eslint`（改动文件）通过。
