### PR TITLE
fix(story-player): skiptothis 跳转后重置自动播放模式

### DIFF
--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -530,6 +530,13 @@ export class StoryRuntime {
     if (this.skipToIndex >= 0 && this.cursor <= this.skipToIndex) {
       this.cursor = this.skipToIndex + 1;
       shouldResume = true;
+      // Native port: Torappu.AVG.AVGController.SkipStory's shared UI tail runs
+      // after the SkipToThis jump and resets set_autoPlayMode(DEFAULT) plus
+      // stops the auto coroutine (2.7.61: 0x183e1a74d / 0x183e1a788), so auto
+      // playback never continues past the anchor. Web adaptation: only the
+      // real jump resets; native also runs this tail for an already-crossed
+      // anchor (a no-op jump), which canSkipNode() precludes here.
+      this.setAutoPlayMode("default");
     } else if (this.skipToIndex >= 0) {
       // SkipToThis is forward-only. Native does not fall back to skipnode or
       // StopStory after playback has already crossed the anchor.

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2916,6 +2916,44 @@ describe("StoryRuntime", () => {
     expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "after" });
   });
 
+  it("resets auto play mode to default after a SkipToThis jump", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = new FakeRenderer();
+      const runtime = new StoryRuntime(
+        createContext([
+          '[name="A"]before',
+          "[SkipToThis]",
+          '[name="B"]after',
+          '[name="C"]later',
+        ]),
+        renderer,
+        new FakeAudio(),
+      );
+
+      await runtime.start();
+      runtime.setAutoPlayMode("button_auto");
+      expect(runtime.getAutoPlayState().mode).toBe("button_auto");
+
+      await runtime.skipNode();
+
+      // Native SkipStory tail: set_autoPlayMode(DEFAULT) + stop the auto
+      // coroutine, so auto playback does not continue past the anchor.
+      expect(runtime.getAutoPlayState().mode).toBe("default");
+      expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "after" });
+
+      // The cancelled button-auto click never fires; "later" only shows on a
+      // manual advance.
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "after" });
+
+      await runtime.advance();
+      expect(renderer.lastDialogue).toEqual({ speaker: "C", text: "later" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("disables segment skip when the story has no skip anchors", async () => {
     const runtime = new StoryRuntime(
       createContext(['[name="A"]before', '[name="B"]after']),


### PR DESCRIPTION
# fix(story-player): skiptothis 跳转后重置自动播放模式

## 背景

native 逆向关键结论(2.7.61 / build 2761 GameAssembly.dll,IDA 反编译复核,
详见 arknights-rev `docs/impl-review/impl-review-skiptothis-command.md`):

- `AVGController.SkipStory`(0x183e1a150)的 skiptothis 分支跳转写点
  `m_executeIndex = m_skipToIndex`(0x183e1a6fe)后**不 return**,fall through
  到公共 UI 收尾(0x183e1a704 起),其中:
  - `set_autoPlayMode(DEFAULT)` @ **0x183e1a74d**;
  - 停 auto 协程 @ **0x183e1a788**。
  即 native 里跳到锚点后自动播放必然退出,auto 模式不会延续到锚点之后。
- 前端 `skipNode()`(runtime.ts)的 skiptothis 分支此前只做跳转
  (`cursor = skipToIndex + 1`),未重置 autoPlayMode —— review 差异清单
  **#1(P2)**:「跳转后不退出自动播放」,修复建议为在 skiptothis 分支补
  `setAutoPlayMode("default")`。

## 修复内容

差异清单条目 + 改法(仅 #1 一条,其余条目按文档建议维持现状):

| # | 严重度 | 条目 | 处理 |
|---|---|---|---|
| 1 | P2 | 跳转后不退出自动播放 | **修复**:`skipNode()` skiptothis 跳转分支补 `this.setAutoPlayMode("default")`(内部含 `cancelAutoClick()`,对应 native 停 auto 协程);附 Native provenance 注释(注明 Web 适配:仅真实跳转重置,越过锚点的 no-op 收尾由 `canSkipNode()` 禁用按钮预先排除) |
| 2 | P2 | 越过锚点后点击跳过的收尾 | 不改(文档:可接受,UI 不可达) |
| 3 | P2 | 无确认面板 | 不改(文档:有意省略) |
| 4 | P3 | 跳转后清空 skipnode 队列 | 不改(文档:latest 数据 5 个文件中 skipnode 均与锚点同位或在前,实际无差异;且属 skip 状态机公共改动面) |
| 5 | P3 | 越过锚点的按钮状态 | 不改(文档:前端为 UX 改进,保持) |
| 6 | P3 | 0.2s 起播延迟 | 不改(文档:与本命令无关的全局时序差异,记录备查) |
| 7 | P3 | 多个 `[SkipToThis]` | 不改(文档:一致,无需处理) |

## 验证用剧情文件

语料库 latest(26-08-07-14-53-29_30b8f0)中 `[SkipToThis]` 共 5 处,均触发
本修复的跳转分支;修复效果在「跳过时正处于 button_auto/quick_play 自动播放」
场景下可见(auto 退出,不再越过锚点继续自动推进):

- `obt/guide/beg/0_welcome_to_guide.txt:331` — 331 行教学前情后锚点,自动播放中跳过 → 跳到 `[StartBattle(stageId="guide_01")]` 且 auto 复位
- `obt/guide/beg/1a_guide_1to2.txt:5` — 锚点后 `[StartBattle(stageId="guide_02")]`
- `obt/guide/beg/1b_guide_1to2.txt:9` — 同上另一分支
- `obt/guide/beg/2_guide_to_home.txt:170` — 锚点后 `[GotoPage(dest="home")]`
- `activities/act50side/training/training_act50side_01_b.txt:33` — 锚点后 `[battle.unlockfunction(...)]`

## 测试

- 新增单测 `tests/runtime.spec.ts`「resets auto play mode to default after a
  SkipToThis jump」:button_auto 激活时跳过 → mode 复位 default、落点为锚点
  下一行、已取消的 auto 定时点击不再触发(推进 5s 不前进)、手动 advance 恢复。
- `pnpm test`:20 文件 **223 用例全绿**(基线 222 + 新增 1)。
- `pnpm exec vue-tsc -b` 通过;`pnpm exec eslint`(改动文件)通过。
- `STORY_CORPUS_ROOT=<latest/story> pnpm test:story-log` 全语料 Log All
  对拍通过(2/2,含独立 runtime oracle 全路径对拍)。
