### PR TITLE
fix(story-player): endtip 空脚本补全与空对话框显示对齐 native

### DIFF
--- a/src/widgets/StoryPlayer/engine/parser.ts
+++ b/src/widgets/StoryPlayer/engine/parser.ts
@@ -196,24 +196,27 @@ function logicalLines(source: string | readonly string[]): LogicalLine[] {
 export function parseScript(source: string | readonly string[]): ParsedLine[] {
   const sourceLines = logicalLines(source);
   const lines = sourceLines.map((line) => parseLine(line.raw, line.lineNumber));
-  if (lines.length > 0) {
-    const last = lines.at(-1);
-    if (!(last?.kind === "command" && last.command === "endtip")) {
-      const lineNumber = sourceLines.at(-1)?.lineNumber ?? 1;
-      // Native provenance: `Torappu.AVG.AVGParser.TryParse(string, List<Command>)`
-      // and `Torappu.AVG.AVGUtils.GenerateEndtipCommand`. Ports the implicit
-      // terminal command for a non-empty script.
-      lines.push({
-        args: { block: true },
-        command: "endtip",
-        content: "",
-        kind: "command",
-        lineNumber,
-        paramPresent: true,
-        raw: "[endtip(block=true)]",
-        trailingText: "",
-      });
-    }
+  const last = lines.at(-1);
+  if (!(last?.kind === "command" && last.command === "endtip")) {
+    const lineNumber = sourceLines.at(-1)?.lineNumber ?? 1;
+    // Native provenance: `Torappu.AVG.AVGParser.TryParse(string, List<Command>)`
+    // (2.7.61: 0x183E7E450, plus the extracted `_AppendEndTip` 0x183E7EA10)
+    // and `Torappu.AVG.AVGUtils.GenerateEndtipCommand` (0x183E40F70). Native
+    // appends when `commands.Count <= 0 || Last(commands).command != "endtip"`,
+    // so an EMPTY command list (empty / whitespace-only / comment-only script)
+    // also receives the implicit terminal endtip. The appended line's
+    // `lineNumber` is a web diagnostic only; native `Command` carries no line
+    // number (ctor default 0).
+    lines.push({
+      args: { block: true },
+      command: "endtip",
+      content: "",
+      kind: "command",
+      lineNumber,
+      paramPresent: true,
+      raw: "[endtip(block=true)]",
+      trailingText: "",
+    });
   }
   return lines;
 }

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -39,6 +39,7 @@ import {
   type CharacterSlotInput,
   type CurtainInput,
   type DecisionSelection,
+  type DialogueDisplayOptions,
   type FocusOutInput,
   type FocusParamInput,
   type GridBackgroundInput,
@@ -493,8 +494,9 @@ export class PixiStoryRenderer implements StoryRenderer {
     speaker: string,
     text: string,
     tagStyles?: Record<string, { fill: string }>,
+    options?: DialogueDisplayOptions,
   ): void {
-    this.dialogPanel.setDialogue(speaker, text, tagStyles);
+    this.dialogPanel.setDialogue(speaker, text, tagStyles, options);
   }
 
   async showDecision(

--- a/src/widgets/StoryPlayer/engine/rendering/panels/DialogPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/DialogPanel.ts
@@ -10,7 +10,11 @@ import {
 
 import { DIALOG_FRAME_URL } from "../../../assets";
 import { DIALOG_FONT_FAMILY } from "../../font";
-import { STORY_HEIGHT, STORY_WIDTH } from "../../types";
+import {
+  type DialogueDisplayOptions,
+  STORY_HEIGHT,
+  STORY_WIDTH,
+} from "../../types";
 
 /**
  * Web/PIXI reconstruction of the visual surface used by
@@ -122,6 +126,7 @@ export class DialogPanel {
     speaker: string,
     text: string,
     tagStyles?: Record<string, { fill: string }>,
+    options?: DialogueDisplayOptions,
   ): void {
     if (this.speaker) {
       this.speaker.text = speaker;
@@ -132,7 +137,10 @@ export class DialogPanel {
       this.dialogue.text = text;
     }
     this.applyLayout();
-    const visible = Boolean(speaker || text);
+    // Native keeps an explicit `isHidden` state on DialogPanel: `_ExecuteDialog`
+    // hides the box for empty content, while `_ExecuteEndtip` calls
+    // `set_isHidden(false)` and shows an empty box (see DialogueDisplayOptions).
+    const visible = options?.forceVisible === true || Boolean(speaker || text);
     for (const item of [
       this.topGradient,
       this.bottomGradient,

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -345,6 +345,7 @@ export class StoryRuntime {
     speaker: string;
     richChars: RichChar[];
     tagStyles?: Record<string, { fill: string }>;
+    forceVisible: boolean;
   } | null = null;
   private typingSessionId = 0;
   private quickSpeedLevel = 0;
@@ -838,9 +839,15 @@ export class StoryRuntime {
 
     switch (line.command) {
       case "endtip": {
-        // Native port: Torappu.AVG.DialogPanel._ExecuteEndtip and
-        // AVGStoryCache.shouldProcessEndtip. It only shows and blocks in auto
-        // play for non-video-only stories; manual mode is a no-op.
+        // Native port: Torappu.AVG.DialogPanel._ExecuteEndtip (2.7.61:
+        // 0x183E73AB0) and AVGStoryCache.shouldProcessEndtip (0x183E60C60). It
+        // only shows and blocks in auto play for non-video-only stories; manual
+        // mode is a no-op. In auto play native calls set_isHidden(false) before
+        // BeginText("") (which normalizes null content to the empty string), so
+        // the player sees an EMPTY dialog box (top/bottom bars, no speaker, no
+        // text) that blocks until a manual click -- force the panel visible
+        // instead of the content-derived hide. The `block` parameter is never
+        // read by the executor, matching native.
         const shouldProcessEndtip =
           (this.autoPlayMode === "button_auto" ||
             this.autoPlayMode === "quick_play") &&
@@ -849,7 +856,9 @@ export class StoryRuntime {
 
         this.setAutoPlayMode("default");
         this.resetMultiline();
-        this.startTypingDialogue("", line.content);
+        this.startTypingDialogue("", line.content, 1, 0, {
+          forceVisible: true,
+        });
         return "wait_input";
       }
 
@@ -2528,9 +2537,11 @@ export class StoryRuntime {
     text: string,
     delayScale = 1,
     startIndex = 0,
+    options?: { forceVisible?: boolean },
   ): void {
     this.cancelTyping();
 
+    const forceVisible = options?.forceVisible === true;
     const translatedSpeaker = this.translateText(speaker);
     const richChars = parseRichChars(this.translateText(text));
     this.currentMessageLength = richChars.length;
@@ -2541,7 +2552,12 @@ export class StoryRuntime {
       const tagged = richCharsToTaggedText(richChars);
       const colors = collectColors(richChars);
       const ts = colors.length > 0 ? buildTagStyles(colors) : undefined;
-      this.renderer.setDialogue(translatedSpeaker, tagged, ts);
+      this.renderer.setDialogue(
+        translatedSpeaker,
+        tagged,
+        ts,
+        forceVisible ? { forceVisible: true } : undefined,
+      );
       this.onTypingComplete();
       return;
     }
@@ -2554,11 +2570,13 @@ export class StoryRuntime {
       speaker: translatedSpeaker,
       richChars,
       tagStyles,
+      forceVisible,
     };
     this.renderer.setDialogue(
       translatedSpeaker,
       richCharsToTaggedText(richChars.slice(0, from)),
       tagStyles,
+      forceVisible ? { forceVisible: true } : undefined,
     );
 
     void this.runTyping(
@@ -2567,6 +2585,7 @@ export class StoryRuntime {
       richChars,
       delayScale,
       from,
+      forceVisible,
     );
   }
 
@@ -2585,6 +2604,7 @@ export class StoryRuntime {
     richChars: RichChar[],
     delayScale: number,
     startIndex = 0,
+    forceVisible = false,
   ): Promise<void> {
     for (let index = startIndex; index < richChars.length; index += 1) {
       if (
@@ -2604,7 +2624,12 @@ export class StoryRuntime {
         return;
 
       const visible = richCharsToTaggedText(richChars.slice(0, index + 1));
-      this.renderer.setDialogue(speaker, visible);
+      this.renderer.setDialogue(
+        speaker,
+        visible,
+        undefined,
+        forceVisible ? { forceVisible: true } : undefined,
+      );
     }
 
     const finalDelayMs = this.getTypeWriterDelayMs(delayScale);
@@ -2623,12 +2648,13 @@ export class StoryRuntime {
   private finishTypingNow(): boolean {
     if (!this.typingSession) return false;
 
-    const { speaker, richChars, tagStyles } = this.typingSession;
+    const { speaker, richChars, tagStyles, forceVisible } = this.typingSession;
     this.cancelTyping();
     this.renderer.setDialogue(
       speaker,
       richCharsToTaggedText(richChars),
       tagStyles,
+      forceVisible ? { forceVisible: true } : undefined,
     );
     return true;
   }

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -495,6 +495,19 @@ export interface InterludeInput {
   type: InterludeElementType;
 }
 
+/**
+ * Native provenance: `Torappu.AVG.DialogPanel` visibility is an explicit
+ * `isHidden` state toggled by `set_isHidden`, not derived from content.
+ * `_ExecuteDialog` hides the box for empty content, while `_ExecuteEndtip`
+ * (2.7.61: 0x183E73AB0) calls `set_isHidden(false)` + `BeginText("")` to show
+ * an EMPTY dialog box -- the web panel needs the explicit override to model
+ * that, since it otherwise derives visibility from speaker/text presence.
+ */
+export interface DialogueDisplayOptions {
+  /** Keep the dialog frame visible even with no speaker and no text. */
+  forceVisible?: boolean;
+}
+
 export interface StoryRenderer {
   clearCgItems: (
     key?: string,
@@ -550,6 +563,7 @@ export interface StoryRenderer {
     speaker: string,
     text: string,
     tagStyles?: Record<string, { fill: string }>,
+    options?: DialogueDisplayOptions,
   ) => void;
   setImage: (key: string, input?: BackgroundInput) => Promise<void>;
   setImageRotate: (input: ImageRotateInput) => Promise<void>;

--- a/tests/dialogPanel.spec.ts
+++ b/tests/dialogPanel.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+// DialogPanel.mount() 走 Assets.load 拉内置 UI 贴片；单测里让它失败，
+// 走 catch 分支（上下黑条为 null，面板/文本仍在），只验证可见性语义。
+// happy-dom 没有 canvas 2d context，BestFit 测量一并 stub 掉。
+vi.mock("pixi.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("pixi.js")>();
+  return {
+    ...actual,
+    Assets: {
+      ...actual.Assets,
+      load: vi.fn().mockRejectedValue(new Error("assets disabled in test")),
+    },
+    CanvasTextMetrics: {
+      ...actual.CanvasTextMetrics,
+      measureText: vi.fn().mockReturnValue({ height: 0, width: 0 }),
+    },
+  };
+});
+
+const { DialogPanel } =
+  await import("../src/widgets/StoryPlayer/engine/rendering/panels/DialogPanel");
+
+describe("DialogPanel", () => {
+  it("hides on empty content but stays visible for the endtip override", async () => {
+    const warns: string[] = [];
+    const { Container } = await import("pixi.js");
+    const panel = new DialogPanel(new Container(), (detail: string) =>
+      warns.push(detail),
+    );
+    await panel.mount();
+    expect(warns).toEqual(["failed ui: sprite_avg_cutscene"]);
+
+    // `_ExecuteDialog` 的空 content：框整体隐藏
+    panel.setDialogue("", "");
+    const state = panel as unknown as {
+      dialogue: { visible: boolean };
+      panel: { visible: boolean };
+      speaker: { visible: boolean };
+    };
+    expect(state.panel.visible).toBe(false);
+    expect(state.speaker.visible).toBe(false);
+    expect(state.dialogue.visible).toBe(false);
+
+    // 正常有内容的对白：显示
+    panel.setDialogue("阿米娅", "你好");
+    expect(state.panel.visible).toBe(true);
+
+    // `_ExecuteEndtip`：set_isHidden(false) + BeginText(""),
+    // 空内容也要显示空框（2.7.61: 0x183E73AB0）
+    panel.setDialogue("", "", undefined, { forceVisible: true });
+    expect(state.panel.visible).toBe(true);
+    expect(state.speaker.visible).toBe(true);
+    expect(state.dialogue.visible).toBe(true);
+  });
+});

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -49,6 +49,28 @@ describe("parser", () => {
     expect(output[2]).toMatchObject({ command: "endtip", kind: "command" });
   });
 
+  it("appends the implicit endtip even to an empty command list", () => {
+    // Native TryParse (2.7.61: 0x183E7E450) checks
+    // `commands.Count <= 0 || Last(commands).command != "endtip"`: empty,
+    // whitespace-only, and comment-only scripts also receive the terminal
+    // endtip, so auto play still lands on the blocking end-tip box.
+    for (const source of ["", "  \n\n\t\n", "// only a comment\n\n"]) {
+      const output = parseScript(source);
+      expect(output).toHaveLength(1);
+      expect(output[0]).toMatchObject({
+        command: "endtip",
+        kind: "command",
+        lineNumber: 1,
+      });
+    }
+  });
+
+  it("does not append a duplicate endtip", () => {
+    const output = parseScript(["[endtip]"]);
+    expect(output).toHaveLength(1);
+    expect(output[0]).toMatchObject({ command: "endtip", kind: "command" });
+  });
+
   it("joins continuations before filtering comments and blank lines", () => {
     const output = parseScript(
       '[Character(name="a",\\\n xScale=1.2)]\n // comment\n\ntext',

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -16,6 +16,7 @@ import type {
   CharacterSlotInput,
   CurtainInput,
   DecisionSelection,
+  DialogueDisplayOptions,
   FocusOutInput,
   FocusParamInput,
   GridBackgroundInput,
@@ -76,6 +77,7 @@ class FakeRenderer implements StoryRenderer {
   largeBackgroundTweenCalls: LargeBackgroundTweenInput[] = [];
   largeImageTweenCalls: LargeBackgroundTweenInput[] = [];
   lastDialogue = { speaker: "", text: "" };
+  lastDialogueForceVisible = false;
   dialogueTexts: string[] = [];
   showItemCalls: ShowItemInput[] = [];
   stickerCalls: StickerInput[] = [];
@@ -251,8 +253,14 @@ class FakeRenderer implements StoryRenderer {
     this.actionCalls.push(input);
   }
 
-  setDialogue(speaker: string, text: string): void {
+  setDialogue(
+    speaker: string,
+    text: string,
+    _tagStyles?: Record<string, { fill: string }>,
+    options?: DialogueDisplayOptions,
+  ): void {
     this.lastDialogue = { speaker, text };
+    this.lastDialogueForceVisible = options?.forceVisible === true;
     this.dialogueTexts.push(text);
   }
 
@@ -658,6 +666,57 @@ describe("StoryRuntime", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("shows a visible empty dialog box at endtip in auto play", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = new FakeRenderer();
+      const runtime = new StoryRuntime(
+        createContext(['[name="A"]hi']),
+        renderer,
+        new FakeAudio(),
+      );
+
+      await runtime.start();
+      runtime.setAutoPlayMode("button_auto");
+
+      await vi.advanceTimersByTimeAsync(2000);
+
+      // Native _ExecuteEndtip (2.7.61: 0x183E73AB0) calls set_isHidden(false)
+      // before BeginText(""), so auto play ends on a visible EMPTY box (no
+      // speaker, no text) that blocks for a manual click -- not a content-
+      // derived hidden panel.
+      expect(runtime.getAutoPlayState().mode).toBe("default");
+      expect(runtime.getState()).toBe("waiting_input");
+      expect(renderer.lastDialogue).toEqual({ speaker: "", text: "" });
+      expect(renderer.lastDialogueForceVisible).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("runs the implicit endtip of an empty script in auto play", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([""]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    // Native TryParse (2.7.61: 0x183E7E450) appends endtip even when the
+    // command list is empty, so an empty script still shows the blocking
+    // end-tip box in auto play instead of finishing immediately.
+    runtime.setAutoPlayMode("button_auto");
+    await runtime.start();
+
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(runtime.getAutoPlayState().mode).toBe("default");
+    expect(renderer.lastDialogue).toEqual({ speaker: "", text: "" });
+    expect(renderer.lastDialogueForceVisible).toBe(true);
+
+    await runtime.advance();
+    expect(runtime.getState()).toBe("finished");
   });
 
   it("uses the selected auto speed and manual input disables auto mode", async () => {


### PR DESCRIPTION
## 背景

依据官服客户端 2.7.61（build 2761）GameAssembly.dll 的 IDA 反编译复核（review 文档 `arknights-rev/docs/impl-review/impl-review-endtip-command.md`），`endtip` 的条件模型移植本已正确（`shouldProcessEndtip = (button_auto || quick_play) && !isVideoOnly`、手动 no-op、先关自动播放再阻塞、`block` 参数不读）。本次修复两处 P1 边缘偏差，native 关键结论：

- **parser 自动补全**：`AVGParser.TryParse(String, List<Command>&)`（VA `0x183E7E450`，2.7.61 另将追加逻辑抽为 `_AppendEndTip` `0x183E7EA10`，两处同一逻辑）在 `commands != null && (commands.Count <= 0 || Last(commands).command != "endtip")` 时调用 `AVGUtils.GenerateEndtipCommand()`（`0x183E40F70`，`{ command: "endtip", param: { block: true } }`，不设 content）——**空命令列表（空串/全空白/全注释脚本）同样补一条 endtip**，触发条件是 content != null。
- **endtip 显示效果**：`DialogPanel._ExecuteEndtip`（`0x183E73AB0`）在自动播放下先 `set_autoPlayMode(DEFAULT)` 强制关自动播放，再 `set_isHidden(false)` **显示对话框** + `_name.set_text("")` + `AVGTypeWriterText.BeginText`（`0x183ED78A0`，首行把 null content 归一为空串，空串下打字机立即耗尽并停在阻塞态）——玩家看到的是**空文本、无发言人的对话框**，等一次手动点击。`block=true` 参数 executor 内不读。

## 修复内容

对应 review 差异清单：

- **#1（P1）空脚本不补 endtip**：`engine/parser.ts` 的 `parseScript` 去掉 `lines.length > 0` 前提，仅保留"最后一条非 endtip 才补"。空脚本现在产出单条 `[endtip(block=true)]` 命令流：自动播放下停在阻塞的 end-tip 空框，手动模式立即 finished，与 native 逐字对齐。
- **#2（P1）endtip 触发时对话框可见性**：native DialogPanel 显隐是 `set_isHidden` 的显式状态，web 端此前按"speaker/text 均空则隐藏"推导，把 endtip 的框藏掉了。新增 `DialogueDisplayOptions { forceVisible }`（`engine/types.ts`，注释标明 native 显隐状态概念），沿 `DialogPanel.setDialogue` → `PixiStoryRenderer.setDialogue` → runtime 打字机三处（含 `finishTypingNow` 补全路径）透传；endtip 分支传 `forceVisible: true`，空内容也显示框。`[Dialog]` 空内容隐藏框与 multiline 语义不动（避免与 #343 的对话框渐隐分支冲突）。
- **#3（P2）补全行 lineNumber**：native `Command` 无行号概念（ctor 默认 0），web 取最后保留行行号属诊断信息——已在 `parseScript` 的 provenance 注释中注明差异，不改行为。
- **#4（P3，endtip 不更新 `displayedLineIndex`）**：review 建议维持现状，不动。

## 验证用剧情文件

- `activities/act12d6/level_act12d6_ending_1.txt`（第 1-35 行，36-38 为空行）：末条 `[Blocker(fadetime=3,block=true)]`（第 35 行）后补隐式 endtip；开启自动播放播到结尾，验证现在停在**可见的空对话框**等点击而非空画面（#2）。
- `activities/act17d7/act17d7_01b.txt`（第 1-9 行）：小体积快速复现同上路径。
- 空命令列表补全（#1）：全语料 5526 个剧情文件均有非注释内容行（awk 逐文件扫描确认），生产 **0 命中**——前瞻对齐，由单测锁定（`tests/parser.spec.ts` 空/全空白/全注释三例 + `tests/runtime.spec.ts` 空脚本自动播放走到阻塞 endtip）。

## 测试

- `pnpm test`：227 用例全绿（基线 222；新增 parser 2 例、runtime 2 例、`tests/dialogPanel.spec.ts` 可见性 1 例）。
- `STORY_CORPUS_ROOT=<corpus> pnpm test:story-log`：全语料符号预算分析 + 独立 runtime oracle 对拍 2/2 通过。
- `pnpm exec vue-tsc -b` 通过；改动文件 `pnpm exec eslint` 0 问题。
