### PR TITLE
fix(story-player): 教学路径命令族(tutorial/inputblocker/popupdialog)告警降级 unimplemented_command 并去重

### DIFF
--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -161,6 +161,31 @@ const builtinCommandNames = [
 
 const unsupportedAd8Commands = new Set(["bgeffect", "effect"]);
 
+/**
+ * Native provenance: gameplay 教学路径命令族——`tutorial` / `popupdialog` /
+ * `inputblocker` 由 `Torappu.AVG.AVGTutorialPanel.GetExecutors`（VA 0x183e63690，
+ * 2.7.61/build 2761 GameAssembly.dll IDA 反编译复核）注册：`"tutorial"` 与
+ * `"popupdialog"` 绑同一个 `_ExecuteTutorial` 委托（行为差异完全由参数集决定），
+ * `"inputblocker"` → `_ExecuteInputBlocker`（VA 0x183e64bd0）。native 侧渲染
+ * 聚光灯/手指引导、教程对白框（AVGTutorialDialog）、输入拦截遮罩并阻塞命令流。
+ *
+ * Web 侧有意省略整套教学 UI/信号系统/挖洞遮罩：全语料统计（gamedata 26-08-07）
+ * 中三条命令 100% 集中在 gameplay 教学脚本（obt/tutorial、obt/guide、活动
+ * guide/training），正常剧情（obt/main、activities/level_*）0 条，剧情回放
+ * widget 不会加载这些脚本。`aside` 同理（DialogPanel.GetExecutors VA 0x183e71df0
+ * 注册 `aside` → `_ExecuteAside`，现网 story 0 样本，见 dialog review #5）。
+ *
+ * 命中时按「已知但未实现」降级告警（`unimplemented_command`，每命令名一次），
+ * 执行语义与 unknown_command 路径一致：静默跳过、不阻塞——native 教学面板虽会
+ * 阻塞，但既然不渲染教学 UI 就没有可解除的阻塞点，放行是唯一安全选择。
+ */
+const knownUnimplementedCommands = new Set([
+  "tutorial",
+  "popupdialog",
+  "inputblocker",
+  "aside",
+]);
+
 interface InterruptibleWait {
   id: number;
   interrupt?: () => void;
@@ -357,6 +382,13 @@ export class StoryRuntime {
   private multilineShownChars = 0;
   private readonly stickerIds = new Set<string>();
   private pendingInputEffect: (() => Promise<void> | void) | null = null;
+  /**
+   * Web-only（native 无对应概念）：knownUnimplementedCommands 中已告警过的
+   * 命令名。教学脚本里同一命令高频成对出现（如 InputBlocker 的 blockInput
+   * true/false 开关对、连续多条 Tutorial），每命令名只告警一次，避免逐条
+   * console.warn 淹没真正需要关注的 unknown_command。
+   */
+  private readonly warnedUnimplementedCommands = new Set<string>();
 
   constructor(
     context: Context,
@@ -819,6 +851,18 @@ export class StoryRuntime {
     if (line.command === "header") return Promise.resolve("continue");
     const executors = this.commandRegistry.get(line.command);
     if (executors === null) {
+      // 教学路径命令族（见 knownUnimplementedCommands 声明处的 native
+      // provenance）：native 有 executor 但 web 有意省略，降级为
+      // unimplemented_command 并按命令名去重；跳过语义与 unknown_command
+      // 路径一致（静默放行、不阻塞）。
+      if (knownUnimplementedCommands.has(line.command)) {
+        if (!this.warnedUnimplementedCommands.has(line.command)) {
+          this.warnedUnimplementedCommands.add(line.command);
+          this.warn("unimplemented_command", line.command);
+        }
+        return Promise.resolve("continue");
+      }
+
       this.warn("unknown_command", line.command);
       return Promise.resolve("continue");
     }

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -130,6 +130,7 @@ export interface RuntimeWarning {
     | "invalid_parameter"
     | "missing_asset"
     | "parse"
+    | "unimplemented_command"
     | "unsupported_command"
     | "unsupported_visual"
     | "unknown_command";

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -865,6 +865,78 @@ describe("StoryRuntime", () => {
     );
   });
 
+  it("downgrades known-unimplemented tutorial-family commands and dedupes per name", async () => {
+    // 语料样本：obt/tutorial/level/main_00-06.txt:2-3 连续两条 [Tutorial]，
+    // main_01-01.txt:3-4 InputBlocker/PopupDialog 成对出现。教学路径命令族
+    // （tutorial/popupdialog/inputblocker/aside）native 有 executor 但 web 有意
+    // 省略，应降级为 unimplemented_command 且每命令名只告警一次；跳过不阻塞，
+    // 剧情继续推进到后续对白行。
+    const warnings: RuntimeWarning[] = [];
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[Tutorial(focusX=-546, animStyle="Highlight", dialogHead="$avatar_doberm")] 啧，他们还在组织进攻。真是难缠。',
+        '[Tutorial(focusX=-546, animStyle="Highlight", dialogHead="$avatar_amiya")] 博士，战场下方的道路已经被打开。',
+        "[InputBlocker(blockInput=false)]",
+        '[PopupDialog(dialogHead="$avatar_amiya", animStyle="NoWait")] 博士请注意。',
+        "[aside]旁白",
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      {
+        onWarning: (warning) => warnings.push(warning),
+      },
+    );
+
+    await runtime.start();
+
+    // 五条命令各自只告警一次，全部为降级类型，不产生 unknown_command。
+    const unimplemented = warnings.filter(
+      (item) => item.type === "unimplemented_command",
+    );
+    expect(unimplemented.map((item) => item.detail)).toEqual([
+      "tutorial",
+      "inputblocker",
+      "popupdialog",
+      "aside",
+    ]);
+    expect(warnings.some((item) => item.type === "unknown_command")).toBe(
+      false,
+    );
+    // 跳过不阻塞：剧情推进到对白行等待输入。
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "ok" });
+  });
+
+  it("still warns unknown_command for commands outside the known-unimplemented table", async () => {
+    // 教学脚本里 tutorial 家族常与战斗侧命令混排（如 main_01-01.txt 的
+    // Battle.LockFunction）：不在表内的命令必须保持 unknown_command，不能被
+    // 降级分支顺带吞掉。
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[Battle.LockFunction(mask="SYSTEM_MENU_INTERACT")]',
+        '[name="A"]ok',
+      ]),
+      new FakeRenderer(),
+      new FakeAudio(),
+      {
+        onWarning: (warning) => warnings.push(warning),
+      },
+    );
+
+    await runtime.start();
+
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        detail: "battle.lockfunction",
+        type: "unknown_command",
+      }),
+    ]);
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
   it("blocks on video command until playback completes", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(


### PR DESCRIPTION
## 背景

基于官服客户端 2.7.61（build 2761）GameAssembly.dll 的 IDA 反编译复核（impl-review 文档，2026-08-24），三条教学路径命令 `tutorial` / `inputblocker` / `popupdialog` 的 native 结论：

- **注册**：`Torappu.AVG.AVGTutorialPanel.GetExecutors`（VA `0x183e63690`）注册三个 key：`"tutorial"` 与 `"popupdialog"` 绑**同一个** `_ExecuteTutorial` 委托（行为差异完全由参数集决定），`"inputblocker"` → `_ExecuteInputBlocker`（VA `0x183e64bd0`）。signal 接收器也共用 `"tutorial"` key。
- **native 行为**：渲染聚光灯/手指引导、教程对白框（`AVGTutorialDialog.Show` VA `0x183ed6020`，打字机 + 0.4s 淡入）、输入拦截遮罩（含 4 块局部遮罩挖洞），除 NoWait 外阻塞命令流，靠点击（先跳打字机再关窗）/外部 signal 解除。
- **语料影响面 0**（gamedata 26-08-07 全量 story，5526 文件）：`[Tutorial]` 1,246 条/571 文件、`[InputBlocker]` 519 条/237 文件、`[PopupDialog]` 1,708 条/598 文件，**100% 集中在 gameplay 教学路径**（obt/tutorial、obt/guide、活动 guide/training、sandboxperm 等），正常剧情文件（obt/main、activities/level_*.txt）**0 条**。剧情回放 widget 不会加载这些脚本。

因此三篇 review 均将「命令整体缺失」裁剪为 P3 维持现状（不实现教学 UI/信号系统/挖洞遮罩），三条 P3 的共性可执行项即本 PR：告警降级，避免污染日志。

## 修复内容

对应三篇 impl-review 文档条目：

- tutorial review #5（P3）：「在 `builtinCommandNames` 外维护一张『已知但未实现』命令表，把 warning 从 `unknown_command` 降级为 `unimplemented_command`，避免污染日志」
- inputblocker review #4（P3）：「归入『已知未实现』命令表，避免 unknown_command 噪音」
- popupdialog review #4（P3）：「归入『已知未实现』命令表降级 warning」
- 顺带纳入 **dialog review #5**（P3，同款处理）：`aside`（`DialogPanel.GetExecutors` VA `0x183e71df0` 注册 `aside` → `_ExecuteAside`；现网 story 0 样本，语料实测确认）

改法（3 文件 +117 行，最小 diff）：

- `engine/runtime.ts`：新增模块级 `knownUnimplementedCommands` 表（`tutorial` / `popupdialog` / `inputblocker` / `aside`，命令名小写不变量与 parser 对齐），声明处带 native provenance 注释（三命令 native 有 executor、VA、web 有意省略理由、语料影响面 0）。`executeCommand` 的 registry-miss 分支命中该表时改打 `unimplemented_command`（走同一 `onWarning` 通道），并经实例级 `warnedUnimplementedCommands` 集合**每命令名只告警一次**；未命中保持原 `unknown_command`。
- `engine/types.ts`：`RuntimeWarning["type"]` 联合新增 `"unimplemented_command"`。
- 执行语义不变：静默跳过、不阻塞（不渲染教学 UI 就没有可解除的阻塞点，放行是唯一安全选择）。不实现教学 UI、signal 系统、挖洞遮罩、popupdialog 对白框——review 明确维持现状。

## 验证用剧情文件

语料根：`/home/xwbx/Documents/torappu/storage/asset/gamedata/latest/story`。用临时脚本以真实文件喂 `StoryRuntime` 收集警告（验证后已删）：

| 文件（相对路径） | 行号 | 验证项 |
| --- | --- | --- |
| `obt/tutorial/level/main_00-06.txt` | 2-3 | 两条 `[Tutorial]` 只产生 **1 条** `unimplemented_command`（detail=tutorial）→ 按命令名去重 |
| `obt/tutorial/level/main_01-01.txt` | 2-6 | 行3 `[InputBlocker]`、行4 `[PopupDialog]` 各降级 1 条 `unimplemented_command`；行2/行6 `[Battle.LockFunction]`/`[Battle.unlockFunction]` **保持 `unknown_command`** → 表外命令不被降级分支吞掉 |
| `obt/tutorial/level/main_00-01.txt` | 2 | 单条 `[PopupDialog]` → 1 条 `unimplemented_command`，非零个、非 unknown |

另在单测中以 main_00-06.txt / main_01-01.txt 的真实命令行复现以上场景，并验证跳过后剧情推进到后续对白行（不阻塞）。

## 测试

- `pnpm test`：**224/224 通过**（基线 222 + 新增 3 例：降级+去重+不阻塞、unknown 边界）
- `pnpm exec vue-tsc -b`：通过
- `pnpm exec eslint <改动文件>`：通过
- `STORY_CORPUS_ROOT=... pnpm test:story-log` 全语料对拍：2/2 通过，log 侧无感知变化（符合预期——Log All 子系统不消费 runtime 警告）
