### PR TITLE
fix(story-player): animtext 按 <p=N> 下标填充文本槽位并预处理字面换行

### DIFF
--- a/src/widgets/StoryPlayer/engine/preload.ts
+++ b/src/widgets/StoryPlayer/engine/preload.ts
@@ -1,5 +1,7 @@
 import { Assets } from "pixi.js";
 
+import { STAMP_ASSETS } from "../assets";
+
 import {
   resolveAssetUrl,
   resolveStoryAssetByKey,
@@ -286,6 +288,12 @@ export function collectContextAssetUrls(context: Context): string[] {
   return collectContextAssetManifest(context).urls;
 }
 
+function scriptUsesAnimText(context: Context): boolean {
+  return parseScript(context.scriptText ?? context.script).some(
+    (line) => line.kind === "command" && line.command === "animtext",
+  );
+}
+
 function collectPreloadAssetUrls(context: Context): string[] {
   const urls = new Set(collectContextAssetUrls(context));
 
@@ -293,6 +301,15 @@ function collectPreloadAssetUrls(context: Context): string[] {
   // renderer 在 createUi 时再 Assets.load 即可命中缓存。它属于播放器内置资源，
   // 不应出现在面向用户的剧情资源列表中。
   urls.add(DIALOG_FRAME_URL);
+
+  // animtext `group_location_stamp` 的 7 张内置贴片同理。native 侧
+  // AVGDisplayableExecutor.InternalResRefCollector.GatherResRefs 对 ANIMATE_TEXT
+  // 落入空分支、不登记任何资源引用（native LoadAsset 同步，印章当帧出现）；
+  // web 的 Assets.load 异步，首次播放会晚 1-2 帧，故在剧本确实使用 animtext 时
+  // 一并预热，让面板内 Assets.load 命中缓存。属 web 适配，非 native 行为移植。
+  if (scriptUsesAnimText(context)) {
+    for (const url of Object.values(STAMP_ASSETS)) urls.add(url);
+  }
 
   return [...urls];
 }

--- a/src/widgets/StoryPlayer/engine/rendering/panels/AnimTextPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/AnimTextPanel.ts
@@ -33,10 +33,36 @@ function lerpKeyframes(
   return frames.at(-1)![1];
 }
 
-function splitContent(content: string): string[] {
-  return [...content.matchAll(/<p=\d+>(.*?)<\/>/gs)].map(
-    (match) => match[1] ?? "",
-  );
+/**
+ * Native provenance: `Torappu.FormatUtil.FormatAvgSplitContentTextFromData`
+ * (VA 0x181efb180) → `_HandleAvgSplitContentTextTags` (VA 0x181f017c0), then
+ * `AnimatedTextStampView.InitView` (VA 0x183e244f0):
+ * - the literal two-character `\n` is unescaped into a real newline before
+ *   tag parsing;
+ * - each `<p=N>…</>` contributes dict[N - 1] = inner text (`Int32.TryParse`,
+ *   so only pure digits count as split tags);
+ * - `<p=0>` logs `Avg split content id should start from 1, not 0` and is
+ *   dropped from the dict;
+ * - `InitView` fills slot i via `dict.TryGetValue(i)` — slot i ← `<p=i+1>` by
+ *   index, NOT document order: a stamp that only writes `<p=2>` fills the sub
+ *   slot and leaves the main slot empty.
+ *
+ * Non-`p` rich-text tags are not converted here: the widget rich-text pipeline
+ * (`engine/richtext.ts`) only ports `<color>`, and production animtext data
+ * carries no rich-text tags inside the split content.
+ */
+function splitStampSlots(content: string, onInvalidId?: () => void): string[] {
+  const normalized = content.replaceAll(String.raw`\n`, "\n");
+  const slots: string[] = [];
+  for (const match of normalized.matchAll(/<p=(\d+)>(.*?)<\/>/gs)) {
+    const id = Number.parseInt(match[1]!, 10);
+    if (id === 0) {
+      onInvalidId?.();
+      continue;
+    }
+    slots[id - 1] = match[2] ?? "";
+  }
+  return slots;
 }
 
 /**
@@ -44,6 +70,12 @@ function splitContent(content: string): string[] {
  * the serialized `AVG/AnimateText/group_location_stamp` prefab's visible
  * timeline. Sprite construction and keyframe playback are a Web/PIXI
  * adaptation, not a port of Unity Animator internals.
+ *
+ * `AnimTextInput.id` is intentionally unused: native `InitView` records it
+ * into `m_stampId`, but every targeted-cleanup path is unreachable in 2.7.61
+ * (`clear` is discarded by `_GenParamWithCmd` before reaching the executor,
+ * and no `animtextclean` executor is registered), so stamps are only ever
+ * cleared wholesale (`_CleanAllTextStamps` on reset / script end).
  */
 export class AnimTextPanel {
   private readonly stamps: StampView[] = [];
@@ -60,6 +92,11 @@ export class AnimTextPanel {
   ) {}
 
   async show(input: AnimTextInput): Promise<void> {
+    // Native loads any template via
+    // `ResourceRouter.GetAVGAnimateTextTemplatePath` (`AVG/AnimateText/{0}`,
+    // VA 0x183e8fb60) and LogError+throws when the prefab is missing. This
+    // widget intentionally crops to the only template that exists in the
+    // game data (`group_location_stamp`); other names warn and no-op.
     if (input.name !== "group_location_stamp") {
       this.onWarning?.(`unsupported_visual animtext:${input.name}`);
       return;
@@ -137,7 +174,9 @@ export class AnimTextPanel {
     );
     gradient.anchor.set(0.5);
     gradient.alpha = 0.15;
-    const parts = splitContent(input.content);
+    const parts = splitStampSlots(input.content, () =>
+      this.onWarning?.("animtext split content id should start from 1, not 0"),
+    );
     const main = new Text({
       style: new TextStyle({
         fill: "#ffffff",

--- a/tests/animTextPanel.spec.ts
+++ b/tests/animTextPanel.spec.ts
@@ -1,0 +1,143 @@
+import { Container, Text, Texture } from "pixi.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AnimTextPanel } from "../src/widgets/StoryPlayer/engine/rendering/panels/AnimTextPanel";
+
+import type { AnimTextInput } from "../src/widgets/StoryPlayer/engine/types";
+
+const { loadMock } = vi.hoisted(() => ({
+  loadMock: vi.fn(async () => Texture.WHITE),
+}));
+
+vi.mock("pixi.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("pixi.js")>()),
+  Assets: { load: loadMock },
+}));
+
+function input(overrides: Partial<AnimTextInput> = {}): AnimTextInput {
+  return {
+    block: false,
+    content: "",
+    id: "at1",
+    name: "group_location_stamp",
+    position: { x: -400, y: -200 },
+    style: "avg_both",
+    ...overrides,
+  };
+}
+
+// tween 永不完成即可:block=false 时 show() 不等动画,文本属性可当场断言。
+const pendingTween = () => new Promise<void>(() => {});
+
+function collectTexts(container: Container): Text[] {
+  const texts: Text[] = [];
+  for (const child of container.children) {
+    if (child instanceof Text) texts.push(child);
+    else if (child instanceof Container) texts.push(...collectTexts(child));
+  }
+  return texts;
+}
+
+async function stampTexts(
+  panel: AnimTextPanel,
+  layer: Container,
+  input: AnimTextInput,
+): Promise<{ main: Text; sub: Text }> {
+  await panel.show(input);
+  const root = layer.children.at(-1) as Container;
+  const [main, sub] = collectTexts(root).sort(
+    (a, b) => a.position.y - b.position.y,
+  );
+  return { main: main!, sub: sub! };
+}
+
+describe("AnimTextPanel", () => {
+  beforeEach(() => {
+    loadMock.mockClear();
+  });
+
+  it("fills slot i from <p=i+1> by index, so a <p=2>-only stamp lands in the sub slot", async () => {
+    const layer = new Container();
+    const panel = new AnimTextPanel(layer, pendingTween);
+
+    const ordered = await stampTexts(
+      panel,
+      layer,
+      input({
+        content: "<p=1>维多利亚边境，布查特市</><p=2>一个月后</>",
+      }),
+    );
+    expect(ordered.main.text).toBe("维多利亚边境，布查特市");
+    expect(ordered.sub.text).toBe("一个月后");
+
+    // 生产样本 level_main_15-12_end.txt:342 只写 <p=2> 且 avg_only_medium:
+    // native 语义是槽 0 留空、文本进槽 1(sub),而非按出现顺序填 main。
+    const skipped = await stampTexts(
+      panel,
+      layer,
+      input({
+        content: "<p=2>距离本舰骚乱开始已过去五十七分钟</>",
+        style: "avg_only_medium",
+      }),
+    );
+    expect(skipped.main.text).toBe("");
+    expect(skipped.sub.text).toBe("距离本舰骚乱开始已过去五十七分钟");
+    expect(skipped.main.visible).toBe(false);
+    expect(skipped.sub.visible).toBe(true);
+  });
+
+  it(
+    String.raw`unescapes literal \n into a newline before split parsing`,
+    async () => {
+      const layer = new Container();
+      const panel = new AnimTextPanel(layer, pendingTween);
+      const { main } = await stampTexts(
+        panel,
+        layer,
+        input({
+          content: String.raw`<p=1>第一行\n第二行</>`,
+        }),
+      );
+      expect(main.text).toBe("第一行\n第二行");
+    },
+  );
+
+  it("drops <p=0> with a warning and keeps other slots intact", async () => {
+    const layer = new Container();
+    const warning = vi.fn();
+    const panel = new AnimTextPanel(layer, pendingTween, warning);
+    const { main, sub } = await stampTexts(
+      panel,
+      layer,
+      input({
+        content: "<p=0>非法段</><p=1>主行</><p=2>副行</>",
+      }),
+    );
+    expect(warning).toHaveBeenCalledWith(
+      "animtext split content id should start from 1, not 0",
+    );
+    expect(main.text).toBe("主行");
+    expect(sub.text).toBe("副行");
+  });
+
+  it("hides the sub row for avg_only_heavy and rejects unknown templates", async () => {
+    const layer = new Container();
+    const warning = vi.fn();
+    const panel = new AnimTextPanel(layer, pendingTween, warning);
+    const { main, sub } = await stampTexts(
+      panel,
+      layer,
+      input({
+        content: "<p=1>舰船附近的无人地带</>",
+        style: "avg_only_heavy",
+      }),
+    );
+    expect(main.text).toBe("舰船附近的无人地带");
+    expect(main.visible).toBe(true);
+    expect(sub.visible).toBe(false);
+
+    await panel.show(input({ content: "<p=1>x</>", name: "other" }));
+    expect(warning).toHaveBeenCalledWith("unsupported_visual animtext:other");
+    expect(layer.children).toHaveLength(1);
+  });
+});

--- a/tests/preload.spec.ts
+++ b/tests/preload.spec.ts
@@ -2,6 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { STAMP_ASSETS } from "../src/widgets/StoryPlayer/assets";
 import {
   collectContextAssetManifest,
   collectContextAssetUrls,
@@ -133,6 +134,28 @@ describe("preloadContextAssets", () => {
       false,
     );
     expect(loadMock).not.toHaveBeenCalled();
+  });
+
+  it("preheats animtext stamp textures only for scripts that use animtext", async () => {
+    const stampUrls = Object.values(STAMP_ASSETS);
+
+    const withAnimText = createContext([
+      '[animtext(id="at1",name="group_location_stamp",style="avg_only_medium",pos="-400,-200",block=false)]<p=2>距离本舰骚乱开始已过去五十七分钟</>',
+    ]);
+    await preloadContextAssets(withAnimText);
+    const loadedWithStamp = loadMock.mock.calls[0]![0] as string[];
+    expect(loadedWithStamp).toEqual(expect.arrayContaining(stampUrls));
+    // 内置贴片不属于剧情资源,不应进入面向用户的资源清单。
+    expect(collectContextAssetUrls(withAnimText)).toEqual(
+      expect.not.arrayContaining(stampUrls),
+    );
+
+    loadMock.mockClear();
+    await preloadContextAssets(
+      createContext(['[background(image="bg_rhodes_day")]']),
+    );
+    const loadedWithoutStamp = loadMock.mock.calls[0]![0] as string[];
+    expect(loadedWithoutStamp).toEqual(expect.not.arrayContaining(stampUrls));
   });
 
   it("lists every face for a used base and marks referenced faces", () => {


### PR DESCRIPTION
## 背景

依据官服客户端 2.7.61(build 2761)GameAssembly.dll 的 IDA 反编译复核(review 文档 `arknights-rev/docs/impl-review/impl-review-animtext-command.md`),`animtext` 的关键 native 语义:

- `AnimatedTextStampView.InitView`(VA 0x183e244f0)填充文本是**按槽位下标取值**:`for i in 0.._textArray.Length: text = dict.TryGetValue(i) ?? ""`,而 dict 的键是 `<p=N>` 的 **N−1**——即槽 i ← `<p=i+1>`,不是按标签出现顺序。只写 `<p=2>` 的印章文本进 sub 槽、main 槽留空。
- `FormatUtil.FormatAvgSplitContentTextFromData`(VA 0x181efb180)→ `_HandleAvgSplitContentTextTags`(VA 0x181f017c0):解析前把字面 `\n`(反斜杠+n 两字符)替换为真换行;`<p=N>` 的 N 经 `Int32.TryParse`;`N==0` 记 `LogError("Avg split content id should start from 1, not 0")` 且不入表;非纯数字标签按富文本转换、不进 dict。
- 模板:native 经 `ResourceRouter.GetAVGAnimateTextTemplatePath`(VA 0x183e8fb60,`"AVG/AnimateText/{0}"`)加载任意模板,游戏数据中仅存在 `group_location_stamp`。
- 预加载:`AVGDisplayableExecutor.InternalResRefCollector.GatherResRefs`(VA 0x183e46b50)对 ANIMATE_TEXT 落入空分支、不登记资源;native `LoadAsset` 同步,印章当帧出现。
- `id`:native `InitView` 记入 `m_stampId`,但 2.7.61 中 `clear` 参数被 `_GenParamWithCmd`(0x183e22556 处 GetOrDefault 结果未赋值)丢弃、且无 `animtextclean` executor,定向清理路径不可达。

## 修复内容

对照 review 差异清单(P2×3、P3×5,无 P0/P1):

- **P2#1 槽位下标取段**(核心修复):原 `splitContent` 按出现顺序 `parts[0]→text_main`、`parts[1]→text_sub`,只写 `<p=2>` 时文本被错填进 main 槽——`avg_only_medium` 样式下 main 槽被隐藏,整枚印章无字。改为 `splitStampSlots` 按 N−1 建槽位数组、按槽位下标取值,并对齐 `<p=0>` 丢弃 + 警告(native LogError 的等价物)。**注:review 原文称"现有数据不受影响"不准确——生产语料 495 条 animtext 中有 74 条只写 `<p=2>`(全部 `avg_only_medium`),均受此 bug 影响。**
- **P2#2 分段预处理**:分段解析前把字面 `\n` 替换为换行(对齐 `FormatAvgSplitContentTextFromData`)。富文本标签转换未做:widget 富文本管线(`engine/richtext.ts`)仅移植 `<color>`,且生产 animtext 分段内富文本标签 0 命中,取舍已在代码注释说明。
- **P3#7 纹理异步延迟**:preload 阶段当剧本包含 `animtext` 命令时,预热 `group_location_stamp` 的 7 张内置贴片(与 `DIALOG_FRAME_URL` 同一模式,不进面向用户的资源清单),消除首次播放印章晚 1-2 帧出现;属 web 适配(native 无 animtext 预加载)。
- **P2#3 模板白名单 / P3#6 id 未用**:按 review 建议维持现状(有意裁剪/行为等价),补全 Native provenance 注释说明依据。
- 其余 P3(#4 5s 动画不随速度档缩放、#5 block 失败分支、#8 空内容等价)按 review 建议维持现状,未改动。

## 验证用剧情文件

语料根:`torappu/storage/asset/gamedata/latest/story/`(下为相对路径):

- `obt/main/level_main_15-12_end.txt:342`(及 395/442/492)— 只写 `<p=2>` + `avg_only_medium`(P2#1 主验证:文本应进 sub 槽显示,而非填进被隐藏的 main 槽)
- `activities/act37side/level_act37side_03_beg.txt:279`、`activities/act38side/level_act38side_01_beg.txt:11` — 同上,活动剧情样本
- `obt/main/level_main_15-18_end.txt:416` — `<p=1>`+`<p=2>` 顺序样本(回归:映射改法不影响顺序数据)
- `\n` 字面量与 `<p=0>`:生产语料 0 命中,前瞻对齐,由单测锁定(`tests/animTextPanel.spec.ts`)

## 测试

- `pnpm test`:**227 用例全绿**(基线 222,新增 `tests/animTextPanel.spec.ts` 4 例 + `tests/preload.spec.ts` 1 例)
- `pnpm exec vue-tsc -b` 通过
- `pnpm exec eslint` 改动的 4 个文件通过
