### PR TITLE
fix(story-player): avgdisplay fade 时长≤0 跳过 alpha 赋值并对齐枚举化 slot/style 比较

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/panels/AvgDisplayPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/AvgDisplayPanel.ts
@@ -18,6 +18,44 @@ type Tween = (
 ) => Promise<void>;
 
 /**
+ * Canonical style/slot views mirroring AVGDisplayableUtil.GenTypeFromRaw /
+ * GenSlotFromRaw (0x183e39cd0 / 0x183e39ba0, 2.7.61): integers parse first
+ * (no enum range check), then case-sensitive ordinal aliases; everything else
+ * collapses to NONE. AVGDisplayableManager._DisplayInternal (0x183e38f70)
+ * compares these parsed enums when deciding whether an id's holder must be
+ * disposed and rebuilt, so "3" vs "effect" (same enum member) or two unknown
+ * strings (both NONE) must NOT trigger a rebuild -- comparing raw strings
+ * would discard the live entry's position/alpha mid-animation.
+ */
+const STYLE_ENUM: Record<string, string> = {
+  "1": "animetext",
+  "2": "spine",
+  "3": "effect",
+  "4": "bgeffect",
+  "5": "bg",
+  "6": "animekv",
+  "7": "character",
+  animetext: "animetext",
+  animekv: "animekv",
+  bgeffect: "bgeffect",
+  bg: "bg",
+  character: "character",
+  effect: "effect",
+  spine: "spine",
+};
+const SLOT_ENUM: Record<string, string> = {
+  "1": "bgover",
+  "2": "charover",
+  "3": "cgover",
+  bgover: "bgover",
+  cgover: "cgover",
+  charover: "charover",
+};
+const canonicalStyle = (style: string): string => STYLE_ENUM[style] ?? "none";
+const canonicalSlot = (slot: AvgDisplaySlot): string =>
+  SLOT_ENUM[slot] ?? "none";
+
+/**
  * Port scope: `Torappu.AVG.AVGDisplayableExecutor._ExecuteAVGDisplayable`.
  * It retains id replacement, slot/style routing, and command timing; PIXI
  * containers and the currently supported `bg` asset are Web adaptations.
@@ -57,7 +95,14 @@ export class AvgDisplayPanel {
     }
 
     let state = this.states.get(input.id);
-    if (state && (state.slot !== input.slot || state.style !== input.style)) {
+    // Slot/style change check compares the parsed-enum equivalents (see
+    // STYLE_ENUM above), matching _DisplayInternal's enum comparison instead
+    // of raw strings.
+    if (
+      state &&
+      (canonicalSlot(state.slot) !== canonicalSlot(input.slot) ||
+        canonicalStyle(state.style) !== canonicalStyle(input.style))
+    ) {
       this.remove(input.id);
       state = undefined;
     }
@@ -75,6 +120,15 @@ export class AvgDisplayPanel {
     }
 
     if (state.name !== input.name) {
+      // Divergence (intentional, verified 2.7.61): native
+      // _LoadContentIfNeed (0x183e389c0) compares the holder's GameObject
+      // name -- NOT the command `name` -- so content is generated once per
+      // holder instance and re-displaying a live id with a different `name`
+      // only replays features (the 2.7.51 doc's "name change rebuilds
+      // content" claim does not hold in 2.7.61). We keep rebuilding because
+      // it matches the command's intent; no production story re-names a live
+      // id without an intervening destroy (`[avgdisplay(id="1")]`), so this
+      // divergence is corpus-unreachable.
       for (const child of state.root.removeChildren()) child.destroy();
       state.name = input.name;
       await this.generateContent(state, input);
@@ -102,6 +156,14 @@ export class AvgDisplayPanel {
       input.style === "character";
     const supportsScale = input.style === "animekv";
     const supportsFade = input.style === "bg";
+    // Native port: AVGDisplayableHolder._ApplyFadeFeature (0x183e372e0,
+    // 2.7.61) skips the ENTIRE fade block when CalculateFadetime(duration)
+    // <= 0 -- alpha is left completely untouched, unlike position/scale which
+    // snap straight to the end point on the same branch. Under the
+    // fast-forward gear (animateRatio = 0) every bg fade lands there, so a
+    // dimming overlay must keep its current alpha instead of snapping to
+    // `ato` (default 0, which made duration-less bg displays vanish).
+    const fadeActive = supportsFade && input.durationMs > 0;
     const hasEntry =
       input.style === "animekv" &&
       (input.entryFrom !== undefined || input.entryTo !== undefined);
@@ -114,14 +176,14 @@ export class AvgDisplayPanel {
       input.style === "character"
     )
       root.rotation = (input.rotationZ * Math.PI) / 180;
-    if (supportsFade) root.alpha = input.alphaFrom ?? 1;
+    if (fadeActive) root.alpha = input.alphaFrom ?? 1;
 
     const hasPositionTween =
       supportsPosition && (startX !== endX || startY !== endY);
     const hasScaleTween =
       supportsScale && (startScaleX !== endScaleX || startScaleY !== endScaleY);
     const alphaTo = input.alphaTo ?? 0;
-    const hasFadeTween = supportsFade && root.alpha !== alphaTo;
+    const hasFadeTween = fadeActive && root.alpha !== alphaTo;
     const hasTween =
       input.durationMs > 0 &&
       (hasPositionTween || hasScaleTween || hasFadeTween || hasEntry);
@@ -138,7 +200,7 @@ export class AvgDisplayPanel {
           startScaleX + (endScaleX - startScaleX) * progress,
           startScaleY + (endScaleY - startScaleY) * progress,
         );
-      if (supportsFade)
+      if (fadeActive)
         root.alpha =
           (input.alphaFrom ?? 1) +
           (alphaTo - (input.alphaFrom ?? 1)) * progress;

--- a/tests/avgDisplayPanel.spec.ts
+++ b/tests/avgDisplayPanel.spec.ts
@@ -1,0 +1,134 @@
+import { Container, Texture } from "pixi.js";
+import { describe, expect, it } from "vitest";
+
+import { AvgDisplayPanel } from "../src/widgets/StoryPlayer/engine/rendering/panels/AvgDisplayPanel";
+
+import type { AvgDisplayInput } from "../src/widgets/StoryPlayer/engine/types";
+
+function input(overrides: Partial<AvgDisplayInput> = {}): AvgDisplayInput {
+  return {
+    block: false,
+    durationMs: 0,
+    entryIndex: 0,
+    id: "1",
+    layer: 1,
+    name: "bg_black",
+    rotationX: 0,
+    rotationY: 0,
+    rotationZ: 0,
+    slot: "bgover",
+    style: "bg",
+    ...overrides,
+  };
+}
+
+async function tweenImmediately(
+  _duration: number,
+  update: (progress: number) => void,
+  complete?: () => void,
+): Promise<void> {
+  update(1);
+  complete?.();
+}
+
+function makePanel(): {
+  panel: AvgDisplayPanel;
+  slots: Record<string, Container>;
+} {
+  const slots = {
+    bgover: new Container(),
+    cgover: new Container(),
+    charover: new Container(),
+  };
+  const panel = new AvgDisplayPanel(
+    slots,
+    async (name) => (name === "missing" ? null : Texture.WHITE),
+    tweenImmediately,
+  );
+  return { panel, slots };
+}
+
+describe("AvgDisplayPanel", () => {
+  // Native port: AVGDisplayableHolder._ApplyFadeFeature (0x183e372e0,
+  // 2.7.61) skips the whole fade feature when CalculateFadetime(duration)
+  // <= 0, leaving alpha untouched (position/scale still snap to their end
+  // point). The fast-forward gear (animateRatio = 0) drives every bg fade
+  // into that branch.
+  it("leaves bg alpha untouched when durationMs <= 0", async () => {
+    const { panel, slots } = makePanel();
+    // Establish a dimmed overlay (afrom == ato snaps alpha directly).
+    await panel.display(
+      input({ alphaFrom: 0.5, alphaTo: 0.5, durationMs: 1000 }),
+    );
+    const root = slots.bgover.children[0];
+    expect(root.alpha).toBe(0.5);
+
+    // Fast-forward replay (durationMs = 0) must not snap alpha to ato.
+    await panel.display(input({ alphaFrom: 1, alphaTo: 0, durationMs: 0 }));
+    expect(slots.bgover.children[0]).toBe(root);
+    expect(root.alpha).toBe(0.5);
+  });
+
+  it("keeps a fresh duration-less bg visible instead of fading to the default ato=0", async () => {
+    const { panel, slots } = makePanel();
+    await panel.display(input({ durationMs: 0 }));
+    expect(slots.bgover.children[0].alpha).toBe(1);
+  });
+
+  it("still tweens bg alpha when durationMs > 0", async () => {
+    const { panel, slots } = makePanel();
+    await panel.display(input({ alphaFrom: 1, alphaTo: 0, durationMs: 700 }));
+    expect(slots.bgover.children[0].alpha).toBe(0);
+  });
+
+  it("snaps position to the end point when durationMs <= 0", async () => {
+    const { panel, slots } = makePanel();
+    await panel.display(
+      input({ style: "effect", name: "$e_x", x: 10, xTo: 30, durationMs: 0 }),
+    );
+    const root = slots.bgover.children[0];
+    expect(root.position.x).toBe(640 + 30);
+  });
+
+  // Native port: _DisplayInternal (0x183e38f70) compares the enums parsed by
+  // GenTypeFromRaw / GenSlotFromRaw, so numeric spellings and aliases of the
+  // same member ("5"/"bg", "1"/"bgover") or two unknown values (both NONE)
+  // never rebuild a live entry; a real enum change does.
+  it("does not rebuild when style/slot only differ in raw spelling", async () => {
+    const { panel, slots } = makePanel();
+    await panel.display(
+      input({ alphaFrom: 0.5, alphaTo: 0.5, durationMs: 1000 }),
+    );
+    const root = slots.bgover.children[0];
+
+    await panel.display(input({ style: "5", slot: "bgover", durationMs: 0 }));
+    expect(slots.bgover.children[0]).toBe(root);
+    expect(root.alpha).toBe(0.5);
+
+    // A known member vs an unknown value IS an enum change (bg -> NONE):
+    // rebuild, then two unknown values share the NONE bucket -- no rebuild.
+    await panel.display(input({ style: "weird", slot: "bgover" }));
+    const unknownRoot = slots.bgover.children[0];
+    expect(unknownRoot).not.toBe(root);
+    await panel.display(input({ style: "other", slot: "bgover" }));
+    expect(slots.bgover.children[0]).toBe(unknownRoot);
+  });
+
+  it("rebuilds when the parsed style or slot enum actually changes", async () => {
+    const { panel, slots } = makePanel();
+    await panel.display(
+      input({ alphaFrom: 0.5, alphaTo: 0.5, durationMs: 1000 }),
+    );
+    const root = slots.bgover.children[0];
+
+    await panel.display(
+      input({ style: "4", name: "$eb_glow_s", durationMs: 0 }),
+    );
+    expect(slots.bgover.children).toHaveLength(1);
+    expect(slots.bgover.children[0]).not.toBe(root);
+
+    await panel.display(input({ style: "bg", slot: "cgover", durationMs: 0 }));
+    expect(slots.bgover.children).toHaveLength(0);
+    expect(slots.cgover.children).toHaveLength(1);
+  });
+});

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -540,6 +540,28 @@ describe("StoryRuntime", () => {
     ]);
   });
 
+  it("normalizes numeric avgdisplay style/slot spellings to their aliases", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[avgdisplay(id="9",name="bg_black",style=5,slot=1,duration=1)]',
+        '[avgdisplay(id="9",name="bg_black",style="bg",slot="bgover",duration=1)]',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // Native GenTypeFromRaw / GenSlotFromRaw parse integers first, so "5"
+    // and "bg" are the same enum member: both displays must reach the panel
+    // with identical canonical spellings (no holder rebuild in between).
+    expect(renderer.avgDisplayCalls).toEqual([
+      expect.objectContaining({ id: "9", style: "bg", slot: "bgover" }),
+      expect.objectContaining({ id: "9", style: "bg", slot: "bgover" }),
+    ]);
+  });
+
   it("enters waiting_input on first dialogue", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(


### PR DESCRIPTION
## 背景

基于明日方舟官服客户端 2.7.61（build 2761）GameAssembly.dll 的 IDA 反编译复核（2026-08-24/25，详见 arknights-rev `docs/impl-review/impl-review-avgdisplay-command.md`），`avgdisplay` 的 native 关键结论：

- **fade 特性**（`AVGDisplayableHolder._ApplyFadeFeature` @ `0x183e372e0`）：`afrom` 默认 1、`ato` 默认 0、`duration` 默认 0.1，过 `CalculateFadetime`（`× animateRatio`，`0x183e3f860`）后 **`d ≤ 0` 时整块跳过——alpha 完全不动**；这与 position/scale（`d ≤ 0` 直接赋终点）语义不同。快进档 `animateRatio = 0` 下**所有 bg fade 都落在该分支**，遮罩保持当前透明度。
- **slot/style 变化判定**（`AVGDisplayableManager._DisplayInternal` @ `0x183e38f70`）：比较的是 `GenTypeFromRaw`/`GenSlotFromRaw`（`0x183e39cd0` / `0x183e39ba0`）解析出的**枚举值**——整数先解析（无范围校验）、别名区分大小写、未知名统一落 NONE。因此 `"3"` 与 `"effect"` 互切、两个未知值互切都**不触发** holder 销毁重建。
- **内容不随 name 重建**（`_LoadContentIfNeed` @ `0x183e389c0`）：判据是 holder 的 GameObject 名而非命令 `name`，内容每个 holder 实例只生成一次（2.7.51 历史文档 §2.1 的"换 name 重建"说法在 2.7.61 不成立）。

## 修复内容

对照 review 差异清单（P0 × 0，P1 × 1，P2 × 3）：

- **#1 P1 — fade 时长 ≤ 0 的终态**：`AvgDisplayPanel` 新增 `fadeActive = supportsFade && durationMs > 0` 门控初始 `alpha = afrom` 赋值、`hasFadeTween` 与 apply 内 alpha 插值。`durationMs ≤ 0`（快进档或显式 duration=0）时 alpha 完全不动，与 native `LE(d,0)` 整块跳过一致；修复前 `apply(1)` 会把 alpha 瞬移到 `ato`（默认 0），使无独立时长来源的 bg 遮罩在快进档瞬间消失。position/scale 的"直接赋终点"保持不变（native 同款分支）。
- **#3 P2 — slot/style 按原始字符串比较**：新增 `STYLE_ENUM`/`SLOT_ENUM` 规范化表（数字与别名折叠到同一枚举名，未知值统一 `none` ≙ NONE），存活条目的 slot/style 变化判定改按规范化值比较，等价拼写互切不再误触发 remove+重建丢失进行中的位置/透明度状态。
- **#2 P2 — 同 id 换 name 的内容重建**：语料全扫（5526 个剧情文件、128 条 avgdisplay）确认**不存在"存活条目换 name"用例**（仅有的 2 组 id 复用均被 `name=""` 销毁命令隔开，native 侧销毁即移除字典条目），保留前端"换 name 重建"行为（更符合命令意图），补 native divergence 注释说明 `_LoadContentIfNeed` 的真实判据。
- **#4 P2 — ease**：全语料 0 命中（review 建议"数据未见使用"），维持现状不实现。

## 验证用剧情文件

语料根：`gamedata/latest/story/`（相对路径）：

- `activities/act20mini/level_act20mini_st01.txt:527` — `[avgdisplay(id="1",style="bg",name="bg_black",afrom=0.5,ato=0,duration=0.7,slot="bgover",layer=1,block=true)]`：正常档 0.7s 淡出遮罩；**快进档修复前 alpha 瞬移 0.5→0（画面瞬间变亮），修复后保持 0.5**（P1）。
- `activities/act44side/level_act44side_08_beg.txt:87` — `afrom=1,ato=0.5,duration=2`：快进档修复前瞬移到 0.5，修复后保持 1（P1）。
- `obt/main/level_main_15-15_beg.txt:101/118` — id=1 的 bg 遮罩与销毁序列：验证销毁后 id 复用走全新建（#2 注释所述不可达路径的邻近用例）。
- #3（等价拼写互切）与"存活条目换 name"：语料 0 命中，**前瞻对齐，由单测锁定**（`tests/avgDisplayPanel.spec.ts`）。

## 测试

- 新增 `tests/avgDisplayPanel.spec.ts`（6 例：fade≤0 跳过 / 新建 bg 保持可见 / duration>0 仍插值 / position 直接赋终点 / 等价拼写不重建+真实枚举变化重建）；
- `tests/runtime.spec.ts` 补数字拼写归一化 1 例（`style=5,slot=1` 与 `style="bg",slot="bgover"` 到达 panel 时完全一致）。
- `pnpm test`：**229 用例全绿**（基线 222 + 7）；`pnpm exec vue-tsc -b` 通过；`pnpm exec eslint`（改动文件）0 error 0 warning。
