### PR TITLE
fix(story-player): video 命令 res 分支存在性预检与 native 注释对齐

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/panels/VideoPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/VideoPanel.ts
@@ -2,8 +2,10 @@ import type { Container } from "pixi.js";
 
 /**
  * Web adaptation of `Torappu.AVG.AVGVideoPanel._ExecuteVideo` / `_PlayVideo`.
- * It preserves full-screen UI suppression and completion timing, while native
- * Unity video/player lifecycle is represented by an HTMLVideoElement.
+ * It preserves full-screen UI suppression; completion keeps the native
+ * end-of-current-frame FinishCommand timing (`InvokeEndOfFrame` →
+ * `WaitForEndOfFrame`), while native Unity video/player lifecycle is
+ * represented by an HTMLVideoElement.
  */
 export class VideoPanel {
   private active: HTMLVideoElement | null = null;

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -171,6 +171,23 @@ function sleepWithTimeout(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Native port: `VideoManager.CheckVideoExist` (2.7.61 VA 0x183B2FDB0) — the
+ * synchronous `RawResManager.CheckExist` gate of the `res` branch in
+ * `AVGVideoPanel._PlayVideo`. The web approximation is a HEAD probe against
+ * the resolved CDN URL: only a definitive 404/410 reproduces a miss. A probe
+ * that cannot decide (network/CORS failure, any other status) reports
+ * "exists" so the legacy `<video>` error path stays in charge.
+ */
+async function probeVideoAssetWithHead(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(url, { method: "HEAD" });
+    return response.status !== 404 && response.status !== 410;
+  } catch {
+    return true;
+  }
+}
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
@@ -324,6 +341,8 @@ export class StoryRuntime {
   private readonly firstRead: boolean;
   private pendingWait: InterruptibleWait | null = null;
   private pendingWaitId = 0;
+  /** `VideoManager.CheckVideoExist` web approximation; see `probeVideoAssetWithHead`. */
+  private readonly probeVideoAsset: (url: string) => Promise<boolean>;
   private processing = false;
   private processingCompletion: Promise<void> | null = null;
   private resolveProcessingCompletion: (() => void) | null = null;
@@ -373,6 +392,7 @@ export class StoryRuntime {
       typeWriterDelayMs: Math.max(0, Math.round(options.typingIntervalMs ?? 0)),
     };
     this.firstRead = options.firstRead ?? true;
+    this.probeVideoAsset = options.probeVideoAsset ?? probeVideoAssetWithHead;
     this.renderer = renderer;
     this.audio = audio;
     this.sleep = options.sleep ?? sleepWithTimeout;
@@ -890,11 +910,20 @@ export class StoryRuntime {
       }
 
       case "video": {
-        // Native port: Torappu.AVG.VideoPanel._ExecuteVideo / _PlayVideo. `url`
-        // takes priority and is used verbatim; only the `res` fallback is resolved
+        // Native port: Torappu.AVG.AVGVideoPanel._ExecuteVideo / _PlayVideo
+        // (2.7.61: still the legacy bool executor, consumed by the new
+        // ExecutorComponent.Execute(Command, Action) adapter). `url` takes
+        // priority; an http(s) value is emitted verbatim like native
+        // (0x183E68AAD), while any other value goes through the same CDN
+        // normalization as `res` — a web delivery adaptation, native never
+        // converts `url`.
         const url = toString(this.exactArg(args, "url"));
         const res = toString(this.exactArg(args, "res"));
         if (!url && !res) {
+          // Native: DLog.LogError("[AVG.Video] No url or res!") + return
+          // false → ExecutorComponent.Execute finishes the command
+          // synchronously in the same frame (0x183E45C12); no blocking state
+          // is ever entered.
           this.warn("invalid_parameter", "video: no url or res");
           return "continue";
         }
@@ -907,13 +936,40 @@ export class StoryRuntime {
           return "continue";
         }
 
+        // Native port: VideoManager.CheckVideoExist (0x183B2FDB0) gates the
+        // `res` branch before playback; a miss raises
+        // Toast(NO_VIDEO_MESSAGE) and _PlayVideo returns false so the command
+        // ends in the same frame (0x183E689FC) without blocking. The `url`
+        // branch has no such check in native. Web adaptation: the HEAD probe
+        // (`probeVideoAssetWithHead`) approximates the local RawResManager
+        // lookup; onWarning is the Toast equivalent. Skipping during the
+        // probe releases the wait so the command ends without playing.
+        if (!url) {
+          let assetExists = true;
+          const probeInterrupted = await this.waitInterruptiblePromise(
+            this.probeVideoAsset(resolved).then((exists) => {
+              assetExists = exists;
+            }),
+            () => this.renderer.stopVideo(),
+          );
+          if (probeInterrupted) return "continue";
+          if (!assetExists) {
+            this.warn("missing_asset", `video: ${res}`);
+            return "continue";
+          }
+        }
+
         this.state = "waiting_video";
         const interrupted = await this.waitInterruptiblePromise(
           this.renderer.playVideo(resolved),
           () => this.renderer.stopVideo(),
         );
-        // PLAYEND/ERROR finish on the next frame. Force-end is released by the
-        // wrapper immediately and deliberately bypasses this yield.
+        // Native finishes on PLAYEND/ERROR at the END of the CURRENT frame
+        // (InvokeEndOfFrame → WaitForEndOfFrame; 2.7.61 token-verified — the
+        // IDA shared-body symbol InvokeNextFrame is an ICF-fold alias).
+        // `sleep(0)` is the macro-task web approximation. Force-end is
+        // released by CommandExecutorWrapper.ForceEnd synchronously in-frame
+        // and deliberately bypasses this yield.
         if (!interrupted) await this.sleep(0);
         this.state = "running";
         return "continue";

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -624,6 +624,13 @@ export interface RuntimeOptions {
   animateRatio?: number;
   firstRead?: boolean;
   onWarning?: (warning: RuntimeWarning) => void;
+  /**
+   * Native port: `VideoManager.CheckVideoExist` (2.7.61 VA 0x183B2FDB0) —
+   * `RawResManager.CheckExist` gating the `res` branch of
+   * `AVGVideoPanel._PlayVideo` before playback. The web default is a HEAD
+   * probe against the resolved CDN URL; injectable for tests.
+   */
+  probeVideoAsset?: (url: string) => Promise<boolean>;
   sleep?: (ms: number) => Promise<void>;
   typingIntervalMs?: number;
 }

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { StoryRuntime } from "../src/widgets/StoryPlayer/engine/runtime";
 
@@ -404,6 +404,21 @@ function createContext(script: readonly string[]): Context {
 }
 
 describe("StoryRuntime", () => {
+  // `video(res=...)` probes the resolved CDN URL with a HEAD request before
+  // playback (native `VideoManager.CheckVideoExist` port). Default to an
+  // affirmative probe so the suite never touches the network; probe-specific
+  // cases override the stub inside their body.
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ status: 200 })),
+    );
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("maps spellsticker parameters and hides the blocking view before advancing", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(
@@ -813,12 +828,12 @@ describe("StoryRuntime", () => {
     );
 
     const startPromise = runtime.start();
-    await Promise.resolve();
-
-    // IsMp4VideoPath has no call sites; the extension gates nothing.
-    expect(renderer.videoCalls).toEqual([
-      "https://torappu.prts.wiki/assets/video/act15side/iw01",
-    ]);
+    await vi.waitFor(() => {
+      // IsMp4VideoPath has no call sites; the extension gates nothing.
+      expect(renderer.videoCalls).toEqual([
+        "https://torappu.prts.wiki/assets/video/act15side/iw01",
+      ]);
+    });
     expect(warnings).toEqual([]);
 
     renderer.finishVideo();
@@ -878,18 +893,129 @@ describe("StoryRuntime", () => {
 
     const startPromise = runtime.start();
 
-    await Promise.resolve();
-
-    expect(runtime.getState()).toBe("waiting_video");
-    expect(renderer.videoCalls).toEqual([
-      "https://torappu.prts.wiki/assets/video/act15side/iw01.mp4",
-    ]);
+    await vi.waitFor(() => {
+      expect(runtime.getState()).toBe("waiting_video");
+      expect(renderer.videoCalls).toEqual([
+        "https://torappu.prts.wiki/assets/video/act15side/iw01.mp4",
+      ]);
+    });
 
     renderer.finishVideo();
     await startPromise;
 
     expect(runtime.getState()).toBe("waiting_input");
     expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
+  });
+
+  it("ends the video command in-frame when the res existence probe misses", async () => {
+    // Native: CheckVideoExist == false → Toast(NO_VIDEO_MESSAGE) +
+    // _PlayVideo returns false → same-frame FinishCommand; the queue keeps
+    // running without ever entering the blocking video state.
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ status: 404 })),
+    );
+    const runtime = new StoryRuntime(
+      createContext(['[video(res="video/gone.mp4")]', '[name="A"]after']),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    expect(renderer.videoCalls).toEqual([]);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        detail: "video: video/gone.mp4",
+        type: "missing_asset",
+      }),
+    ]);
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
+  });
+
+  it("keeps the <video> error path when the probe cannot decide", async () => {
+    // Network-level failures (offline, CORS-opaque CDN) must not reproduce
+    // CheckVideoExist == false; the miss is then reported by the <video>
+    // error event as before.
+    const renderer = new FakeRenderer();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new TypeError("Failed to fetch");
+      }),
+    );
+    const runtime = new StoryRuntime(
+      createContext([
+        '[video(res="video/act15side/IW01.mp4")]',
+        '[name="A"]after',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    const startPromise = runtime.start();
+    await vi.waitFor(() => {
+      expect(renderer.videoCalls).toEqual([
+        "https://torappu.prts.wiki/assets/video/act15side/iw01.mp4",
+      ]);
+    });
+
+    renderer.finishVideo();
+    await startPromise;
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("does not probe the url branch, matching native _PlayVideo", async () => {
+    const fetchMock = vi.fn(async () => ({ status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext(['[video(url="video/Custom.MP4")]', '[name="A"]after']),
+      renderer,
+      new FakeAudio(),
+    );
+
+    const startPromise = runtime.start();
+    await vi.waitFor(() => {
+      expect(renderer.videoCalls).toEqual([
+        "https://torappu.prts.wiki/assets/video/custom.mp4",
+      ]);
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    renderer.finishVideo();
+    await startPromise;
+  });
+
+  it("releases the probe wait when the story is skipped before playback", async () => {
+    const renderer = new FakeRenderer();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<{ status: number }>(() => {})),
+    );
+    const runtime = new StoryRuntime(
+      createContext([
+        '[skipnode(mode="skip")]',
+        '[video(res="video/02.mp4")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    const startPromise = runtime.start();
+    // The probe is still pending here; skip must not strand the runtime on it.
+    await vi.waitFor(() => expect(runtime.canSkipNode()).toBe(true));
+
+    await runtime.skipNode();
+    await startPromise;
+
+    expect(renderer.videoCalls).toEqual([]);
+    expect(runtime.getState()).toBe("finished");
   });
 
   it("nofirstskip handles first-read skip by jumping to the next protected anchor", async () => {
@@ -971,9 +1097,9 @@ describe("StoryRuntime", () => {
 
     const startPromise = runtime.start();
 
-    await Promise.resolve();
-
-    expect(runtime.getState()).toBe("waiting_video");
+    await vi.waitFor(() => {
+      expect(runtime.getState()).toBe("waiting_video");
+    });
     expect(runtime.canSkipNode()).toBe(true);
 
     await runtime.skipNode();


### PR DESCRIPTION
## 背景

基于官服客户端 2.7.61（build 2761）GameAssembly.dll 的 IDA 反编译复核（review 文档：arknights-rev `docs/impl-review/impl-review-video-command.md`），`video` 命令的关键 native 语义：

- `AVGVideoPanel._PlayVideo`（VA `0x183E688D0`）的 `res` 分支在启播前经 `VideoManager.CheckVideoExist`（`0x183B2FDB0`，即 `RawResManager.CheckExist`）**同步**预检；miss → `UIPopupWindow.Toast(NO_VIDEO_MESSAGE)` + return false，经 `ExecutorComponent.Execute`（`0x183E45B10`）**当帧同步 FinishCommand**（`0x183E45C12`），命令不阻塞。
- `url` 分支 `TryGetParam("url")` 命中即原值直出（`0x183E68AAD`），无预检、无任何转换。
- PLAYEND/ERROR 的 FinishCommand 经 `InvokeEndOfFrame`（`WaitForEndOfFrame`，**当帧帧尾**；IDA 共享体符号 `InvokeNextFrame` 为 ICF 折叠别名），并非下一帧。

## 修复内容

对照 review 差异清单：

- **#1（P2）res 分支无存在性预检**：启播前对 resolved CDN URL 做 HEAD 探测，仅 404/410 视为 miss → `onWarning(missing_asset)`（现有告警通道，native Toast 的 web 等价物）+ 当帧结束命令、不进阻塞态；网络/CORS 失败等不可判定情形放行，退回原 `<video>` error 事件路径（行为不回退）。预检挂入 `waitInterruptiblePromise`，skip 期间直接结束不播放（native 同步预检不可被打断的 web 近似）；`url` 分支不预检，对齐 native。`RuntimeOptions` 新增 `probeVideoAsset` 注入点供测试。
- **#2（P2）url 分支并非 verbatim**：修正 runtime.ts provenance 注释——仅 http(s) 值 verbatim，非 http 值走与 `res` 相同的 CDN 归一化（web 投递适配，native 无转换）。不改实现（生产语料 0 命中 `url=`，归一化对 wiki 投递保留意义）。
- **#3（P3，注释级）**：PLAYEND/ERROR 调度注释由 "next frame" 更正为「当帧帧尾（`InvokeEndOfFrame`/`WaitForEndOfFrame`），`sleep(0)` 为 web 宏任务近似」；`VideoPanel` 头注释 "completion timing" 措辞同步更正。
- **跳过项**（review 标注可接受/有意省略）：#4 skip 后 0.23s 渐隐收尾、#5 播完面板保持、#6 prepared 二段式、#7 视频音量联动、#8 CriWare usm 流——均未实现。

## 验证用剧情文件

语料 `/home/xwbx/Documents/torappu/storage/asset/gamedata/latest/story/`，共 28 处 `[Video`，**全部为 `res=` 形态，`url=` 0 命中**：

- `obt/main/level_main_14-20_beg.txt:9` `[Video(res="video/02.mp4")]` — 最小非 video-only 样本：res 预检 →（资源存在时）播放；当前 torappu CDN 尚无视频镜像（HEAD 404，已实测带 `access-control-allow-origin: *`），走 missing_asset 当帧结束，终态与改动前一致但反馈提前且带 Toast 等价告警。
- `obt/main/level_main_17-17_end.txt:1213` `[Video(res="video/03.mp4")]` — 长剧情中段的同构 res 分支。
- `activities/act15side/level_act15side_entry.txt:5` `[Video(res="video/act15side/IW01.mp4")]`（`is_video_only=true`）— 不进命令循环的短路路径回归（既有用例覆盖）。
- `url=` 分支：生产语料 0 命中，前瞻对齐，由单测锁定（不预检、CDN 归一化）。

## 测试

- `pnpm test`：**226 passed**（基线 222 + 新增 4：预检 miss 当帧结束 / 不可判定放行 / url 分支不预检 / 预检挂起期间 skip 不滞留）；spec 内统一 stub `fetch` 隔离网络，3 处旧时序断言改 `vi.waitFor`。
- `pnpm exec vue-tsc -b` 通过；`pnpm exec eslint`（4 个改动文件）通过。
