### PR TITLE
fix(story-player): bgeffect unsupported 告警按命令名去重并补 native provenance 注释

### DIFF
--- a/src/widgets/StoryPlayer/engine/preload.ts
+++ b/src/widgets/StoryPlayer/engine/preload.ts
@@ -92,6 +92,12 @@ function addCharacterUrl(urls: Set<string>, rawKey: string): string | null {
  * Ports which script commands declare image dependencies. A single eager PIXI
  * batch substitutes for native asset-reference collection and loading.
  *
+ * Deliberately NOT collected: the particle-effect references gathered by
+ * `AVGBattleEffectPanel.InternalResRefCollector.GatherResRefs`
+ * (`AVG/Effects/Background/<name>` for `bgeffect`; VA 0x183e46d40, 2.7.61
+ * build 2761). The runtime treats `bgeffect`/`effect` as warn-only skips
+ * (see `unsupportedAd8Commands` in runtime.ts) — no Ad8 SDK particle layer on
+ * the web, so there is nothing to preload for them.
  */
 function addScriptImageUrls(urls: Set<string>, context: Context): void {
   for (const line of parseScript(context.scriptText ?? context.script)) {

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -159,6 +159,24 @@ const builtinCommandNames = [
   "hidecgitem",
 ] as const;
 
+/**
+ * Native provenance: `bgeffect` / `effect` 由 Ad8 外部 SDK 层渲染
+ * （AVGBattleEffectPanel.GetExecutors 注册明文 key "bgeffect" → `_ExcuteBgEffect`，
+ * VA 0x183e2c8c0 / 0x183e2d0d0；2.7.61/build 2761 GameAssembly.dll IDA 反编译复核）。
+ * Web 侧没有对应渲染层，按 warn-only 跳过，这与 native 控制流语义一致：
+ * - `_ExcuteBgEffect` 的清除/生成分支都 `return false`，永不阻塞、不等待
+ *   FinishCommand；分发层 `ExecutorComponent.Execute`（VA 0x183e45b10）对未
+ *   注册命令同样立即 FinishCommand 放行。
+ * - 语料中生成/清除成对出现（最新 story 全量清除分支约占一半，其中裸
+ *   `[bgeffect]` 就是清除），全有或全无的跳过不会产生"特效残留/泄漏"的
+ *   中间态；只实现生成不实现清除反而更糟。
+ *
+ * 未来若实现渲染，先核对两个 native 语义点（2.7.61 实证，2.7.51 历史文档
+ * 曾记错）：`layer` 默认 **-1**（`GetOrDefault<int>("layer", -1)`，VA
+ * 0x183e2d1bd），裸 `[bgeffect]` = 瞬时清空全部层（`_ClearAllBgEffect` 循环
+ * 0..4，layer=5 漏网；此路径不读 fadetime），不是"清 layer 0"；`flip`：
+ * 1 → y+180，2 → x+180（VERTICAL），现网语料两者都出现。
+ */
 const unsupportedAd8Commands = new Set(["bgeffect", "effect"]);
 
 interface InterruptibleWait {
@@ -357,6 +375,12 @@ export class StoryRuntime {
   private multilineShownChars = 0;
   private readonly stickerIds = new Set<string>();
   private pendingInputEffect: (() => Promise<void> | void) | null = null;
+  /**
+   * Web-only（native 无对应概念）：unsupportedAd8Commands 命中过的命令名
+   * 集合，用于每命令名只告警一次。bgeffect/effect 在语料中高频成对出现
+   * （生成+清除，单文件可达数十条），逐条 console.warn 只是噪音。
+   */
+  private readonly warnedUnsupportedCommands = new Set<string>();
 
   constructor(
     context: Context,
@@ -2508,7 +2532,12 @@ export class StoryRuntime {
 
       default: {
         if (unsupportedAd8Commands.has(line.command)) {
-          this.warn("unsupported_command", line.command);
+          // 每命令名只告警一次（Web-only 降噪，见 warnedUnsupportedCommands）；
+          // 跳过本身与 native 的 return false / 立即 FinishCommand 放行一致。
+          if (!this.warnedUnsupportedCommands.has(line.command)) {
+            this.warnedUnsupportedCommands.add(line.command);
+            this.warn("unsupported_command", line.command);
+          }
           return "continue";
         }
 

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -865,6 +865,39 @@ describe("StoryRuntime", () => {
     );
   });
 
+  it("deduplicates unsupported_command warnings per command name", async () => {
+    // 语料里 bgeffect 生成/清除成对出现（裸 [bgeffect] = native 的瞬时全清
+    // 分支），逐条告警只是噪音：同一命令名只应告警一次。
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[bgeffect(name="$eb_burn", layer=1)]',
+        "[bgeffect]",
+        "[bgeffect(fadetime=2)]",
+        '[effect(name="$e_fire", layer=1)]',
+        "[effect]",
+        '[name="A"]ok',
+      ]),
+      new FakeRenderer(),
+      new FakeAudio(),
+      {
+        onWarning: (warning) => warnings.push(warning),
+      },
+    );
+
+    await runtime.start();
+
+    expect(runtime.getState()).toBe("waiting_input");
+    const unsupported = warnings.filter(
+      (item) => item.type === "unsupported_command",
+    );
+    // 告警顺序与首次命中顺序一致：bgeffect（第 1 行）先于 effect（第 4 行）
+    expect(unsupported.map((item) => item.detail)).toEqual([
+      "bgeffect",
+      "effect",
+    ]);
+  });
+
   it("blocks on video command until playback completes", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(


### PR DESCRIPTION
## 背景

`bgeffect` 在前端已注册进 `builtinCommandNames`，但 executor 无实现分支，命中后仅打
`unsupported_command` 警告并立即继续。按基于官服客户端 2.7.61（build 2761）
GameAssembly.dll 的 IDA 反编译复核结论（`docs/impl-review/impl-review-bgeffect-command.md`），
**warn-only 跳过与 native 推进语义一致、安全，且是当前最优的保守策略**：

- `_ExcuteBgEffect`（VA `0x183e2d0d0`）的清除分支与生成分支都 `return false`，
  永不阻塞、不等待 FinishCommand；分发层 `ExecutorComponent.Execute`
  （VA `0x183e45b10`）对未注册命令同样立即 `FinishCommand()` 放行。
- 语料中 bgeffect 生成/清除成对出现（最新 story 全量清除分支约占 47.7%），
  "全跳过"不产生"特效残留/泄漏"中间态；只实现生成不实现清除反而更糟。
- 渲染本体在 native 侧由 Ad8 外部 SDK 层（`AVG/Effects/Background/<name>` 粒子）
  承载，Web 侧无对应渲染层，故本 PR **不实现** Ad8 背景特效渲染。

**2.7.61 重要更正**（历史 2.7.51 文档记错，本次以反编译为准）：
`layer` 默认值是 **`-1`**（`GetOrDefault<int>("layer", -1)` @ VA `0x183e2d1bd`），
因此裸 `[bgeffect]` 的语义是**瞬时清空全部层**（`_ClearAllBgEffect` 循环 0..4，
layer=5 漏网、不读 fadetime），而非"清 layer 0"；另外 `flip=2`（x+180 VERTICAL）
已在现网语料出现。

## 修复内容

对照 review 差异清单（P0=0）：

| 条目 | 处理 |
| --- | --- |
| #4 P2 警告噪音 | **修复**：`unsupportedAd8Commands` 命中改为**每命令名只告警一次**（新增 `warnedUnsupportedCommands` 集合；语料单文件 bgeffect 可达数十条、裸清除命令也打，逐条 console.warn 纯噪音）。同时在 `unsupportedAd8Commands` 声明处补 Native provenance 注释（注册/分发/恒 return false 的 VA 依据，及未来实现必须先核对的 `layer` 默认 `-1`、全清循环 0..4、`flip` 1/2 语义）。 |
| #2 P2 layer 默认值语义 | 前端未实现、无此风险；按建议在前端侧落地为上述 provenance 注释，记录 2.7.61 的 `-1` 口径供未来实现核对（arknights-rev 历史文档更正不在本仓库范围）。 |
| #5 P3 预载缺失 | 按建议"记录即可"：`preload.ts` 的 provenance 注释注明 native `GatherResRefs`（VA `0x183e46d40`）收集 `AVG/Effects/Background/<name>` 而前端**有意省略**（无渲染层即无预载对象）。 |
| #1 P1 未渲染 / #3 P2 快进淡出短路 | 按文档结论**不实现**（#1 建议接受则降 P3；#3 随 #1 一并实现；warn-only 为最优保守策略）。 |
| #6 P3 重置/销毁 / #7 P3 加载失败 | 前端无状态天然等价 / 仅实现时适用，无需处理。 |

与 PR #374（`effect` 命令，另一分支）的改动有重叠：同样为 `unsupportedAd8Commands`
补 provenance 注释并做每命令名一次的去重告警。本 PR 基于 origin/main 自包含独立实现，
合并时以先合入者为准、后者仅保留 diff 冲突解决即可。

## 验证用剧情文件

语料根：`/home/xwbx/Documents/torappu/storage/asset/gamedata/latest/story/`
（相对以下路径）：

- `obt/main/level_main_14-10_end.txt:111` — 裸 `[bgeffect]`（native 瞬时全清分支；
  施法演出结束后清场，同文件内与生成分支成对）
- `obt/main/level_main_11-14_end.txt:198`、`obt/main/level_main_14-04_end.txt:357`
  — 裸清除；`obt/main/level_main_14-10_end.txt:198` 为大小写混用 `[bgEffect]`
- `obt/main/level_main_13-12_end.txt:794` — `[bgeffect(fadetime=2)]`（无 name 无 layer，
  native 仍瞬时全清、fadetime 被忽略）
- `obt/memory/story_nymph_2_1.txt:447`、`activities/act50side/level_act50side_st02.txt:7`
  — `flip = 2`（x+180，2.7.61 新出现的取值）
- `activities/act49side/level_act49side_04_end.txt:513` — 越界 `layer=4`；
  `obt/memory/story_whitw2_1_1.txt:589/602` — `layer=5`（在全清循环 0..4 之外，
  只能同层显式清除）

验证项：以上所有形态在改动后均只产生**一次** `unsupported_command`（每命令名），
播放不被阻塞（裸清除后对白照常推进，同 native 恒放行）。

## 测试

- `pnpm test`：**223 用例全绿**（基线 222 + 新增 1）
- 新增 `tests/runtime.spec.ts`：`deduplicates unsupported_command warnings per
  command name`（3 条 bgeffect + 2 条 effect 只告警 bgeffect/effect 各一次，
  且 state 正常进入 `waiting_input`）
- `pnpm exec vue-tsc -b`：通过
- `pnpm exec eslint`（改动文件）：通过
