### PR TITLE
fix(story-player): 未配对 [theater(mode=false)] 重置自动播放为手动

### DIFF
--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -2957,7 +2957,16 @@ export class StoryRuntime {
           this.theaterMode = true;
           this.buttonSpeedLevel = 0;
           this.applyScriptAutoPlayMode("button_auto");
-        } else if (!mode && this.theaterMode) {
+        } else if (!mode) {
+          // Native AVGController.SetTheaterMode(false) runs unconditionally while
+          // a story is running (only gate is get_isRunning): _SetTheaterModeStatus's
+          // exit path does _StopAutoClick() first and, when no status was saved
+          // (unpaired exit, !m_needResumeAutoStatus), falls back to
+          // set_autoPlayMode(DEFAULT) instead of restoring. So an unpaired
+          // [theater(mode=false)] resets a running auto-play to manual — not a
+          // no-op. applyScriptAutoPlayMode("default") covers _StopAutoClick() as
+          // well: it cancels the pending auto click when the mode changes, and in
+          // "default" no click is ever scheduled.
           this.theaterMode = false;
           const cached = this.theaterAutoPlayCache;
           this.theaterAutoPlayCache = null;
@@ -2967,6 +2976,8 @@ export class StoryRuntime {
             this.applyScriptAutoPlayMode(
               cached.mode === "quick_play" ? "default" : cached.mode,
             );
+          } else {
+            this.applyScriptAutoPlayMode("default");
           }
         }
         return "continue";

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -657,6 +657,46 @@ describe("StoryRuntime", () => {
     }
   });
 
+  it("resets a running auto play on an unpaired theater exit", async () => {
+    // Native SetTheaterMode(false) executes unconditionally: without a saved
+    // auto status (_SetTheaterModeStatus !m_needResumeAutoStatus branch) it
+    // does _StopAutoClick() + set_autoPlayMode(DEFAULT), so a lone
+    // [theater(mode=false)] drops the player out of auto play instead of
+    // being a no-op (corpus: act25side/level_act25side_02_beg.txt:616).
+    vi.useFakeTimers();
+    try {
+      const renderer = new FakeRenderer();
+      const runtime = new StoryRuntime(
+        createContext([
+          '[name="A"]hi',
+          "[theater(mode=false)]",
+          '[name="B"]next',
+        ]),
+        renderer,
+        new FakeAudio(),
+      );
+
+      await runtime.start();
+      runtime.setAutoPlayMode("button_auto");
+
+      // Auto-advance past "hi" (1.5s + 2 chars * 0.03s), through the unpaired
+      // theater exit, onto "next".
+      await vi.advanceTimersByTimeAsync(1560);
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(runtime.getAutoPlayState().mode).toBe("default");
+      expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "next" });
+      expect(runtime.getState()).toBe("waiting_input");
+
+      // Auto was reset to manual: "next" no longer auto-advances.
+      await vi.advanceTimersByTimeAsync(1620);
+      expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "next" });
+      expect(runtime.getState()).toBe("waiting_input");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("auto-advances after the native button-auto delay and stops at endtip", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## 背景

对 `theater` 命令做 native 对齐复核（明日方舟官服客户端 2.7.61 / build 2761 GameAssembly.dll，IDA 反编译复核）。关键结论（VA 均为 2.7.61 基线）：

- `AVGTheaterLabel._ExecuteTheaterNode`（VA `0x183E63280`）：`GetOrDefault<bool>("mode", 1)` → `SetTheaterMode(value)`，返回不阻塞；前端 `mode` 默认 `true` 与之一致；
- `AVGController.SetTheaterMode`（`0x183E19F00`）仅以 `get_isRunning`（`m_story != null`）为 gate，**`mode=false` 时退出路径无条件执行**，不要求当前处于 theater 模式；
- `AVGController._SetTheaterModeStatus`（`0x183E1D700`）退出分支：先 `_StopAutoClick()`，随后若无 enter 时保存的状态（`!m_needResumeAutoStatus`，即未配对退出）→ **`set_autoPlayMode(DEFAULT)`**（重置为手动，而非跳过恢复）；
- 全剧情语料（latest，5526 个 story 文件）仅 1 处未配对 `[theater(mode=false)]`：`activities/act25side/level_act25side_02_beg.txt:616`（该文件与其前一支文件均无 `theater(mode=true)`，疑为作者笔误，但 native 照样执行重置）。

## 修复内容

review 差异清单（P0/P1 无）条目处理：

| # | 严重度 | 条目 | 处理 |
| --- | --- | --- | --- |
| 1 | P2 | 未配对 `[theater(mode=false)]`：native 重置 autoPlayMode 为 DEFAULT，前端整段 no-op | **修复**：`runtime.ts` `case "theater"` 退出分支去掉 `&& this.theaterMode` gate；`theaterAutoPlayCache === null`（对应 `!m_needResumeAutoStatus`）时 `setAutoPlayMode("default")`——其内部 `cancelAutoClick()` 同时覆盖 native `_StopAutoClick()`（`default` 模式下本就不会调度 auto click）。附 Native provenance 注释 |
| 2 | P3 | enter 时 `ResumeAuto()` / `_UpdateSkipStatus()` | 维持现状：web 无「暂停 auto」与 skip 按钮状态机，有意省略 |
| 3 | P3 | HUD 五键显隐 / 阅读模式禁用 / 长按抑制 | 维持现状：widget 无 HUD/阅读模式/长按手势，有意省略 |
| 4 | P3 | exit 恢复 quick play 档位多还原了 `quickSpeedLevel` | 维持现状：review 裁定语义近似即可 |

配对 enter→exit 恢复路径与 `advance()` 的 `theaterMode` 点击抑制 gate（对应 native `OnClickPress` 的 `!isTheaterMode` 整体 gate）均不变。

## 验证用剧情文件

- `activities/act25side/level_act25side_02_beg.txt:616` — 全语料唯一未配对 `[theater(mode=false)]`：若玩家开着自动播放，native 在该行退回手动；修复后前端同样重置为 `default`。由新增单测锁定行为，无需实机验证；
- 配对场景回归确认未破坏：`obt/main/level_main_14-20_beg.txt:3/11`、`activities/act18side/level_act18side_st01.txt:186/191` 等 20 对 enter/exit 由全语料 story-log 回归覆盖。

## 测试

- 新增单测 `tests/runtime.spec.ts`："resets a running auto play on an unpaired theater exit"；
- `pnpm test`：223 passed（222 基线 + 1 新增）；
- `pnpm exec vue-tsc -b`：通过；
- `pnpm exec eslint src/widgets/StoryPlayer/engine/runtime.ts tests/runtime.spec.ts`：通过；
- `STORY_CORPUS_ROOT=<latest/story> pnpm test:story-log` 全语料回归：2 passed（5526 个 story 文件，双解释器对拍一致）。
