### PR TITLE
fix(story-player): header 数字形式枚举按值解析（fit_mode/char_sort_type）

### DIFF
--- a/src/widgets/StoryPlayer/engine/parser.ts
+++ b/src/widgets/StoryPlayer/engine/parser.ts
@@ -225,6 +225,74 @@ function metadataValue(
   return args[key];
 }
 
+// Native provenance: `Torappu.AVG.AVGController.FitMode` (dump.cs TypeDefIndex
+// 8072) and `Torappu.UI.CharacterSortType` (TypeDefIndex 14697). HEADER parses
+// both fields through `DotNetExtensionMethods.GetEnum<T>` ->
+// `Enum.Parse(typeof(T), s, ignoreCase: true)`, which resolves purely numeric
+// literals by enum *value*: `fit_mode=1` is BLACK_MASK and `char_sort_type = 5`
+// is BY_GAIN_TIME_DOWN. The bare-number form really occurs in guide stories
+// (e.g. obt/guide/l0-6/0_upgrade_skill.txt:1).
+const FIT_MODE_BY_VALUE: Readonly<Record<number, string>> = {
+  0: "DEFAULT",
+  1: "BLACK_MASK",
+};
+
+const CHARACTER_SORT_TYPE_BY_VALUE: Readonly<Record<number, string>> = {
+  0: "BY_LEVEL_UP",
+  1: "BY_LEVEL_DOWN",
+  2: "BY_RARITY_UP",
+  3: "BY_RARITY_DOWN",
+  4: "BY_GAIN_TIME_UP",
+  5: "BY_GAIN_TIME_DOWN",
+  6: "BY_NAME_UP",
+  7: "BY_NAME_DOWN",
+  8: "BY_COST_UP",
+  9: "BY_COST_DOWN",
+  10: "BY_HP_UP",
+  11: "BY_HP_DOWN",
+  12: "BY_ATK_UP",
+  13: "BY_ATK_DOWN",
+  14: "BY_DEF_UP",
+  15: "BY_DEF_DOWN",
+  16: "BY_RES_UP",
+  17: "BY_RES_DOWN",
+  18: "BY_FAVOR_UP",
+  19: "BY_FAVOR_DOWN",
+  20: "BY_RESPAWN_UP",
+  21: "BY_RESPAWN_DOWN",
+  22: "BY_BLOCKNUM_UP",
+  23: "BY_BLOCKNUM_DOWN",
+  24: "BY_ATKSPEED_UP",
+  25: "BY_ATKSPEED_DOWN",
+  26: "BY_HANDBOOKSTAGE_UP",
+  27: "BY_HANDBOOKSTAGE_DOWN",
+};
+
+/**
+ * Port of `DotNetExtensionMethods.GetEnum<T>` as called from
+ * `AVGParser.TryParse(String, StoryParam, Story&)`: stringify the param value
+ * (native `GetString`), treat the empty string as "use the default" (native
+ * `IsNullOrEmpty` check), resolve integer literals by enum value, and match
+ * member names case-insensitively (native `Enum.Parse(ignoreCase: true)`).
+ *
+ * Web adaptation: native `Enum.Parse` throws on unknown names and fails the
+ * whole story load; the web parser stays lenient and keeps the uppercased
+ * literal / default instead (impl-review P2 #1 deliberately not ported).
+ */
+function resolveEnumName(
+  value: StoryCommandValue | undefined,
+  byValue: Readonly<Record<number, string>>,
+  fallback: string,
+): string {
+  const raw = value === undefined ? "" : String(value);
+  if (raw === "") return fallback;
+  if (/^-?\d+$/.test(raw)) {
+    const byValueName = byValue[Number(raw)];
+    if (byValueName) return byValueName;
+  }
+  return raw.toUpperCase();
+}
+
 export function parseStory(source: string | readonly string[]): {
   lines: ParsedLine[];
   metadata: StoryMetadata;
@@ -233,9 +301,15 @@ export function parseStory(source: string | readonly string[]): {
   const first = lines[0];
   const header =
     first?.kind === "command" && first.command === "header" ? first : undefined;
-  const fitMode = String(
-    metadataValue(header?.args ?? {}, "fit_mode") ?? "DEFAULT",
-  ).toUpperCase();
+  // Native provenance: `GetEnum<FitMode>(header.param, "fit_mode", DEFAULT,
+  // ignoreCase: true)` and `GetEnum<CharacterSortType>(header.param,
+  // "char_sort_type", BY_GAIN_TIME_DOWN, true)` in `AVGParser.TryParse(String,
+  // StoryParam, Story&)` -- numeric literals resolve by enum value.
+  const fitMode = resolveEnumName(
+    metadataValue(header?.args ?? {}, "fit_mode"),
+    FIT_MODE_BY_VALUE,
+    "DEFAULT",
+  );
   const isTutorial = metadataValue(header?.args ?? {}, "is_tutorial") === true;
   const isVideoOnly =
     metadataValue(header?.args ?? {}, "is_video_only") === true;
@@ -245,10 +319,11 @@ export function parseStory(source: string | readonly string[]): {
     lines,
     metadata: {
       args: header?.args ?? {},
-      characterSortType: String(
-        metadataValue(header?.args ?? {}, "char_sort_type") ??
-          "BY_GAIN_TIME_DOWN",
-      ).toUpperCase(),
+      characterSortType: resolveEnumName(
+        metadataValue(header?.args ?? {}, "char_sort_type"),
+        CHARACTER_SORT_TYPE_BY_VALUE,
+        "BY_GAIN_TIME_DOWN",
+      ),
       denyAutoSwitchScene:
         metadataValue(header?.args ?? {}, "deny_auto_switch_scene") === true,
       dontClearGameObjectPoolOnStart:

--- a/tests/parser.spec.ts
+++ b/tests/parser.spec.ts
@@ -100,4 +100,43 @@ describe("parser", () => {
     const story = parseStory('[HEADER(id="x")] T');
     expect(story.metadata.id).toBe("");
   });
+
+  it("resolves numeric fit_mode literals by enum value like GetEnum", () => {
+    // `Enum.Parse` resolves "1" by value -> FitMode.BLACK_MASK, for both the
+    // bare and quoted spelling.
+    expect(parseStory("[HEADER(fit_mode=1)] T").metadata.fitMode).toBe(
+      "BLACK_MASK",
+    );
+    expect(parseStory('[HEADER(fit_mode="1")] T').metadata.fitMode).toBe(
+      "BLACK_MASK",
+    );
+    expect(parseStory("[HEADER(fit_mode=0)] T").metadata.fitMode).toBe(
+      "DEFAULT",
+    );
+    // Unknown names stay lenient instead of failing the whole load (the native
+    // Enum.Parse would throw).
+    expect(parseStory('[HEADER(fit_mode="nope")] T').metadata.fitMode).toBe(
+      "DEFAULT",
+    );
+  });
+
+  it("normalizes numeric char_sort_type literals to enum names", () => {
+    // Corpus form: obt/guide/l0-6/0_upgrade_skill.txt:1 writes
+    // `char_sort_type = 5`, which is BY_GAIN_TIME_DOWN by enum value.
+    expect(
+      parseStory("[HEADER(char_sort_type = 5)] T").metadata.characterSortType,
+    ).toBe("BY_GAIN_TIME_DOWN");
+    // obt/guide/l0-0/2_make_squad.txt:1 uses the string-name spelling.
+    expect(
+      parseStory('[HEADER(char_sort_type="BY_RARITY_DOWN")] T').metadata
+        .characterSortType,
+    ).toBe("BY_RARITY_DOWN");
+    expect(
+      parseStory("[HEADER(char_sort_type=3)] T").metadata.characterSortType,
+    ).toBe("BY_RARITY_DOWN");
+    // Default: BY_GAIN_TIME_DOWN (5).
+    expect(parseStory("[HEADER] T").metadata.characterSortType).toBe(
+      "BY_GAIN_TIME_DOWN",
+    );
+  });
 });


### PR DESCRIPTION
## 背景

基于官服客户端 2.7.61（build 2761）GameAssembly.dll 的 IDA 反编译复核（`AVGParser.TryParse(String, StoryParam, Story&)` @ `0x183E7DDC0`，详见逆向工作区 `docs/impl-review/impl-review-header-command.md`）：

- HEADER 的两个枚举字段经 `DotNetExtensionMethods.GetEnum<T>`（`0x1840F2D40`）解析：`param.GetString(key, "")` 把参数值转成字符串，空串返回默认值（`fit_mode` → `DEFAULT(0)`、`char_sort_type` → `BY_GAIN_TIME_DOWN(5)`），再 `Enum.Parse(typeof(T), s, ignoreCase: true)`。
- `Enum.Parse` 对**纯数字字面量按枚举值解析**：`fit_mode=1` → `BLACK_MASK`；`char_sort_type = 5` → `BY_GAIN_TIME_DOWN`（`AVGController.FitMode`：DEFAULT=0/BLACK_MASK=1；`Torappu.UI.CharacterSortType` 28 值，5=BY_GAIN_TIME_DOWN）。
- 数字字面量写法在现网引导样本中真实存在（见下节）。此前前端把 `char_sort_type = 5` 存成原始串 `"5"`、`fit_mode=1` 回落 `DEFAULT`，均与 native 不符（review 差异清单 P2 #2）。
- review 差异 P2 #1（native 对非法枚举名抛异常导致整段 story 加载失败）：文档建议前端保持宽容、不移植，本 PR 按建议维持现状。

## 修复内容

对应 review 差异清单 **P2 #2（数字形式枚举不识别/不归一）**：

- `src/widgets/StoryPlayer/engine/parser.ts`：新增 `resolveEnumName`（移植 `GetEnum` 的取值语义：值字符串化、空串→默认值、整数按枚举值→成员名映射、成员名大小写不敏感）+ `FIT_MODE_BY_VALUE` / `CHARACTER_SORT_TYPE_BY_VALUE` 两张值→名映射表（带 Native provenance 注释）。
  - `fitMode`：数字 `1`（含引号 `"1"`）→ `BLACK_MASK`，`0` → `DEFAULT`；
  - `characterSortType`：数字归一为枚举名（`5` → `BY_GAIN_TIME_DOWN`、`3` → `BY_RARITY_DOWN`），字符串名行为不变（大写化保留）；空串值现在回落默认值 `BY_GAIN_TIME_DOWN`（对齐 native `GetEnum` 的 `IsNullOrEmpty` 分支）；
  - 未知/非法值维持宽容（大写化原样保留或回落默认），不移植 native 抛异常语义。
- `tests/parser.spec.ts`：新增 2 组用例锁定上述行为。
- P3 #3~#6（briefId/overrideId、title null 归一、无消费方元字段、未知命令 warn）按 review 建议全部维持现状。

## 验证用剧情文件

语料根：`torappu` 解包 `gamedata/latest/story/`（2.7.61），grep 全量确认：

| 文件（相对 `story/`） | 行 | 内容 | 验证项 |
| --- | --- | --- | --- |
| `obt/guide/l0-6/0_upgrade_skill.txt` | 1 | `char_sort_type = 5` | 数字 → `BY_GAIN_TIME_DOWN`（修复前为原始串 `"5"`） |
| `obt/guide/l0-6/0_upgrade_skill_mastery.txt` | 1 | `char_sort_type = 5` | 同上 |
| `obt/guide/l0-0/2_make_squad.txt` | 1 | `char_sort_type="BY_RARITY_DOWN"` | 字符串名行为不回归 |
| `obt/main/level_main_00-01_beg.txt` | 1 | `fit_mode="BLACK_MASK"` | 字符串 fit_mode 不回归 |
| `fit_mode` 数字形式 | — | 全语料 0 命中（仅 `"BLACK_MASK"` 字符串写法） | 前瞻对齐，由单测锁定（`fit_mode=1`/`"1"`/`0`） |

上述语料文件均用修复后的 parser 实测通过（`characterSortType`/`fitMode` 输出与 native 语义一致）。

## 测试

- `pnpm test`：20 个文件 224 用例全绿（含新增 2 用例；基线 222）。
- `pnpm exec vue-tsc -b`：通过。
- `pnpm exec eslint src/widgets/StoryPlayer/engine/parser.ts tests/parser.spec.ts`：无告警。
