### PR TITLE
fix(story-player): curtain 按 2.7.61 复核修正 animateRatio/alpha snap/四角几何/grad 收起

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -111,6 +111,36 @@ const CURTAIN_STAGE_CORNERS: ReadonlyArray<{ x: number; y: number }> = [
 ];
 
 /**
+ * Native corner curtains (direction 1/3/5/7): `_GenSizeDeltaWithMultiplior`
+ * scales only the Y axis of a 1600x1600 rect whose pivot sits off-screen, so
+ * they are offset horizontal bands, not diagonal wipes. Values come from the
+ * level1 `panel_curtains` scene (AVGCurtain pivot/anchoredPosition): the hinge
+ * is 240.7px past the top edge (y=960.7) or 218.2px below the bottom
+ * (y=-218.2) -- fills under ~0.14-0.15 never reach the stage and draw
+ * nothing -- and the 1600-wide rect is horizontally offset (right corners
+ * start around x=402, left ones end around x=873), so even fill=1 never spans
+ * the whole stage width. See arknights-rev docs/commands/avg-curtain-command.md
+ * §4 for the full per-direction RectTransform table.
+ */
+interface CurtainCornerSpec {
+  /** The curtain hangs from above the stage (true) or rises from below. */
+  fromTop: boolean;
+  /** Fixed Y of the off-screen hinge edge. */
+  hingeY: number;
+  /** Rect left/right in stage coordinates (may be off-screen). */
+  left: number;
+  right: number;
+}
+
+const CURTAIN_CORNER_SIDE = 1600;
+const CURTAIN_CORNER_SPECS: Readonly<Record<number, CurtainCornerSpec>> = {
+  1: { fromTop: true, hingeY: 960.7, left: 404.7, right: 2004.7 },
+  3: { fromTop: false, hingeY: -218.2, left: 401.5, right: 2001.5 },
+  5: { fromTop: false, hingeY: -218.2, left: -729.9, right: 870.1 },
+  7: { fromTop: true, hingeY: 960.7, left: -726.7, right: 873.3 },
+};
+
+/**
  * 对话框顶部/底部黑条用到的同一张渐变纹理（APK 中 `sprite_avg_cutscene`，
  * 4×310 RGBA，自上而下 alpha 0→1）。放在 `public/` 下由 Vite 直接服务，
  * 预加载由 preload.ts 把该 URL 加入预加载集来预热 pixi Assets 缓存。
@@ -206,6 +236,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   >();
 
   private readonly curtainLayer = this.layers.curtains;
+  // Skip semantics: 2.7.61's AVGCurtainPanel.ShouldResetOnSkip returns false
+  // (0x183e54960, literal `xor al, al`), so skipping a segment must NOT clear
+  // curtains -- they only go away via curtain commands or full destroy().
   private readonly curtains = new Map<number, CurtainRenderState>();
   private readonly gridBackgroundLayer = this.layers.gridBackground;
   private gridBackgroundSessionId = 0;
@@ -1825,7 +1858,10 @@ export class PixiStoryRenderer implements StoryRenderer {
           fadeMs,
           fillFrom: state.fill,
           fillTo: 0,
-          grad: false,
+          // Native `HideCurtain` only tweens sizeDelta toward zero; it never
+          // touches alpha or the `_gradientImg` active state, so the 20px
+          // feather must stay on while the curtain retracts.
+          grad: state.grad,
         }),
       ),
     );
@@ -2046,8 +2082,17 @@ export class PixiStoryRenderer implements StoryRenderer {
     const state = this.ensureCurtainState(direction);
     const fromFill = clamp01(input.fillFrom ?? state.fill);
     const toFill = clamp01(input.fillTo);
-    const fromAlpha = clamp01(input.alphaFrom ?? state.alpha);
-    const toAlpha = clamp01(input.alphaTo ?? fromAlpha);
+    // Native port: `_ExecuteCurtain` reads `afrom` (default: the alpha
+    // captured *before* the snap) and then runs `SetCurtainAlpha(1.0)`
+    // unconditionally, before choosing the instant/tween branch. The re-snap
+    // to `afrom` only happens inside the a>=0 alpha tween
+    // (`SetCurtainAlphaTween` snaps afrom while building the sequence). With
+    // `a` absent the curtain therefore presents fully opaque no matter what
+    // alpha an earlier command left behind, and a bare `afrom` is ignored.
+    const capturedAlpha = clamp01(input.alphaFrom ?? state.alpha);
+    const fromAlpha = input.alphaTo === undefined ? 1 : capturedAlpha;
+    const toAlpha =
+      input.alphaTo === undefined ? fromAlpha : clamp01(input.alphaTo);
 
     state.fill = fromFill;
     state.alpha = fromAlpha;
@@ -2062,6 +2107,13 @@ export class PixiStoryRenderer implements StoryRenderer {
       return;
     }
 
+    // Native kills the side's previous tween (2.7.51: DOKill(transform,
+    // false)) before starting the new one. The 2.7.61 build literally calls
+    // DOKill(curtain component, complete: true) at 0x183e54e43, whose target
+    // matches neither tween's actual target (_curtainRect / _canvasGroup), so
+    // the kill is a no-op there -- likely a native regression. The session
+    // bump keeps the documented intent (one live tween per side); do not
+    // "align" it with the broken 2.7.61 form.
     const sessionId = ++state.tweenSessionId;
     const animate = () =>
       this.tween(
@@ -2460,6 +2512,12 @@ export class PixiStoryRenderer implements StoryRenderer {
       return;
     }
 
+    const corner = CURTAIN_CORNER_SPECS[state.direction];
+    if (corner) {
+      this.drawCurtainCornerBand(state, corner);
+      return;
+    }
+
     const threshold = this.curtainThreshold(vector, state.fill);
     if (threshold === null) {
       state.graphic.visible = false;
@@ -2493,6 +2551,91 @@ export class PixiStoryRenderer implements StoryRenderer {
         type: "linear",
       }),
     );
+  }
+
+  /**
+   * Corner-band drawing for direction 1/3/5/7 (see CURTAIN_CORNER_SPECS): the
+   * visible shape is a horizontal band stuck to the top/bottom stage edge with
+   * a horizontal offset, growing as `fill` scales the off-screen-hinged
+   * 1600x1600 rect on Y only. The `grad` feather stays a 20px vertical strip
+   * on the inner edge -- native corner curtains only ever get the vertical
+   * gradient material, so there is no horizontal feather.
+   */
+  private drawCurtainCornerBand(
+    state: CurtainRenderState,
+    spec: CurtainCornerSpec,
+  ): void {
+    const left = Math.max(0, spec.left);
+    const right = Math.min(STORY_WIDTH, spec.right);
+    // `edge` is the inner edge: the only rect edge that moves as fill
+    // animates (the hinge edge is fixed off-screen).
+    const size = CURTAIN_CORNER_SIDE * clamp01(state.fill);
+    const edge = spec.fromTop ? spec.hingeY - size : spec.hingeY + size;
+
+    if (right <= left || (spec.fromTop ? edge >= STORY_HEIGHT : edge <= 0)) {
+      state.graphic.visible = false;
+      return;
+    }
+
+    state.graphic.visible = true;
+
+    const feather = state.grad ? CURTAIN_GRADIENT_PX : 0;
+    const fillBand = (
+      low: number,
+      high: number,
+      style: number | FillGradient,
+    ) => {
+      if (high <= low) return;
+      state.graphic
+        .poly([left, low, right, low, right, high, left, high])
+        .fill(style);
+    };
+
+    if (spec.fromTop) {
+      // Hangs from above: opaque body fills [edge + feather, stage top];
+      // the feather strip [edge, edge + feather] fades downward, opaque on
+      // the body side, transparent at the inner edge.
+      const stripHigh = Math.min(STORY_HEIGHT, edge + feather);
+      fillBand(stripHigh, STORY_HEIGHT, 0x00_00_00);
+      fillBand(
+        edge,
+        stripHigh,
+        this.curtainCornerFeatherGradient(
+          { x: 0, y: stripHigh },
+          { x: 0, y: edge },
+        ),
+      );
+      return;
+    }
+
+    // Rises from below: body fills [stage bottom, edge - feather]; the
+    // feather strip [edge - feather, edge] fades upward toward the centre.
+    const stripLow = Math.max(0, edge - feather);
+    fillBand(0, stripLow, 0x00_00_00);
+    fillBand(
+      stripLow,
+      edge,
+      this.curtainCornerFeatherGradient(
+        { x: 0, y: stripLow },
+        { x: 0, y: edge },
+      ),
+    );
+  }
+
+  private curtainCornerFeatherGradient(
+    opaque: { x: number; y: number },
+    transparent: { x: number; y: number },
+  ): FillGradient {
+    return new FillGradient({
+      colorStops: [
+        { color: "rgba(0, 0, 0, 1)", offset: 0 },
+        { color: "rgba(0, 0, 0, 0)", offset: 1 },
+      ],
+      end: transparent,
+      start: opaque,
+      textureSpace: "global",
+      type: "linear",
+    });
   }
 
   /** Projection along `vector` where the curtain's inner edge sits. */
