### PR TITLE
fix(story-player): skipnode 外围行为对齐 native 2.7.61

### DIFF
--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -278,6 +278,19 @@ interface SkipNodeLabel {
   mode: SkipMode;
 }
 
+/**
+ * Case-insensitive command-argument lookup shared by the standalone
+ * preprocessors and `StoryRuntime.arg`. Keeps parameter keys' source casing
+ * intact while tolerating case variants at read time.
+ */
+function lookupCommandArg(args: StoryCommandArgs, key: string): unknown {
+  if (Object.prototype.hasOwnProperty.call(args, key)) return args[key];
+  const matched = Object.keys(args).find(
+    (candidate) => candidate.toLowerCase() === key.toLowerCase(),
+  );
+  return matched === undefined ? undefined : args[matched];
+}
+
 function preprocessSkipNodes(
   lines: ReturnType<typeof parseScript>,
 ): SkipNodeLabel[] {
@@ -286,10 +299,13 @@ function preprocessSkipNodes(
   for (const [index, line] of lines.entries()) {
     if (line.kind !== "command" || line.command !== "skipnode") continue;
 
-    // Native port: Torappu.AVG.AVGStoryCache.CalSkipMode. Only the exact
-    // lower-case sentinel maps to FIRST_CANNOT_SKIP; every other value,
+    // Native port: Torappu.AVG.AVGStoryCache.AddSkipNode (0x183e5eec0) reads
+    // the mode via GetOrDefault("mode", "skip"), then CalSkipMode (0x183e5f180)
+    // maps only the exact lower-case sentinel "nofirstskip" to
+    // FIRST_CANNOT_SKIP; every other value falls back to CAN_SKIP. Key lookup
+    // is case-insensitive like every other command argument.
     const mode =
-      toString(line.args.mode, "skip") === "nofirstskip"
+      toString(lookupCommandArg(line.args, "mode"), "skip") === "nofirstskip"
         ? "nofirstskip"
         : "skip";
     labels.push({ lineIndex: index, mode });
@@ -520,6 +536,12 @@ export class StoryRuntime {
   async skipNode(): Promise<void> {
     if (this.destroyed || !this.canSkipNode()) return;
 
+    // Native port: Torappu.AVG.AVGController.OnSkipBtnClicked (2.7.61
+    // 0x183e16ee0) drops the skip click entirely while autoPlayMode ==
+    // QUICK_PLAY. The brief-confirm panel it shows otherwise is a native-only
+    // UI that this widget intentionally omits.
+    if (this.autoPlayMode === "quick_play") return;
+
     const hadActiveProcessLoop = this.processing;
     const activeProcessCompletion = this.processingCompletion;
     let shouldResume = false;
@@ -529,6 +551,12 @@ export class StoryRuntime {
     // the native m_executeIndex < m_skipToIndex forward-only test.
     if (this.skipToIndex >= 0 && this.cursor <= this.skipToIndex) {
       this.cursor = this.skipToIndex + 1;
+      // Native port: Torappu.AVG.AVGController.SkipStory's skiptothis tail
+      // (2.7.61 0x183e1a74d/0x183e1a788) resets autoPlayMode back to DEFAULT
+      // and stops the auto coroutine before resuming. The skipnode branch
+      // below deliberately does not: native leaves the auto mode untouched
+      // on a label jump.
+      this.setAutoPlayMode("default");
       shouldResume = true;
     } else if (this.skipToIndex >= 0) {
       // SkipToThis is forward-only. Native does not fall back to skipnode or
@@ -541,9 +569,17 @@ export class StoryRuntime {
         this.currentSkipMode = nextLabel.mode;
       }
 
-      const tutorial = this.context.storyMetadata?.isTutorial ?? false;
+      // Native port: Torappu.AVG.AVGController.get_isSkippable (2.7.61
+      // 0x183e1f7a0): isRunning && story.isSkippable &&
+      // AVGStoryCache.CheckIfSkippableInCurMode (0x183e5f250). story.isSkippable
+      // is the HEADER `is_skippable` flag -- since 2.7.61 the tutorial gate is
+      // expressed through it (header defaults it to !is_tutorial during
+      // parsing, see parser.ts) instead of a direct !isTutorial check.
+      // CheckIfSkippableInCurMode: a nofirstskip anchor only blocks first
+      // reads.
+      const storySkippable = this.context.storyMetadata?.isSkippable ?? true;
       const isSkippable =
-        !tutorial &&
+        storySkippable &&
         (this.currentSkipMode !== "nofirstskip" || !this.firstRead);
       if (nextLabel && !isSkippable) {
         // Native stores the anchor index and the coroutine's leading increment
@@ -556,6 +592,12 @@ export class StoryRuntime {
     }
 
     this.pendingInputEffect = null;
+    // Known deviation from native: SkipStory's tail runs
+    // AVGController._ResetComponentsOnSkip (0x183e1d3f0), which walks every
+    // registered component (background, characters, ...) through the
+    // ShouldResetOnSkip family. This widget only clears the transient overlays
+    // and the typing session; scene state survives the jump, which is a
+    // deliberate simplification rather than native parity.
     await this.renderer.clearInterludes();
     await this.renderer.clearSpellStickers();
 
@@ -739,11 +781,7 @@ export class StoryRuntime {
   }
 
   private arg(args: StoryCommandArgs, key: string): unknown {
-    if (Object.prototype.hasOwnProperty.call(args, key)) return args[key];
-    const matched = Object.keys(args).find(
-      (candidate) => candidate.toLowerCase() === key.toLowerCase(),
-    );
-    return matched === undefined ? undefined : args[matched];
+    return lookupCommandArg(args, key);
   }
 
   private exactArg(args: StoryCommandArgs, key: string): unknown {

--- a/src/widgets/StoryPlayer/index.vue
+++ b/src/widgets/StoryPlayer/index.vue
@@ -108,6 +108,13 @@ const canAdvance = computed(
     (state.value === "idle" || state.value === "waiting_input"),
 );
 
+// Native OnSkipBtnClicked（2.7.61 反编译 0x183e16ee0）在 quick_play 模式下忽略
+// 跳过点击；runtime.skipNode() 已按此兜底，这里同步禁用按钮，避免出现可点但
+// 无响应的控件。
+const canSkipStory = computed(
+  () => canSkipNode.value && autoPlayMode.value !== "quick_play",
+);
+
 const currentSpeedLevel = computed(() =>
   autoPlayMode.value === "quick_play"
     ? quickSpeedLevel.value
@@ -563,7 +570,7 @@ onBeforeUnmount(() => {
               <NButton
                 size="small"
                 type="primary"
-                :disabled="!(preloadReady && canSkipNode)"
+                :disabled="!(preloadReady && canSkipStory)"
                 @click="onSkipNode"
               >
                 <template #icon>

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -29,6 +29,7 @@ import type {
   SpellStickerInput,
   StickerInput,
   StoryAudio,
+  StoryMetadata,
   StoryRenderer,
   SubtitleInput,
   TimerClearInput,
@@ -364,6 +365,23 @@ class FakeAudio implements StoryAudio {
   }
 
   destroy(): void {}
+}
+
+function storyMetadata(overrides: Partial<StoryMetadata> = {}): StoryMetadata {
+  return {
+    args: {},
+    characterSortType: "BY_GAIN_TIME_DOWN",
+    denyAutoSwitchScene: false,
+    dontClearGameObjectPoolOnStart: false,
+    fitMode: "DEFAULT",
+    id: "",
+    isAutoable: true,
+    isSkippable: true,
+    isTutorial: false,
+    isVideoOnly: false,
+    title: "",
+    ...overrides,
+  };
 }
 
 function createContext(script: readonly string[]): Context {
@@ -1000,6 +1018,160 @@ describe("StoryRuntime", () => {
     expect(warnings).toEqual([]);
     expect(runtime.canSkipNode()).toBe(true);
     expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("gates skipping on header is_skippable instead of is_tutorial (2.7.61 get_isSkippable)", async () => {
+    // training_act50side_01_b shape: HEADER carries is_tutorial=true AND
+    // is_skippable=true. Native 2.7.61 AVGController.get_isSkippable only
+    // consults story.isSkippable, so the skip must stop the whole story here;
+    // the pre-2.7.61 !isTutorial gate would wrongly resume at the anchor.
+    const renderer = new FakeRenderer();
+    const context = createContext([
+      '[skipnode(mode="nofirstskip")]',
+      '[name="A"]x',
+      '[skipnode(mode="skip")]',
+      '[name="B"]y',
+    ]);
+    context.storyMetadata = storyMetadata({
+      isSkippable: true,
+      isTutorial: true,
+    });
+    const runtime = new StoryRuntime(context, renderer, new FakeAudio());
+
+    await runtime.start();
+    await runtime.skipNode();
+
+    expect(runtime.getState()).toBe("finished");
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "x" });
+  });
+
+  it("resumes at the anchor instead of ending when header marks the story unskippable", async () => {
+    const renderer = new FakeRenderer();
+    const context = createContext([
+      '[skipnode(mode="skip")]',
+      '[name="A"]x',
+      '[skipnode(mode="skip")]',
+      '[name="B"]y',
+    ]);
+    context.storyMetadata = storyMetadata({ isSkippable: false });
+    const runtime = new StoryRuntime(context, renderer, new FakeAudio(), {
+      firstRead: false,
+    });
+
+    await runtime.start();
+    await runtime.skipNode();
+
+    // Native SkipStory: get_isSkippable() is false, so it must not
+    // StopStory("Skipped"); it jumps past the dequeued anchor and resumes.
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "y" });
+  });
+
+  it("resets auto play mode to default on a skiptothis jump", async () => {
+    const sleep = vi.fn(() => new Promise<void>(() => {}));
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext(['[name="A"]x', "[skiptothis]", '[name="B"]y']),
+      renderer,
+      new FakeAudio(),
+      { sleep },
+    );
+
+    await runtime.start();
+    runtime.setAutoPlayMode("button_auto");
+    expect(runtime.getAutoPlayState().mode).toBe("button_auto");
+
+    await runtime.skipNode();
+
+    // Native SkipStory's skiptothis tail resets autoPlayMode to DEFAULT.
+    expect(runtime.getAutoPlayState().mode).toBe("default");
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "y" });
+  });
+
+  it("keeps the auto play mode on a skipnode label jump", async () => {
+    const sleep = vi.fn(() => new Promise<void>(() => {}));
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        "[delay(time=30)]",
+        '[skipnode(mode="nofirstskip")]',
+        '[name="A"]x',
+        '[skipnode(mode="skip")]',
+        '[name="B"]y',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { sleep },
+    );
+
+    const startPromise = runtime.start();
+    await Promise.resolve();
+
+    // First read hits the nofirstskip anchor: jump past it and resume.
+    await runtime.skipNode();
+    await startPromise;
+    expect(runtime.getState()).toBe("waiting_input");
+
+    runtime.setAutoPlayMode("button_auto");
+    await runtime.skipNode();
+
+    // Native leaves the auto mode untouched on the skipnode branch; only the
+    // skiptothis tail resets it. The second skip ends the story.
+    expect(runtime.getAutoPlayState().mode).toBe("button_auto");
+    expect(runtime.getState()).toBe("finished");
+  });
+
+  it("ignores skip clicks during quick play like native OnSkipBtnClicked", async () => {
+    const sleep = vi.fn(() => new Promise<void>(() => {}));
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        "[delay(time=30)]",
+        '[skipnode(mode="skip")]',
+        '[name="A"]x',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { sleep },
+    );
+
+    runtime.setAutoPlayMode("quick_play");
+    const startPromise = runtime.start();
+    await Promise.resolve();
+    expect(runtime.getState()).toBe("waiting_timer");
+
+    await runtime.skipNode();
+
+    // Quick play swallows the skip request entirely.
+    expect(runtime.getState()).toBe("waiting_timer");
+    expect(runtime.canSkipNode()).toBe(true);
+
+    runtime.setAutoPlayMode("default");
+    await runtime.skipNode();
+    await startPromise;
+    expect(runtime.getState()).toBe("finished");
+  });
+
+  it("reads the skipnode mode key case-insensitively like native GetOrDefault", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[name="A"]x',
+        '[skipnode(Mode="nofirstskip")]',
+        '[name="B"]y',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+    await runtime.skipNode();
+
+    // The uppercase key still resolves to nofirstskip, so a first read can
+    // only jump past the anchor instead of ending the story.
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "y" });
   });
 
   it("supports multiline command as dialogue wait", async () => {


### PR DESCRIPTION
## 背景

基于官服客户端 2.7.61（build 2761）GameAssembly.dll 的 IDA 反编译复核（review 文档：arknights-rev `docs/impl-review/impl-review-skipnode-command.md`），skipnode 核心状态机（两阶段队列、`CalSkipMode` 精确小写匹配、nofirstskip + firstRead 闸门、label-jump 落点 = 锚点下一行）前端已与 native 对齐；本次修复外围行为差异，关键 native 结论：

- `AVGController.get_isSkippable`（0x183e1f7a0，2.7.61）= `isRunning && m_story.isSkippable && CheckIfSkippableInCurMode()`——教学关不再直接用 `!isTutorial`，改由 HEADER 的 `is_skippable` 参数表达（`Story.isSkippable` 字段）；`CheckIfSkippableInCurMode`（0x183e5f250）= nofirstskip 锚点仅拦首通。
- `AVGController.SkipStory`（0x183e1a150）skiptothis 公共尾部会 `set_autoPlayMode(DEFAULT)` + 停 auto 协程（0x183e1a74d/0x183e1a788）；skipnode label-jump 分支则**不**重置 auto 模式。
- `AVGController.OnSkipBtnClicked`（0x183e16ee0）在 `autoPlayMode == QUICK_PLAY` 时直接忽略点击（剧情简介确认面板为 native 独有 UI，widget 有意省略）。
- `AVGStoryCache.AddSkipNode`（0x183e5eec0）用 `GetOrDefault("mode", "skip")` 读参；`SkipStory` 尾部的 `_ResetComponentsOnSkip`（0x183e1d3f0）遍历全部组件做重置。

## 修复内容

按 review 差异清单（P2×4、P3×5）逐条甄别：

| 条目 | 处理 |
| --- | --- |
| #1 P2 isSkippable 组合闸元数据 | **修**：`skipNode()` 的组合闸由 `!metadata.isTutorial` 换为 `metadata.isSkippable`（parser 已从 HEADER `is_skippable` 计算，缺省回落 `!is_tutorial`，见 parser.ts）。现网触发样本：`training_act50side_01_b`（is_tutorial=true **且** is_skippable=true）旧逻辑会错误拒绝整段跳过。 |
| #2 P2 skiptothis 跳转不重置 auto | **修**：`skipNode()` skiptothis 分支补 `setAutoPlayMode("default")`；skipnode label-jump 分支维持不重置（native 同样不重置，单测锁定边界）。 |
| #3 P2 quick_play 不禁点 | **修**：`runtime.skipNode()` 顶部按 `OnSkipBtnClicked` 语义忽略 quick_play 请求；index.vue 同步禁用按钮（避免可点但无响应）。确认面板维持有意省略。 |
| #4 P2 组件重置范围 | **按建议记录偏差**：在 `skipNode()` 重置块加注释，说明 native `_ResetComponentsOnSkip` 全组件重置而 widget 仅清 interlude/spellsticker/打字机，属有意简化。不扩清单（避免与其他 PR 的清理项重叠）。 |
| #5 P3 skiptothis 后不清 skipnode 队列 | 不改（清单建议「可不改」）。 |
| #6 P3 预处理读参键大小写 | **修**：提取模块级 `lookupCommandArg()`（原 `StoryRuntime.arg` 的实现），`preprocessSkipNodes` 用它做大小写不敏感回退，对齐 native `GetOrDefault`。 |
| #7 P3 按钮可用性口径 | 不改（清单结论「行为等价，可不改」；native `_UpdateSkipStatus` 不看剩余队列长度，现状反而更贴近）。 |
| #8 P3 执行体不即时刷新按钮 | 不改（80ms 轮询兜底，观感差异可忽略，清单无修复建议）。 |
| #9 P3 跳过后隐藏按钮 | 无需处理（清单原话）。 |

## 验证用剧情文件

语料根：`/home/xwbx/Documents/torappu/storage/asset/gamedata/latest/story/`

- `activities/act50side/training/training_act50side_01_b.txt` L1（`is_skippable=true, is_tutorial=true`）、L2/L20/L32（skipnode 锚点）——#1 现网触发样本：旧 `!isTutorial` 闸在此文件错误拒绝整段跳过，修复后与 native 一致（mode=skip 段点击跳过直接结束剧情）。
- `activities/act45side/level_act45side_08_end.txt` L9（nofirstskip）/ L19（skip）——nofirstskip→Video→skip 标准用法，回归既有用例（首通跳到保护段、重看允许整段跳过）仍绿。
- `obt/main/level_main_14-20_beg.txt` L2 等 6 文件 12 处锚点全部小写 `mode=`，且全部 `is_skippable=true`——#6 无生产触发，前瞻对齐，由单测锁定。
- latest 语料 `skiptothis` 0 命中（review 所述 training 文件已无该命令）——#2 无生产触发，前瞻对齐，由单测锁定。
- `is_skippable=false` 的 18 个文件（obt/guide 等）均不含 skipnode/skiptothis——#1 的拒绝路径无生产触发，由单测锁定。

## 测试

- `pnpm test`：228 用例全绿（基线 222 + 新增 6：is_skippable 闸×2、skiptothis auto 重置×1、skipnode label-jump 不重置 auto×1、quick_play 禁点×1、mode 键大小写×1）。
- `pnpm exec vue-tsc -b` 通过；`pnpm exec eslint`（改动三文件）0 error 0 warning。
- 未动 `engine/log/` 与 decision/multiline 语义（skipnode 不在 Log All 符号分析建模范围内），无需跑全语料对拍。
