### PR TITLE
fix(story-player): delay 阻塞期间点击重置自动播放模式

### DIFF
--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -488,11 +488,22 @@ export class StoryRuntime {
       return;
     }
 
-    if (this.state !== "waiting_input") return;
-
+    // Native port: Torappu.AVG.AVGController.OnClickPress (2.7.61 VA
+    // 0x183E15900) resets the auto play mode to DEFAULT on every non-theater
+    // press, with no regard for what the command loop is currently blocked
+    // on -- a press landing inside a blocking `delay` still flips quick_play's
+    // animateRatio back to 1 so delays enqueued afterwards keep real-time
+    // pacing. The press never interrupts the wait itself (OnClickPress does
+    // not touch the blocking executors), which the waiting_input gate below
+    // preserves: the player has no pause semantics and advance() stays a
+    // no-op for the story flow. Theater presses return before this side
+    // effect (native isTheaterMode early-out at 0x183E159B2).
     if (this.theaterMode) return;
 
     this.setAutoPlayMode("default");
+
+    if (this.state !== "waiting_input") return;
+
     await this.advanceFromClick();
   }
 

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -403,6 +403,12 @@ function createContext(script: readonly string[]): Context {
   };
 }
 
+// 释放足够的微任务队列回合，让 processLoop 在被 resolve 的 sleep 之后
+// 走到下一条命令的 sleep 调用（race/then 链约 5-6 个 tick）。
+async function flushMicrotasks(rounds = 8): Promise<void> {
+  for (let round = 0; round < rounds; round += 1) await Promise.resolve();
+}
+
 describe("StoryRuntime", () => {
   it("maps spellsticker parameters and hides the blocking view before advancing", async () => {
     const renderer = new FakeRenderer();
@@ -582,6 +588,75 @@ describe("StoryRuntime", () => {
 
     expect(sleep).toHaveBeenNthCalledWith(1, 500);
     expect(sleep).toHaveBeenNthCalledWith(2, 0);
+  });
+
+  it("resets auto play mode when clicked while a delay blocks, without interrupting it", async () => {
+    const pendingSleeps: Array<() => void> = [];
+    const sleep = vi.fn(
+      () => new Promise<void>((resolve) => pendingSleeps.push(resolve)),
+    );
+    const runtime = new StoryRuntime(
+      createContext(["[delay(time=2)]", "[delay(time=3)]", '[name="A"]done']),
+      new FakeRenderer(),
+      new FakeAudio(),
+      { sleep },
+    );
+
+    runtime.setAutoPlayMode("quick_play");
+    const startPromise = runtime.start();
+    await flushMicrotasks();
+
+    // quick_play 的 animateRatio=0 把第一条 delay 折叠成 0ms。
+    expect(runtime.getState()).toBe("waiting_timer");
+    expect(sleep).toHaveBeenNthCalledWith(1, 0);
+
+    await runtime.advance();
+
+    // 点击不能打断等待（native OnClickPress 不触碰阻塞执行器），但必须
+    // 把模式重置为 default，让之后入队的 delay 恢复真实时长。
+    expect(runtime.getState()).toBe("waiting_timer");
+    expect(runtime.getAutoPlayState().mode).toBe("default");
+
+    pendingSleeps[0]!();
+    await flushMicrotasks();
+
+    expect(sleep).toHaveBeenNthCalledWith(2, 3000);
+
+    pendingSleeps[1]!();
+    await startPromise;
+
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("keeps theater presses inert while a delay blocks", async () => {
+    const pendingSleeps: Array<() => void> = [];
+    const sleep = vi.fn(
+      () => new Promise<void>((resolve) => pendingSleeps.push(resolve)),
+    );
+    const runtime = new StoryRuntime(
+      createContext(["[theater]", "[delay(time=2)]"]),
+      new FakeRenderer(),
+      new FakeAudio(),
+      { sleep },
+    );
+
+    const startPromise = runtime.start();
+    await flushMicrotasks();
+
+    expect(runtime.getState()).toBe("waiting_timer");
+    expect(runtime.getAutoPlayState().mode).toBe("button_auto");
+
+    await runtime.advance();
+
+    // theater 模式下 native OnClickPress 整体早退，连模式重置都不做。
+    expect(runtime.getState()).toBe("waiting_timer");
+    expect(runtime.getAutoPlayState().mode).toBe("button_auto");
+
+    pendingSleeps[0]!();
+    await startPromise;
+
+    // 脚本尾部的隐式 endtip 在 button_auto 下阻塞，与点击无关。
+    expect(runtime.getState()).toBe("waiting_input");
   });
 
   it("uses value predicates without treating them as label jumps", async () => {


### PR DESCRIPTION
## 背景

native 逆向关键结论（2.7.61 / build 2761 GameAssembly.dll 的 IDA 反编译复核）：

- `AVGController.OnClickPress`（VA `0x183E15900`）在非 Theater 模式下对每次点击**无条件**执行 `set_autoPlayMode(DEFAULT)`（`0x183E159E6`），与命令循环当前阻塞在哪个执行器无关——**delay 阻塞期间的点击同样会重置模式**；函数体不触碰 `m_blockingExecutors`，因此点击不能打断 delay 本身。
- Theater 模式下 `OnClickPress` 整体早退（`0x183E159B2`），连 `Emit(ON_CLICK)` 和模式重置都不做。
- delay 时长 = `AVGController.instance.animateRatio * time`（`_ExecuteDelayCommand` `0x183E6D870` 内联乘法，入队时一次性缩放）：quick_play 档 `animateRatio=0` 会把 delay 折叠为 0，点击重置模式后，**之后入队的 delay** 恢复真实时长。

## 修复内容

差异清单 #1（P2）：delay 期间点击对自动播放模式的副作用。

- 前端原行为：`advance()` 在 `waiting_timer` 状态直接 return——点击既不打断（正确）也**不重置模式**；quick_play 下点击穿过一条 delay 后，后续 delay 仍按 ratio=0 归零。
- 改法：`StoryRuntime.advance()` 把 theater 早退守卫与 `setAutoPlayMode("default")` 提到 `waiting_input` 状态闸门之前：非 Theater 点击在任何阻塞状态下都会重置模式（对齐 native OnClickPress 的无条件语义），但推进本身仍只受 `waiting_input` 闸门控制，不破坏「播放器没有暂停语义、advance() 只在 idle/waiting_input 有效」的不量；Theater 点击保持整体早退（连模式重置都不做）。附 Native provenance 注释。
- P3 三条（#2 计时粒度、#3 timeScale 实现位置、#4 状态机命名）按 review 结论「可接受/无需动作/保持」，未改动。

## 验证用剧情文件

- `story/obt/main/level_main_00-01_end.txt`
  - L144 `[delay(time=1)]`（两次 Blocker 之间的黑屏停顿）：quick_play 下点击此处，验证模式重置为 default 且等待不被打断；
  - L161 `[Delay(time=1)]`（点击之后才入队的 delay）：验证恢复 ratio=1 的真实 1 秒时长，而非被 quick_play 折叠为 0。

## 测试

- `pnpm test`：224 用例全绿（基线 222 + 新增 2：delay 阻塞期间点击重置模式且不打断等待；theater 阻塞期间点击保持无操作）；
- `pnpm exec vue-tsc -b` 通过；`pnpm exec eslint`（改动文件）通过；
- `pnpm test:story-log` 全语料 Log All 回归通过。
