### PR TITLE
fix(story-player): cameraeffect 对齐 native:灰度渲染公式(Rec.601 luma lerp)、OutQuad 缓动、animateRatio 缩放与负 initamount 语义

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -56,6 +56,7 @@ import {
   type TimerStickerInput,
 } from "../types";
 
+import { buildColorEffectMatrix } from "./core/ColorEffectMatrix";
 import { LayerGraph } from "./core/LayerGraph";
 import {
   applyCenteredTransform as applyCenteredTransformToRoot,
@@ -1972,11 +1973,13 @@ export class PixiStoryRenderer implements StoryRenderer {
       this.updateCameraFilter();
       return;
     }
-    // Native `_TweenGrayscaleAmount` (2.7.61 VA 0x183E33C60): any negative
-    // initamount (MathUtil.LT(initAmount, 0), not just the omitted key's -1
-    // default) starts from the current grayscale amount via
-    // GetEffectAmount("grayscale", "grayscale"); non-negative values are the
-    // explicit tween start.
+    // Native `_TweenGrayscaleAmount` (2.7.61 VA 0x183E33C60): a negative
+    // initamount (not just the omitted key's -1 default) starts from the
+    // current grayscale amount via GetEffectAmount("grayscale", "grayscale");
+    // other values are the explicit tween start. Native tests it with
+    // MathUtil.LT(initAmount, 0), which decompiles to `-1e-5 > initAmount`, so
+    // its real threshold sits an epsilon below 0; the plain `>= 0` here only
+    // differs over [-1e-5, 0), which no story script hits.
     const from =
       initialAmount !== undefined && initialAmount >= 0
         ? initialAmount
@@ -1987,9 +1990,14 @@ export class PixiStoryRenderer implements StoryRenderer {
       durationMs,
       (progress) => {
         // Native: the executor never calls SetEase, so DOTween.To tweens with
-        // DOTween 1.2.760's defaultEaseType = Ease.OutQuad (fast-then-slow),
-        // not linear interpolation. Map 1-(1-t)^2 per frame like the native
-        // setter closure (VA 0x183E48CA0) does.
+        // DOTween's default ease. This build ships DOTween 1.2.760, whose
+        // cctor (VA 0x18410B0E0) writes defaultEaseType = 6 = Ease.OutQuad
+        // (fast-then-slow), not linear. DOTween.AutoInit does let a
+        // Resources/DOTweenSettings asset overwrite that field, and the asset
+        // lives in the player's resources.assets rather than a hot-update
+        // bundle so it cannot be read here — but OutQuad is also
+        // DOTweenSettings' own default, so the compiled value stands.
+        // DOTween's OutQuad is `-t*(t-2)`, i.e. the 1-(1-t)^2 below.
         const eased = 1 - (1 - progress) ** 2;
         this.grayscaleAmount = from + (amount - from) * eased;
         this.updateCameraFilter();
@@ -2021,50 +2029,14 @@ export class PixiStoryRenderer implements StoryRenderer {
     if (!this.grayscaleFilter) this.grayscaleFilter = new ColorMatrixFilter();
 
     // Native AVGSceneGrayScale blits the scene once with
-    // AVG/[UC]Common/Arts/Materials/mat_grayscale (Torappu/PostEffect/
-    // Grayscale; formula verified against the GLES3 GLSL in the 2.7.51
-    // Android [uc]shaders.ab bundle): `_Params` = (0.299, 0.587, 0.114,
-    // grayAmount) desaturates by Rec.601 luma (amount 0 = identity), and
-    // `_Inverse` lerps toward 1-color. Native applies inverse before the
-    // luma lerp; the reverse order used here is algebraically equivalent
-    // because the Rec.601 weights sum to 1. pixi's grayscale()/negative()
-    // helpers cannot express this — grayscale() is an additive [s,s,s] tint
-    // that clips mid-grays to white near amount 1, and sequential
-    // multiply=false calls overwrite each other — so compose the 4x5 matrix
-    // directly: lerp(color, luma, gray), then lerp(prev, 1-prev, inverse)
-    // which scales rows by (1-2*inverse) and offsets by `inverse`. The alpha
-    // row stays identity on purpose: native's blit replaces the whole target
-    // so its alpha inversion is invisible, while pixi uses filter alpha for
-    // layer compositing.
-    const gray = this.grayscaleAmount;
-    const inverse = this.inverseAmount;
-    const scale = 1 - 2 * inverse;
-    const lumR = 0.299 * gray;
-    const lumG = 0.587 * gray;
-    const lumB = 0.114 * gray;
-    const diag = 1 - gray;
-    this.grayscaleFilter.matrix = [
-      (lumR + diag) * scale,
-      lumG * scale,
-      lumB * scale,
-      0,
-      inverse,
-      lumR * scale,
-      (lumG + diag) * scale,
-      lumB * scale,
-      0,
-      inverse,
-      lumR * scale,
-      lumG * scale,
-      (lumB + diag) * scale,
-      0,
-      inverse,
-      0,
-      0,
-      0,
-      1,
-      0,
-    ];
+    // AVG/[UC]Common/Arts/Materials/mat_grayscale, writing
+    // `_Params = (0.299, 0.587, 0.114, grayAmount)` and `_Inverse`. See
+    // buildColorEffectMatrix for the shader math and why pixi's
+    // grayscale()/negative() helpers cannot express it.
+    this.grayscaleFilter.matrix = buildColorEffectMatrix(
+      this.grayscaleAmount,
+      this.inverseAmount,
+    );
     this.sceneLayer.filters = [this.grayscaleFilter];
   }
 

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1957,8 +1957,7 @@ export class PixiStoryRenderer implements StoryRenderer {
    *   effect record on story reset/skip; the web player rebuilds the renderer
    *   per playback instead, so no explicit reset exists here.
    * - Colorinverse amount is a shader `_Inverse` float natively (interpolable
-   *   0..1); this command only ever writes 0/1, where `negative()` is
-   *   equivalent.
+   *   0..1, modeled below as `lerp(prev, 1-prev, inverse)` in the matrix).
    */
   async setCameraEffect(
     effect: "Colorinverse" | "Grayscale",
@@ -2021,10 +2020,51 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     if (!this.grayscaleFilter) this.grayscaleFilter = new ColorMatrixFilter();
 
-    this.grayscaleFilter.reset();
-    if (this.grayscaleAmount !== 0)
-      this.grayscaleFilter.grayscale(this.grayscaleAmount, false);
-    if (this.inverseAmount !== 0) this.grayscaleFilter.negative(false);
+    // Native AVGSceneGrayScale blits the scene once with
+    // AVG/[UC]Common/Arts/Materials/mat_grayscale (Torappu/PostEffect/
+    // Grayscale; formula verified against the GLES3 GLSL in the 2.7.51
+    // Android [uc]shaders.ab bundle): `_Params` = (0.299, 0.587, 0.114,
+    // grayAmount) desaturates by Rec.601 luma (amount 0 = identity), and
+    // `_Inverse` lerps toward 1-color. Native applies inverse before the
+    // luma lerp; the reverse order used here is algebraically equivalent
+    // because the Rec.601 weights sum to 1. pixi's grayscale()/negative()
+    // helpers cannot express this — grayscale() is an additive [s,s,s] tint
+    // that clips mid-grays to white near amount 1, and sequential
+    // multiply=false calls overwrite each other — so compose the 4x5 matrix
+    // directly: lerp(color, luma, gray), then lerp(prev, 1-prev, inverse)
+    // which scales rows by (1-2*inverse) and offsets by `inverse`. The alpha
+    // row stays identity on purpose: native's blit replaces the whole target
+    // so its alpha inversion is invisible, while pixi uses filter alpha for
+    // layer compositing.
+    const gray = this.grayscaleAmount;
+    const inverse = this.inverseAmount;
+    const scale = 1 - 2 * inverse;
+    const lumR = 0.299 * gray;
+    const lumG = 0.587 * gray;
+    const lumB = 0.114 * gray;
+    const diag = 1 - gray;
+    this.grayscaleFilter.matrix = [
+      (lumR + diag) * scale,
+      lumG * scale,
+      lumB * scale,
+      0,
+      inverse,
+      lumR * scale,
+      (lumG + diag) * scale,
+      lumB * scale,
+      0,
+      inverse,
+      lumR * scale,
+      lumG * scale,
+      (lumB + diag) * scale,
+      0,
+      inverse,
+      0,
+      0,
+      0,
+      1,
+      0,
+    ];
     this.sceneLayer.filters = [this.grayscaleFilter];
   }
 

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1950,6 +1950,15 @@ export class PixiStoryRenderer implements StoryRenderer {
    * Port scope: `Torappu.AVG.AVGCameraEffect._ExecuteCameraEffect` for the
    * grayscale/inverse branches and their completion behavior. A PIXI color
    * filter substitutes for `AVGSceneEffectManager`'s camera post-process.
+   *
+   * Deliberately unported (verified on 2.7.61 / build 2761 IDA decompile):
+   * - Chaos: dual-material distortion, intentionally skipped upstream.
+   * - Reset lifecycle: native `OnReset`/`ShouldResetOnSkip=true` clears the
+   *   effect record on story reset/skip; the web player rebuilds the renderer
+   *   per playback instead, so no explicit reset exists here.
+   * - Colorinverse amount is a shader `_Inverse` float natively (interpolable
+   *   0..1); this command only ever writes 0/1, where `negative()` is
+   *   equivalent.
    */
   async setCameraEffect(
     effect: "Colorinverse" | "Grayscale",
@@ -1964,13 +1973,26 @@ export class PixiStoryRenderer implements StoryRenderer {
       this.updateCameraFilter();
       return;
     }
-    const from = initialAmount ?? this.grayscaleAmount;
+    // Native `_TweenGrayscaleAmount` (2.7.61 VA 0x183E33C60): any negative
+    // initamount (MathUtil.LT(initAmount, 0), not just the omitted key's -1
+    // default) starts from the current grayscale amount via
+    // GetEffectAmount("grayscale", "grayscale"); non-negative values are the
+    // explicit tween start.
+    const from =
+      initialAmount !== undefined && initialAmount >= 0
+        ? initialAmount
+        : this.grayscaleAmount;
     this.grayscaleAmount = from;
     this.updateCameraFilter();
     const run = this.tween(
       durationMs,
       (progress) => {
-        this.grayscaleAmount = from + (amount - from) * progress;
+        // Native: the executor never calls SetEase, so DOTween.To tweens with
+        // DOTween 1.2.760's defaultEaseType = Ease.OutQuad (fast-then-slow),
+        // not linear interpolation. Map 1-(1-t)^2 per frame like the native
+        // setter closure (VA 0x183E48CA0) does.
+        const eased = 1 - (1 - progress) ** 2;
+        this.grayscaleAmount = from + (amount - from) * eased;
         this.updateCameraFilter();
       },
       () => {

--- a/src/widgets/StoryPlayer/engine/rendering/core/ColorEffectMatrix.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/ColorEffectMatrix.ts
@@ -1,0 +1,88 @@
+import type { ColorMatrix } from "pixi.js";
+
+/**
+ * Rec.601 luma weights, matching the `_Params.xyz` the native material writes
+ * (`0.29899999, 0.58700001, 0.114` as float32). They sum to 1, so desaturating
+ * with them preserves brightness.
+ */
+const LUMA_R = 0.299;
+const LUMA_G = 0.587;
+const LUMA_B = 0.114;
+
+/**
+ * Builds the 4x5 `ColorMatrixFilter` matrix that models Torappu's shared
+ * post-effect material `AVG/[UC]Common/Arts/Materials/mat_grayscale` (shader
+ * `Torappu/PostEffect/Grayscale`).
+ *
+ * Two native implementations blit through that one material, so both route
+ * here: `AVGSceneGrayScale` (2.7.61 `_ApplyAmountsToMaterial` @ 0x183E86CF0,
+ * driven by `cameraeffect`) and `AVGSceneFocusOut` (`Render` @ 0x183E859D0,
+ * driven by `focusout`/`focusparam`). Both write
+ * `_Params = (0.299, 0.587, 0.114, grayAmount)` and `_Inverse = inverseAmount`.
+ *
+ * Fragment math, verified against the GLES3 GLSL in the 2.7.51 Android
+ * `[uc]shaders.ab` bundle:
+ *
+ * ```
+ * A   = lerp(color, 1 - color, _Inverse)
+ * out = lerp(A.rgb, dot(A.rgb, _Params.xyz), _Params.w)
+ * ```
+ *
+ * The matrix below applies the two lerps in the opposite order — desaturate,
+ * then invert — which is algebraically identical because the Rec.601 weights
+ * sum to 1:
+ *
+ * ```
+ * out = (1 - 2*inverse) * lerp(color, luma601(color), gray) + inverse
+ * ```
+ *
+ * so the rgb rows are `lerp(I, luma601 row, gray)` scaled by `1 - 2*inverse`
+ * with an `inverse` offset. `gray = 1` yields rows of exactly
+ * `(0.299, 0.587, 0.114)`.
+ *
+ * pixi's `ColorMatrixFilter.grayscale()`/`negative()` helpers cannot express
+ * this: `grayscale()` builds an *additive* `[s, s, s]` tint whose output is
+ * `s * (R + G + B)`, which clips mid-grays to white near amount 1, and
+ * sequential `multiply = false` calls overwrite each other instead of
+ * composing.
+ *
+ * The alpha row stays identity on purpose. Native inverts alpha too, but its
+ * blit replaces the whole render target (srcBlend 1 / destBlend 0) so that is
+ * invisible; pixi feeds filter alpha into layer compositing, where inverting it
+ * would be very visible. Deliberate divergence — do not "fix".
+ *
+ * @param gray Desaturation amount (`_Params.w`). 0 = identity, 1 = full luma.
+ * @param inverse Inversion amount (`_Inverse`). 0 = identity, 1 = full negative.
+ */
+export function buildColorEffectMatrix(
+  gray: number,
+  inverse: number,
+): ColorMatrix {
+  const scale = 1 - 2 * inverse;
+  const lumR = LUMA_R * gray;
+  const lumG = LUMA_G * gray;
+  const lumB = LUMA_B * gray;
+  const diag = 1 - gray;
+  return [
+    (lumR + diag) * scale,
+    lumG * scale,
+    lumB * scale,
+    0,
+    inverse,
+    lumR * scale,
+    (lumG + diag) * scale,
+    lumB * scale,
+    0,
+    inverse,
+    lumR * scale,
+    lumG * scale,
+    (lumB + diag) * scale,
+    0,
+    inverse,
+    0,
+    0,
+    0,
+    1,
+    0,
+  ];
+}

--- a/src/widgets/StoryPlayer/engine/rendering/panels/FocusEffectPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/FocusEffectPanel.ts
@@ -1,5 +1,7 @@
 import { BlurFilter, ColorMatrixFilter, type Container } from "pixi.js";
 
+import { buildColorEffectMatrix } from "../core/ColorEffectMatrix";
+
 import type { FocusOutInput, FocusParamInput } from "../../types";
 
 type Tween = (
@@ -97,9 +99,20 @@ export class FocusEffectPanel {
       if (amount > 0 && this.config.blur)
         filters.push(new BlurFilter({ strength: amount * 8 }));
       if (amount > 0 && this.config.color !== "None") {
+        // Native `AVGSceneFocusOut.Render` (2.7.61 VA 0x183E859D0) blits with
+        // the same AVG/[UC]Common/Arts/Materials/mat_grayscale material as
+        // `cameraeffect`, writing `_Params = (0.299, 0.587, 0.114,
+        // color == Grayscale)` and `_Inverse = (color == Colorinverse)` — the
+        // channel is binary there, and the per-item focus amount is applied
+        // afterwards by compositing the processed target back through
+        // mat_blit_ghost. That composite is a lerp between the original and
+        // the fully processed pixel, which is exactly what feeding `amount`
+        // into the matrix models, so both channels scale with it.
         const color = new ColorMatrixFilter();
-        if (this.config.color === "Grayscale") color.grayscale(amount, false);
-        else color.negative(false);
+        color.matrix =
+          this.config.color === "Grayscale"
+            ? buildColorEffectMatrix(amount, 0)
+            : buildColorEffectMatrix(0, amount);
         filters.push(color);
       }
       target.filters = filters;

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -2198,17 +2198,25 @@ export class StoryRuntime {
       }
 
       case "cameraeffect": {
-        // Native port: Torappu.AVG.AVGCameraEffect._ExecuteCameraEffect. This
-        // covers its Grayscale/Colorinverse/Chaos dispatch and scaled fadetime.
+        // Native port: Torappu.AVG.AVGCameraEffect._ExecuteCameraEffect
+        // (2.7.61 VA 0x183E32560): case-sensitive Grayscale/Colorinverse
+        // dispatch. Chaos is intentionally unimplemented and degraded to a
+        // warning upstream (see setCameraEffect's port-scope note).
         const effect = toString(this.exactArg(args, "effect"));
         const block = toBoolean(this.exactArg(args, "block"), false);
         const keep = toBoolean(this.exactArg(args, "keep"), false);
         // AVGCameraEffect._defaultFadetime is serialized as 0.4 on
         // AVGController > AVGCamera_Scene; a 0 default would make every
         // fadetime-less cameraeffect invisible.
+        // Native scales the raw seconds by AVGController.animateRatio
+        // (0x183E327C1) before tweening; apply the same current-speed ratio
+        // as `delay` and `calculateFadeMs` (button_auto keeps 1, quick_play
+        // collapses tweens to instant).
         const fadeMs = Math.max(
           0,
-          toNumber(this.exactArg(args, "fadetime"), 0.4) * 1000,
+          toNumber(this.exactArg(args, "fadetime"), 0.4) *
+            this.getCurrentSpeed().animateRatio *
+            1000,
         );
         if (effect === "Chaos") {
           this.warn("unsupported_visual", "cameraeffect:Chaos");

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -2,14 +2,43 @@ import { Container, Sprite, Texture } from "pixi.js";
 import { describe, expect, it, vi } from "vitest";
 
 import { PixiStoryRenderer } from "../src/widgets/StoryPlayer/engine/renderer";
+import { TweenRunner } from "../src/widgets/StoryPlayer/engine/rendering/core/TweenRunner";
 
 import type { Context } from "../src/widgets/StoryPlayer/context";
+import type { AnimationClock } from "../src/widgets/StoryPlayer/engine/execution";
 import type { GridBackgroundInput } from "../src/widgets/StoryPlayer/engine/types";
 
 function createContext(): Context {
   return {
     linkMap: {},
     script: [],
+  };
+}
+
+function createManualClock(): {
+  advance: (ms: number) => void;
+  clock: AnimationClock;
+  drainFrame: () => void;
+} {
+  const frames: Array<() => void> = [];
+  let now = 0;
+  const clock: AnimationClock = {
+    cancelFrame: () => {},
+    now: () => now,
+    requestFrame: (callback) => {
+      frames.push(callback);
+      return frames.length;
+    },
+  };
+  return {
+    advance: (ms) => {
+      now += ms;
+    },
+    clock,
+    drainFrame: () => {
+      const frame = frames.shift();
+      if (frame) frame();
+    },
   };
 }
 
@@ -307,6 +336,44 @@ describe("PixiStoryRenderer", () => {
       enterFrom: "left",
     });
     expect(renderer.characterSlots.get("m").actionX).toBe(0);
+  });
+
+  it("eases the cameraeffect grayscale tween with DOTween's default OutQuad", () => {
+    const manual = createManualClock();
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.tweenRunner = new TweenRunner(() => true, manual.clock);
+
+    void renderer.setCameraEffect("Grayscale", 1, 1000, false, true, 0);
+
+    expect(renderer.grayscaleAmount).toBe(0);
+    manual.advance(500);
+    manual.drainFrame();
+    // Native AVGCameraEffect never calls SetEase, so DOTween.To runs with
+    // DOTween 1.2.760's defaultEaseType=6 (OutQuad): halfway = 0.75, not the
+    // linear 0.5.
+    expect(renderer.grayscaleAmount).toBeCloseTo(0.75);
+    manual.advance(500);
+    manual.drainFrame();
+    expect(renderer.grayscaleAmount).toBe(1);
+  });
+
+  it("starts the grayscale tween from the current amount for any negative initamount", async () => {
+    const manual = createManualClock();
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.tweenRunner = new TweenRunner(() => true, manual.clock);
+
+    await renderer.setCameraEffect("Grayscale", 0.6, 0, false, true);
+    expect(renderer.grayscaleAmount).toBe(0.6);
+
+    void renderer.setCameraEffect("Grayscale", 1, 1000, false, true, -1);
+
+    // Native _TweenGrayscaleAmount checks MathUtil.LT(initAmount, 0): any
+    // negative initamount means "start from the current grayscale amount",
+    // not an explicit negative start.
+    expect(renderer.grayscaleAmount).toBe(0.6);
+    manual.advance(500);
+    manual.drainFrame();
+    expect(renderer.grayscaleAmount).toBeCloseTo(0.9);
   });
 
   it("swaps expressions of the same native character without cross-fading", async () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -15,8 +15,11 @@ function createContext(): Context {
   };
 }
 
+// Turns the -0 that `0 * -1` produces into +0 so `toEqual` stops
+// distinguishing them. Deliberately narrow: `v || 0` would also swallow NaN
+// and let a broken matrix pass.
 function normalizeZero(values: number[]): number[] {
-  return values.map((v) => v || 0);
+  return values.map((v) => (v === 0 ? 0 : v));
 }
 
 function createManualClock(): {
@@ -380,6 +383,24 @@ describe("PixiStoryRenderer", () => {
     expect(renderer.grayscaleAmount).toBeCloseTo(0.9);
   });
 
+  it("starts the grayscale tween from an explicit non-negative initamount", async () => {
+    const manual = createManualClock();
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.tweenRunner = new TweenRunner(() => true, manual.clock);
+
+    await renderer.setCameraEffect("Grayscale", 0.6, 0, false, true);
+    expect(renderer.grayscaleAmount).toBe(0.6);
+
+    // MathUtil.LT(0.2, 0) is false, so native takes the argument as the tween
+    // start and discards the 0.6 the effect manager currently holds.
+    void renderer.setCameraEffect("Grayscale", 1, 1000, false, true, 0.2);
+
+    expect(renderer.grayscaleAmount).toBe(0.2);
+    manual.advance(500);
+    manual.drainFrame();
+    expect(renderer.grayscaleAmount).toBeCloseTo(0.8);
+  });
+
   it("applies grayscale as Rec.601 luma desaturation, not an additive tint", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
 
@@ -425,6 +446,48 @@ describe("PixiStoryRenderer", () => {
     ]);
     expect(normalizeZero(bothMatrix.slice(10, 15))).toEqual([
       -0.299, -0.587, -0.114, 0, 1,
+    ]);
+  });
+
+  it("desaturates focusout targets with the same Rec.601 matrix as cameraeffect", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+
+    renderer.setFocusParam({ blur: false, color: "Grayscale" });
+    await renderer.setFocusOut({
+      block: false,
+      durationMs: 0,
+      id: "",
+      to: 1,
+      type: "bg",
+    });
+
+    // Native AVGSceneFocusOut.Render blits with the same mat_grayscale
+    // material as AVGSceneGrayScale, so focusout must not fall back to pixi's
+    // additive grayscale() tint either.
+    const filters = renderer.backgroundLayer.filters as { matrix: number[] }[];
+    expect(filters).toHaveLength(1);
+    expect(filters[0]!.matrix.slice(0, 5)).toEqual([0.299, 0.587, 0.114, 0, 0]);
+  });
+
+  it("scales the focusout inverse channel by the focus amount", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+
+    renderer.setFocusParam({ blur: false, color: "Colorinverse" });
+    await renderer.setFocusOut({
+      block: false,
+      durationMs: 0,
+      id: "",
+      to: 0.5,
+      type: "bg",
+    });
+
+    // Native keeps `_Inverse` binary and blends the processed target back in
+    // by the per-item amount through mat_blit_ghost; folding the amount into
+    // `_Inverse` models that same lerp, so a half-focused target collapses to
+    // flat mid-grey instead of fully inverting.
+    const filters = renderer.backgroundLayer.filters as { matrix: number[] }[];
+    expect(normalizeZero(filters[0]!.matrix.slice(0, 5))).toEqual([
+      0, 0, 0, 0, 0.5,
     ]);
   });
 

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -15,6 +15,10 @@ function createContext(): Context {
   };
 }
 
+function normalizeZero(values: number[]): number[] {
+  return values.map((v) => v || 0);
+}
+
 function createManualClock(): {
   advance: (ms: number) => void;
   clock: AnimationClock;
@@ -374,6 +378,54 @@ describe("PixiStoryRenderer", () => {
     manual.advance(500);
     manual.drainFrame();
     expect(renderer.grayscaleAmount).toBeCloseTo(0.9);
+  });
+
+  it("applies grayscale as Rec.601 luma desaturation, not an additive tint", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+
+    await renderer.setCameraEffect("Grayscale", 1, 0, false, true);
+
+    // Native AVGSceneGrayScale blits with mat_grayscale and writes
+    // _Params = (0.299, 0.587, 0.114, amount): Rec.601 luma desaturation
+    // where a mid-gray pixel stays mid-gray. pixi's
+    // ColorMatrixFilter.grayscale() builds an additive [s,s,s] matrix that
+    // clips mid-grays to white around amount 1, so the matrix is composed
+    // manually.
+    const matrix = renderer.sceneLayer.filters[0].matrix as number[];
+    expect(matrix.slice(0, 5)).toEqual([0.299, 0.587, 0.114, 0, 0]);
+    expect(matrix.slice(5, 10)).toEqual([0.299, 0.587, 0.114, 0, 0]);
+    expect(matrix.slice(10, 15)).toEqual([0.299, 0.587, 0.114, 0, 0]);
+    expect(matrix.slice(15, 20)).toEqual([0, 0, 0, 1, 0]);
+  });
+
+  it("composes Colorinverse over grayscale like the native _Inverse lerp", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+
+    await renderer.setCameraEffect("Colorinverse", 1, 0, false, true);
+
+    // Native _Inverse lerps each channel toward 1-color in the same blit:
+    // rows scale by -1 with offset 1. (normalizeZero turns the -0 produced
+    // by 0 * -1 into +0, which toEqual distinguishes.)
+    const inverseMatrix = renderer.sceneLayer.filters[0].matrix as number[];
+    expect(normalizeZero(inverseMatrix.slice(0, 5))).toEqual([-1, 0, 0, 0, 1]);
+    expect(normalizeZero(inverseMatrix.slice(5, 10))).toEqual([0, -1, 0, 0, 1]);
+    expect(normalizeZero(inverseMatrix.slice(10, 15))).toEqual([
+      0, 0, -1, 0, 1,
+    ]);
+
+    // With grayscale=1 kept from a previous command, desaturation and
+    // inversion compose into one matrix.
+    await renderer.setCameraEffect("Grayscale", 1, 0, false, true);
+    const bothMatrix = renderer.sceneLayer.filters[0].matrix as number[];
+    expect(normalizeZero(bothMatrix.slice(0, 5))).toEqual([
+      -0.299, -0.587, -0.114, 0, 1,
+    ]);
+    expect(normalizeZero(bothMatrix.slice(5, 10))).toEqual([
+      -0.299, -0.587, -0.114, 0, 1,
+    ]);
+    expect(normalizeZero(bothMatrix.slice(10, 15))).toEqual([
+      -0.299, -0.587, -0.114, 0, 1,
+    ]);
   });
 
   it("swaps expressions of the same native character without cross-fading", async () => {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1818,6 +1818,40 @@ describe("StoryRuntime", () => {
     );
   });
 
+  it("scales cameraeffect fade time by the current-speed animateRatio", async () => {
+    // Native 0x183E327C1: fadetime = raw * AVGController.animateRatio. The
+    // default speed keeps ratio 1, so only ratio-bearing speeds change it.
+    const scaledRenderer = new FakeRenderer();
+    const scaled = new StoryRuntime(
+      createContext([
+        "[cameraeffect(effect=Grayscale,amount=1,fadetime=2,block=true)]",
+        '[name="A"]ok',
+      ]),
+      scaledRenderer,
+      new FakeAudio(),
+      { animateRatio: 0.5 },
+    );
+
+    await scaled.start();
+
+    expect(scaledRenderer.cameraEffectCalls.at(-1)?.durationMs).toBe(1000);
+
+    const quickRenderer = new FakeRenderer();
+    const quick = new StoryRuntime(
+      createContext([
+        "[cameraeffect(effect=Grayscale,amount=1,fadetime=2,block=true)]",
+        '[name="A"]ok',
+      ]),
+      quickRenderer,
+      new FakeAudio(),
+    );
+
+    quick.setAutoPlayMode("quick_play");
+    await quick.start();
+
+    expect(quickRenderer.cameraEffectCalls.at(-1)?.durationMs).toBe(0);
+  });
+
   it("maps focusout duration, from and native blocking semantics without reading fadetime", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(


### PR DESCRIPTION
本 PR 修复 StoryPlayer 对 AVG `cameraeffect` 命令移植中的 4 项行为差异：1 项 P1 渲染公式错误（灰度过曝）+ 3 项 P2（灰度渐变缓动、fadetime 速度缩放、initamount 负值语义），并补全 provenance 注释。依据是对明日方舟官服客户端（2.7.61 / build 2761，Unity IL2CPP）GameAssembly.dll 的 IDA 反编译复核；其中灰度渲染公式额外经 **2.7.51 安卓 APK AssetBundle 中的明文 GLSL 实证**（shader `Torappu/PostEffect/Grayscale`）。关键结论已在下文直接给出，不依赖外部文档。

## 背景：native 的 cameraeffect 机制（2.7.61 / build 2761 IDA 反编译复核）

- `Torappu.AVG.AVGCameraEffect._ExecuteCameraEffect`（VA `0x183E32560`）：大小写敏感三路分发 `Grayscale`/`Colorinverse`/`Chaos`；读取 `block`/`effect`/`fadetime`（缺省 `_defaultFadetime`=0.4，场景序列化值）/`keep`。
- **fadetime 缩放**：`0x183E327C1` 处 `fadetime = fadetime * AVGController.animateRatio`（`AVGController.get_animateRatio` @ `0x183E1EA80`）后才交给渐变。
- `AVGCameraEffect._TweenGrayscaleAmount`（VA `0x183E33C60`）：**任何负值** `initamount`（`MathUtil.LT(initAmount, 0)`，不只是缺省的 -1）→ 渐变起始值取 `GetEffectAmount("grayscale", "grayscale")` 当前灰度；非负值为显式起始。随后 `DOTween.To(setter, start, amount, fadetime)`，setter 闭包（`0x183E48CA0`）每帧以 `duration=0` 配置写 `AVGSceneEffectManager.UpdateEffect`（`0x183E80E10`）。
- **缓动**：executor 从不调用 `SetEase`，`DOTween.To` 使用 DOTween 默认 ease；本 build 为 DOTween **1.2.760**（`DOTween.cctor` @ `0x18410B0E0` 写死版本与 `defaultEaseType = 6` = **Ease.OutQuad**，Ease 枚举序 0 Unset / 1 Linear / 2 InSine / 3 OutSine / 4 InOutSine / 5 InQuad / 6 OutQuad）。即 native 灰度渐变是 **OutQuad（先快后慢）**，不是线性。
- **渲染落地（2.7.61 IDA + 安卓 GLSL 双重实证）**：`UpdateEffect(duration=0)` → `AVGSceneEffectManager._SetEffectAmount`（`0x183E839F0`）按 key 路由到实现类（`_InitEffectImpls` @ `0x183E820A0` 注册 focusout / **grayscale→`AVGSceneGrayScale`** / chaos；**Grayscale 与 Colorinverse 共用同一实例**，colorinverse 只是另一 channel）。`AVGSceneGrayScale.Render`（`0x183E86990`）懒加载材质 `AVG/[UC]Common/Arts/Materials/mat_grayscale`（shader `Torappu/PostEffect/Grayscale`）后 `CommandBuffer.Blit` 单 pass 全屏后处理；`_ApplyAmountsToMaterial`（`0x183E86CF0`）写 `SetVector("_Params", (0.299, 0.587, 0.114, grayAmount))` 与 `SetFloat("_Inverse", inverseAmount)`。fragment 数学（安卓 2.7.51 `[uc]shaders.ab` GLES3 段明文 GLSL）：

  ```glsl
  u_xlat16_0.x = (-_Inverse) + 1.0;
  u_xlat16_1 = texture(_MainTex, vs_TEXCOORD0.xy);        // c
  u_xlat16_0 = u_xlat16_0.xxxx * u_xlat16_1;              // (1-inv)·c
  u_xlat16_1 = (-u_xlat16_1) + vec4(1.0);                 // 1-c
  u_xlat16_0 = u_xlat16_1 * vec4(_Inverse) + u_xlat16_0;  // A = lerp(c, 1-c, inv)
  u_xlat16_2 = dot(u_xlat16_0.xyz, _Params.xyz);          // Rec.601 luma
  u_xlat16_1.xyz = (-u_xlat16_0.xyz) + vec3(u_xlat16_2);  // luma - rgb
  u_xlat16_1.w = 0.0;
  SV_Target0 = _Params.wwww * u_xlat16_1 + u_xlat16_0;    // lerp(rgb, luma, amount)，alpha 不动
  ```

  即：先反色（rgba 四通道）再做 Rec.601 luma 的 lerp 去色；`_Params.w=0` 恒等、`=1` 纯灰且亮度不变。
- `keep=false` 结束时经 OnComplete 闭包（`0x183E48990`）+ `CameraEffectRecord.CreateClearConfig`（`amount=0, duration=0`）**瞬时清零**（前端已一致，未改）。
- Colorinverse 写 shader `_Inverse` float（0..1 可插值），本命令只会写 0/1；修复 1 后前端以同一 lerp 矩阵建模反色，语义与可插值版本一致。
- 状态生命周期：native `OnReset`/`ShouldResetOnSkip=true` 在剧情 reset/skip 时清空效果记录；前端依赖每次播放重建 renderer 实例（未改，补注释说明）。

## 修复内容

### 1. 灰度渲染公式：pixi 加法灰 → Rec.601 luma lerp（P1，实机对比反馈）

| | |
| --- | --- |
| native | 全屏 Blit `Torappu/PostEffect/Grayscale`：`A = lerp(c, 1-c, _Inverse)` → `out.rgb = lerp(A.rgb, dot(A.rgb, (0.299, 0.587, 0.114)), _Params.w)`（Rec.601，权重和 = 1；amount=1 为纯灰且亮度不变） |
| 前端（改前） | `ColorMatrixFilter.grayscale(amount, false)` —— pixi v8 该 helper 生成每行 `[s,s,s]` 的**加法**矩阵，输出 = `s×(R+G+B)`；amount≈1 时中灰 0.5 → 1.5 → 钳到白。实机表现为"开场即过曝"，native 则是"开场为灰" |

**改法**：`updateCameraFilter` 不再使用 `grayscale()/negative()`（且二者以 `multiply=false` 顺序调用会整矩阵互相覆盖，灰度+反色从不同时生效；native 是同一材质一次 Blit 同时生效），改为手写 4×5 矩阵直接赋 `filter.matrix`：

```
out = lerp( lerp(color, luma601(color), gray), 1-·, inverse )
rgb 行系数 = lerp(I, luma601 行, gray) × (1-2·inverse)，行偏移 = inverse
alpha 行恒 [0,0,0,1,0]
```

gray=1 时矩阵行恰为 `(0.299, 0.587, 0.114)`，与 native `_Params` 数值对齐。两个经 GLSL 确认的细节：

- native 顺序是**先反色后去色**，与上式组合顺序相反——Rec.601 权重和=1 时两个仿射操作代数等价（可交换），结果一致；
- native `_Inverse` 连 alpha 一起 lerp，但 Blit 是整屏替换（srcBlend=1/destBlend=0），alpha 不可见；pixi 的 filter alpha 参与层合成，因此前端 alpha 行保持单位（**有意偏离**，不能照抄）。

### 2. 灰度渐变缓动：线性 → OutQuad（P2）

| | |
| --- | --- |
| native | `DOTween.To` 默认 ease = DOTween 1.2.760 `defaultEaseType=6`（Ease.OutQuad），executor 不 SetEase |
| 前端（改前） | `TweenRunner` 线性插值 `from + (amount-from) * t` |

**改法**：`PixiStoryRenderer.setCameraEffect` 的 Grayscale tween 内把进度映射为 `1-(1-t)²`（OutQuad），不改动共享的 `TweenRunner`（其余命令保持线性）。8 秒级长渐变（见下文语料样本）视觉差异最明显：native 前半程走得快、收尾减速。

### 3. `fadetime` 未乘 `animateRatio`（P2）

| | |
| --- | --- |
| native | `fadetime = raw * AVGController.animateRatio`（`0x183E327C1`） |
| 前端（改前） | 直接用原始秒数 |

**改法**：`runtime.ts` cameraeffect 分支的 `fadeMs` 乘 `this.getCurrentSpeed().animateRatio`，与既有 `delay`、`interlude` 时长、`calculateFadeMs`（`AVGUtils.CalculateFadetime` 移植）接入方式一致：普通按钮自动播放 ratio=1（行为不变），quick_play（快速播放）ratio=0（灰度渐变瞬时完成，与 native 快进下动画加速退化一致）。

### 4. `initamount<0` 只覆盖了缺省、未覆盖显式负值（P2）

| | |
| --- | --- |
| native | `_TweenGrayscaleAmount` 以 `MathUtil.LT(initAmount, 0)` 判定——**任何负值**都回退到当前灰度值作起始 |
| 前端（改前） | `from = initialAmount ?? 当前值`：仅 key 缺省（undefined）回退，显式 `initamount=-1` 会从 -1 开始插值 |

**改法**：`from = initialAmount !== undefined && initialAmount >= 0 ? initialAmount : 当前灰度值`。

### 5. 注释补全（顺手项，不改行为）

- `runtime.ts` 原注释 "covers its Grayscale/Colorinverse/Chaos dispatch and scaled fadetime" 部分不实（Chaos 实为 warn 后跳过、缩放此前未实现），已改写为准确描述。
- `setCameraEffect` port-scope 注释补记三项**有意不移植**的语义：Chaos（上游已 warn 跳过）、reset 生命周期（依赖实例重建）、Colorinverse 数值通道（lerp 矩阵建模，与 `_Inverse` 可插值语义一致）。

## 验证用剧情文件

生产剧情语料位于本地 `torappu/storage/asset/gamedata/latest/story`（命令名在语料中有 `cameraeffect`/`CameraEffect`/`cameraEffect` 大小写变体，runtime 小写化分发均可命中）：

- **修复 1（渲染公式）**：`obt/guide/beg/0_welcome_to_guide.txt` 33 行起（`[CameraEffect(effect="Grayscale", fadetime=18, amount=0, block=false)]`，开场即全灰渐出）——修复前前端开场过曝发白，修复后为正常灰度、随渐变恢复彩色；全灰→彩色的过渡亮度应保持不变（Rec.601 权重和=1）。
- **修复 2（OutQuad 缓动）**：同上 33 行（fadetime=18）与 39 行 `fadetime=8, amount=1` —— 全语料最长的灰度渐变，线性与 OutQuad 的差异直观可见（native 收尾明显减速）；`obt/main/level_main_11-01_beg.txt` 17 行（fadetime=1, block=true）可看短渐变的快起。
- **修复 3（animateRatio 缩放）**：任意 Grayscale 渐变行（如上）在播放器快速播放（quick_play）模式下渐变应瞬时完成；普通播放不受影响（ratio=1）。显式负值缩放分支由单测锁定（见下）。
- **修复 4（initamount 语义）**：缺省 initamount 回退当前值的路径——`obt/main/level_main_11-15_beg.txt` 597 行（`initamount=0, amount=0.7, fadetime=2, keep=true`）之后 609 行（`amount=0, fadetime=2`，无 initamount，从当前 0.7 灰度渐出）；显式非负 `initamount=0`/`0.7` 起始——`obt/main/level_main_11-01_end.txt` 118 行、`obt/main/level_main_14-05_end.txt` 337 行。**显式负值 initamount 在全语料 0 命中，属前瞻对齐，由单测锁定**（`tests/renderer.spec.ts` "starts the grayscale tween from the current amount for any negative initamount"）。
- 回归对照（不涉及本次改动）：Colorinverse 用法见 `obt/main/level_main_17-15_beg.txt` 824-851 行等（21 处，全语料 Colorinverse 仅 keep true/false 两种形态）。

## 测试

- `pnpm test`：20 个文件 **227 个用例全部通过**（基线 222 + 新增 5：renderer OutQuad 中点断言 0.75、renderer 负 initamount 回退、runtime animateRatio 0.5 倍缩放与 quick_play 归零、renderer 灰度 Rec.601 矩阵断言、renderer inverse 与 gray+inverse 复合矩阵断言）。
- `pnpm test:story-log`（全语料 Log All 回归，本地语料）：2 个用例通过。
- `pnpm exec vue-tsc -b`：通过。
- `pnpm exec eslint`（4 个改动文件）：通过。