@@ -2590,6 +2733,12 @@ export class PixiStoryRenderer implements StoryRenderer {
     };
   }
 
+  /**
+   * Half-plane sweep vector for the four straight edges (0/2/4/6). Corner
+   * directions 1/3/5/7 still resolve to a non-null vector (validity check)
+   * but draw through CURTAIN_CORNER_SPECS instead -- their diagonal vectors
+   * are unused for drawing.
+   */
   private resolveCurtainVector(
     direction: number,
   ): { x: number; y: number } | null {

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1570,14 +1570,19 @@ export class StoryRuntime {
         const direction = Math.trunc(
           toNumber(this.exactArg(args, "direction"), -1),
         );
-        const fadeMs = Math.max(
-          0,
-          Math.round(toNumber(this.exactArg(args, "fadetime"), 0.4) * 1000),
+        // Native port: `AVGCurtainPanel._ExecuteCurtain` inlines
+        // `scaledFadetime = AVGController.animateRatio * fadetime`
+        // (AVGUtils.CalculateFadetime; the panel implements IFadeTimeRatio),
+        // with fadetime defaulting to the panel's `_defaultFadetime` (0.4).
+        // quick_play (animateRatio 0) therefore always lands in the instant
+        // branch / instant all-side reset below.
+        const fadeMs = this.calculateFadeMs(
+          this.exactArg(args, "fadetime"),
+          0.4,
         );
-        // Native port: Torappu.AVG.AVGCurtainPanel._ExecuteCurtain. It zeroes its
-        // closure's block field on both the
-        // zero-fadetime and the direction < 0 paths, so only a real curtain tween
-        // can block -- the same short circuit blocker has.
+        // It zeroes its closure's block field on both the zero-fadetime and
+        // the direction < 0 paths, so only a real curtain tween can block --
+        // the same short circuit blocker has.
         const block =
           fadeMs > 0 && toBoolean(this.exactArg(args, "block"), false);
 

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -197,6 +197,190 @@ describe("PixiStoryRenderer", () => {
     expect(gradient.end).toEqual({ x: 640, y: 0 });
   });
 
+  it("draws corner curtains as offset horizontal bands with a dead zone", () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+
+    const draws: unknown[] = [];
+    const state = {
+      alpha: 1,
+      direction: 1,
+      fill: 0.5,
+      grad: false,
+      graphic: {
+        alpha: 1,
+        clear: () => {},
+        poly(points: number[]) {
+          draws.push(points);
+          return this;
+        },
+        fill(style: unknown) {
+          draws.push(style);
+          return this;
+        },
+        visible: false,
+      },
+    };
+
+    renderer.updateCurtainState(state, { x: 1, y: 1 });
+
+    // direction 1 is a native 1600x1600 rect scaled on Y only, hinged above
+    // the stage at y=960.7 and offset right (x 404.7..): fill 0.5 puts the
+    // inner edge at 960.7-800 -- a top band with a horizontal offset,
+    // not a diagonal wipe.
+    expect(state.graphic.visible).toBe(true);
+    expect(draws).toEqual([
+      [404.7, 960.7 - 800, 1280, 960.7 - 800, 1280, 720, 404.7, 720],
+      0x00_00_00,
+    ]);
+
+    // Fills under the hinge offset (240.7/1600 ~= 0.15) stay off-screen and
+    // draw nothing.
+    draws.length = 0;
+    state.fill = 0.14;
+    renderer.updateCurtainState(state, { x: 1, y: 1 });
+    expect(state.graphic.visible).toBe(false);
+    expect(draws).toEqual([]);
+  });
+
+  it("feathers corner curtains vertically on the inner edge only", () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+
+    const draws: unknown[] = [];
+    const state = {
+      alpha: 1,
+      direction: 3,
+      fill: 0.5,
+      grad: true,
+      graphic: {
+        alpha: 1,
+        clear: () => {},
+        poly(points: number[]) {
+          draws.push(points);
+          return this;
+        },
+        fill(style: unknown) {
+          draws.push(style);
+          return this;
+        },
+        visible: false,
+      },
+    };
+
+    renderer.updateCurtainState(state, { x: 1, y: -1 });
+
+    // direction 3 rises from below (hinge y=-218.2): fill 0.5 puts the inner
+    // edge at -218.2+800. The body is the band under the edge, the 20px
+    // feather sits above it, and the gradient axis is vertical.
+    const edge = -218.2 + 800;
+    expect(state.graphic.visible).toBe(true);
+    expect(draws[0]).toEqual([
+      401.5,
+      0,
+      1280,
+      0,
+      1280,
+      edge - 20,
+      401.5,
+      edge - 20,
+    ]);
+    expect(draws[1]).toBe(0x00_00_00);
+    expect(draws[2]).toEqual([
+      401.5,
+      edge - 20,
+      1280,
+      edge - 20,
+      1280,
+      edge,
+      401.5,
+      edge,
+    ]);
+    const gradient = draws[3] as any;
+    expect(gradient.start).toEqual({ x: 0, y: edge - 20 });
+    expect(gradient.end).toEqual({ x: 0, y: edge });
+  });
+
+  it("snaps curtain alpha to 1 when `a` is absent, ignoring leftover alpha", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.tween = vi.fn(async () => {});
+
+    // A previous command left the side at alpha 0.3.
+    await renderer.setCurtain({
+      alphaTo: 0.3,
+      block: false,
+      delayMs: 0,
+      direction: 4,
+      fadeMs: 0,
+      fillFrom: 0.5,
+      fillTo: 0.5,
+      grad: false,
+    });
+    expect(renderer.curtains.get(4).alpha).toBe(0.3);
+
+    // With `a` present but no `afrom`, the tween starts from the alpha
+    // captured *before* the unconditional SetCurtainAlpha(1.0) snap.
+    await renderer.setCurtain({
+      alphaTo: 0.8,
+      block: false,
+      delayMs: 0,
+      direction: 4,
+      fadeMs: 150,
+      fillFrom: 0.5,
+      fillTo: 0.6,
+      grad: false,
+    });
+    expect(renderer.curtains.get(4).alpha).toBe(0.3);
+
+    // Without `a` native snaps to 1.0 before branching, so a bare `afrom`
+    // is never applied and the leftover 0.3 does not survive.
+    await renderer.setCurtain({
+      alphaFrom: 0.2,
+      block: false,
+      delayMs: 0,
+      direction: 4,
+      fadeMs: 0,
+      fillFrom: 0.5,
+      fillTo: 0.5,
+      grad: false,
+    });
+    expect(renderer.curtains.get(4).alpha).toBe(1);
+  });
+
+  it("keeps the grad feather while clearCurtains retracts the sides", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.tween = vi.fn(async () => {});
+    // FillGradient needs a real canvas context; this test is about the input
+    // clearCurtains forwards, not the drawing.
+    renderer.updateCurtainState = vi.fn();
+    const spy = vi.spyOn(renderer, "setCurtain");
+
+    await renderer.setCurtain({
+      block: false,
+      delayMs: 0,
+      direction: 0,
+      fadeMs: 0,
+      fillFrom: 1,
+      fillTo: 0.2,
+      grad: true,
+    });
+    await renderer.clearCurtains(100, false);
+
+    // Native HideCurtain only tweens sizeDelta toward zero; it never touches
+    // alpha or the `_gradientImg` active state.
+    expect(spy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        alphaFrom: 1,
+        alphaTo: 1,
+        direction: 0,
+        fillTo: 0,
+        grad: true,
+      }),
+    );
+  });
+
   it("applies background transforms in a dedicated transform space", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1799,6 +1799,72 @@ describe("StoryRuntime", () => {
     expect(runtime.getState()).toBe("waiting_input");
   });
 
+  it("scales curtain fadetime by animateRatio", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        "[curtain(direction=2,fillfrom=1,fillto=0,fadetime=1.5,block=true)]",
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { animateRatio: 0.5 },
+    );
+
+    await runtime.start();
+
+    // _ExecuteCurtain inlines scaledFadetime = animateRatio * fadetime.
+    expect(renderer.curtainCalls).toEqual([
+      {
+        alphaFrom: undefined,
+        alphaTo: undefined,
+        block: true,
+        delayMs: 0,
+        direction: 2,
+        fadeMs: 750,
+        fillFrom: 1,
+        fillTo: 0,
+        grad: false,
+      },
+    ]);
+  });
+
+  it("drops curtain blocking when animateRatio zeroes the fade", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        "[curtain(direction=0,fillfrom=1,fillto=0,fadetime=3,block=true)]",
+        "[curtain(fadetime=2,block=true)]",
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { animateRatio: 0 },
+    );
+
+    await runtime.start();
+
+    // quick_play (animateRatio 0) lands in the instant branches: the
+    // closure's block field is zeroed for the single-side path, direction<0
+    // returns literal false, and a fadetime=3 close can no longer stall the
+    // fast-forward.
+    expect(renderer.curtainCalls).toEqual([
+      {
+        alphaFrom: undefined,
+        alphaTo: undefined,
+        block: false,
+        delayMs: 0,
+        direction: 0,
+        fadeMs: 0,
+        fillFrom: 1,
+        fillTo: 0,
+        grad: false,
+      },
+    ]);
+    expect(renderer.curtainClearCalls).toEqual([{ block: false, fadeMs: 0 }]);
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
   it("maps gridbg into a tiled background layer", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(


### PR DESCRIPTION
## 背景

基于官服客户端 2.7.61（build 2761）GameAssembly.dll 的 IDA 反编译复核（逆向笔记：`arknights-rev/docs/impl-review/impl-review-curtain-command.md`，`AVGCurtainPanel._ExecuteCurtain` VA `0x183e549d0`），curtain 命令的几处 native 语义：

- **fadetime 乘 animateRatio**：`_ExecuteCurtain` 内联 `scaledFadetime = AVGController.animateRatio * fadetime`（`CalculateFadetime` VA `0x183e544f0`）。quick_play（animateRatio=0）落入瞬时分支 / direction<0 的 `_ResetCurtains` 瞬时清屏，且闭包 block 字段被清零——`fadetime=3` 的收幕不能拖住快进。
- **alpha 无条件 snap 到 1**：单边路径在分支选择前无条件 `SetCurtainAlpha(1.0)`；`afrom` 默认取 snap **之前**的 currentAlpha，且仅在 `a>=0` 插入 alpha tween 时由 `SetCurtainAlphaTween`（VA `0x183ecbd50`）在构造时 re-snap。`a` 缺省时幕布恒以 alpha=1 呈现，裸 `afrom` 被忽略。
- **四角（direction 1/3/5/7）几何**：`_GenSizeDeltaWithMultiplior`（VA `0x183e551f0`）把 {0,1,3,4,5,7} 全部映射到 **Y 轴单轴** sizeDelta 缩放；level1 场景里四角是 1600×1600 矩形、铰点在屏幕外（上角 y=960.7、下角 y=-218.2）、水平偏移（右角 x∈[401.5,1280]、左角 x∈[0,873.3] 可见段）。视觉上是**贴上/下边的偏置横带**（fill≲0.15 死区），不是对角线 wipe。
- **全边收起不动 grad/alpha**：`HideCurtain`（VA `0x183ecb9c0`）只把 sizeDelta tween 到零，不碰 `_gradientImg` active 也不碰 alpha，20px 羽化条在收起过程中保持。
- **2.7.61 行为更正**：`ShouldResetOnSkip`（VA `0x183e54960`，指令级 `xor al, al`）已翻转为 **false**——skip 不清 curtain，与前端"段内 skip 不清、销毁才清"的现状一致；`DOKill` 变为 `DOKill(curtain组件, complete:true)`（VA `0x183e54e43`），目标与实际 tween target（`_curtainRect`/`_canvasGroup`）不匹配、实际 kill 不掉任何东西（疑似 native 笔误），前端"新命令作废旧 tween"维持 2.7.51 文档意图，仅补注释防止后人误对齐。
- 另：curtain 在 2.7.61 期内容库已是高频命令（1,143 处 / 228 文件），历史文档"0 使用"过时，本命令为实际承载路径。

## 修复内容

按 review 差异清单：

| # | 严重度 | 差异 | 改法 |
| --- | --- | --- | --- |
| 1 | P1 | fadetime 未乘 animateRatio | `runtime.ts` curtain case 改用现成 helper `calculateFadeMs(fadetime, 0.4)`；换算后 `fadeMs>0 && block` 自动复刻 quick_play 短路（瞬时分支 / 全边瞬时重置恒不阻塞） |
| 2 | P2 | `a` 缺省时沿用旧 alpha | `PixiStoryRenderer.setCurtain` snap 阶段复刻无条件 alpha=1；`afrom` 在有 `a` 时捕获于 snap 之前并由 tween re-snap，无 `a` 时忽略 |
| 3 | P2 | 四角 direction 用 45° 对角半平面 | 新增 `CURTAIN_CORNER_SPECS`（level1 场景铰点/水平偏移值）+ `drawCurtainCornerBand`：Y 轴单轴横带、~0.15 死区、水平偏置、仅竖向 20px 羽化；四直边（0/2/4/6）维持原半平面模型（已逐方向验证与 native 等价） |
| 4 | P3 | 全边收起瞬间关掉羽化条 | `clearCurtains` 透传 `grad: state.grad`（alpha 行为本就一致） |
| 5 | P3 | 旧 tween 作废策略 | 维持现状，补注释标注 2.7.61 `DOKill(组件, complete:true)` 实际不 kill 的字面行为 |

未改动（按清单建议）：#6 clamp01 截断（当前数据 fill≤0.82、a≤1，无命中）、#7 fillto≤0 立即销毁 state（观察等价）、#8 舍入与告警细节（合理增强）。`ShouldResetOnSkip=false` 的 skip 语义前端现状已一致，仅补注释。与 blocker 的共享面（animateRatio 思路、层序）无共享代码改动，`LayerGraph` 未动。

## 验证用剧情文件

语料库：`torappu ... /gamedata/latest/story/`（curtain 共 1,143 处 / 228 文件）

| 文件 | 行号 | 验证项 |
| --- | --- | --- |
| `obt/main/level_main_17-10_beg.txt` | 113-116 | 四角 direction 1/3/5/7 瞬时 fill=1：native 为部分屏宽的横带铺满（如 direction 1 仅覆盖 x≥404.7），旧实现对角 wipe 偏差最大处 |
| `obt/main/level_main_17-10_beg.txt` | 128-131 | 四角 fill 1→0、fadetime=0.3 收起动画（四角几何 + animateRatio 时长） |
| `obt/main/level_main_15-18_end.txt` | 234-235 | direction 1/5 `grad=true` 收起：羽化条随横带收回且保持竖向 |
| `activities/act23side/level_act23side_01_beg.txt` | 810-811 | direction 1/5 fill=0.45 `grad=true`：0.45>死区 0.15，偏置横带 + 竖向羽化 |
| `obt/main/level_main_15-14_end.txt` | 611-612 | fadetime=6 的长收幕：quick_play 下不再按 6s 播放（瞬时 + 不阻塞） |
| `activities/act49side/level_act49side_04_end.txt` | 241, 244 | `afrom=0, a=1, block=true, grad=true`：quick_play 下 block 短路；afrom→a 的 alpha tween 路径 |
| `activities/act37side/level_act37side_01_end.txt` | 53-54 → 62 | `grad=true` 黑条展开后 `[curtain(fadetime=1)]` 全边收起：收起期间 20px 羽化保持（旧实现瞬间消失） |
| P2 #2（alpha snap） | — | 全语料扫描 0 命中（无"a<1 后同 direction 不带 a"的生产序列），**前瞻对齐，由单测锁定** |

## 测试

- `pnpm test`：**228 passed**（基线 222 + 新增 6：animateRatio 缩放、animateRatio=0 的 block 短路与全边瞬时重置、四角横带与死区几何、四角竖向羽化、alpha snap 语义（afrom 捕获/忽略）、clearCurtains 透传 grad）
- `pnpm exec vue-tsc -b`：通过
- `pnpm exec eslint <改动文件>`：通过
