### PR TITLE
fix(story-player): 补齐 label/warp/gotostage 三条流程命令的原生语义

### DIFF
--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -110,6 +110,9 @@ const builtinCommandNames = [
   "video",
   "skipnode",
   "skiptothis",
+  "label",
+  "warp",
+  "gotostage",
   "background",
   "backgroundtween",
   "gridbg",
@@ -304,6 +307,24 @@ function preprocessSkipToIndex(lines: ReturnType<typeof parseScript>): number {
   );
 }
 
+function preprocessLabelMap(
+  lines: ReturnType<typeof parseScript>,
+): Map<string, number> {
+  // Native port: Torappu.AVG.GotoLabelController.PreprocessCommands. It scans
+  // only `label` commands; TryGetParam("name") failing (missing key) makes the
+  // line a silent ignore -- no registration, no warning. RegisterLabel stores
+  // the bare index of the label line itself; the +1 skip offset is applied by
+  // the warp executor (_ExecuteGoto), not here. A repeated name overwrites the
+  // earlier entry (Dictionary set_Item).
+  const labelMap = new Map<string, number>();
+  for (const [index, line] of lines.entries()) {
+    if (line.kind !== "command" || line.command !== "label") continue;
+    if (!Object.prototype.hasOwnProperty.call(line.args, "name")) continue;
+    labelMap.set(toString(line.args.name), index);
+  }
+  return labelMap;
+}
+
 export class StoryRuntime {
   private readonly audio: StoryAudio;
   private readonly defaultSpeed: AutoSpeed;
@@ -333,6 +354,16 @@ export class StoryRuntime {
   private readonly skipNodeLabels: SkipNodeLabel[];
   private skipNodeQueueIndex = 0;
   private readonly skipToIndex: number;
+  /**
+   * Native port: Torappu.AVG.GotoLabelController.m_gotoIndex. One-shot warp
+   * cursor; -1 means "no pending jump". warp sets it, processLoop reads and
+   * resets it before fetching the next command (GotoCommandIndex's read-and-
+   * reset-to--1), so each warp jumps exactly once and two consecutive warps
+   * each take effect.
+   */
+  private gotoIndex = -1;
+  /** Native port: GotoLabelController.m_labelMap, filled by preprocessLabelMap (label name -> bare line index). */
+  private readonly labelMap: Map<string, number>;
   /**
    * Native port: Torappu.AVG.AVGShowItemPanel's single `_slotInUse`.
    * It determines whether `_ExecuteHideItem` blocks.
@@ -378,6 +409,7 @@ export class StoryRuntime {
     this.sleep = options.sleep ?? sleepWithTimeout;
     this.skipNodeLabels = preprocessSkipNodes(this.lines);
     this.skipToIndex = preprocessSkipToIndex(this.lines);
+    this.labelMap = preprocessLabelMap(this.lines);
     this.onWarning = options.onWarning;
     for (const command of builtinCommandNames)
       this.commandRegistry.register(command, (line) =>
@@ -676,6 +708,20 @@ export class StoryRuntime {
 
     try {
       while (!this.destroyed) {
+        // Native port: Torappu.AVG.AVGController.MoveNext consumes
+        // ICommandFlowController.GotoCommandIndex right after the loop-top
+        // index increment and before fetching the command. This cursor
+        // overwrite is deliberately independent of the decision predicate
+        // gate below (native: flow-controller vs predicator are two separate
+        // MoveNext concerns). Web adaptation: our cursor already points at the
+        // next line to fetch, and an out-of-range warp target (a label on the
+        // last line) finishes the story here instead of throwing like the
+        // native List indexer would.
+        if (this.gotoIndex >= 0) {
+          this.cursor = this.gotoIndex;
+          this.gotoIndex = -1;
+        }
+
         if (this.cursor >= this.lines.length) {
           this.renderer.clearAnimTexts();
           this.renderer.clearAvgDisplays();
@@ -929,6 +975,43 @@ export class StoryRuntime {
       case "skiptothis": {
         // Native port: Torappu.AVG.AVGController._PreprocessCommands. This is a
         // preprocess-only command with no executor, so normal playback advances
+        return "continue";
+      }
+
+      case "label": {
+        // Native port: Torappu.AVG.AVGGotoLabel._ExecuteLabel. The native
+        // executor is an empty hotfix shell that always returns false: the
+        // label's whole effect is the preprocess registration done by
+        // preprocessLabelMap, so at run time it is a silent no-op that never
+        // blocks and never warns.
+        return "continue";
+      }
+
+      case "warp": {
+        // Native port: Torappu.AVG.AVGGotoLabel._ExecuteGoto. A missing
+        // `name` key or a labelMap miss is a silent no-op -- no warning, no
+        // exception (every current `[warp(name="chiyu01")]` in the corpus
+        // takes the miss path because no label defines it). On a hit the
+        // one-shot goto cursor becomes the bare label index + 1, i.e. the line
+        // right after the label; the +1 lives here because processLoop
+        // consumes the cursor as an already-incremented "next line" value.
+        const name = this.exactArg(args, "name");
+        if (name === undefined) return "continue";
+        const target = this.labelMap.get(toString(name));
+        if (target === undefined) return "continue";
+        this.gotoIndex = target + 1;
+        return "continue";
+      }
+
+      case "gotostage": {
+        // Native port: Torappu.AVG.AVGGotoStagePanel._ExecuteGotoStage. Its
+        // only side effect is a client UI route
+        // (UIRouteUtil.RouteToStage -> the target stage's selection/preview
+        // page); it never ends the story, blocks the queue, or touches the
+        // command index, and an empty/unresolvable target is a silent no-op.
+        // A web story widget has no game shell to route, so the navigation is
+        // intentionally omitted and the `target` param goes unread: the
+        // command just keeps playback moving.
         return "continue";
       }
 

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2960,4 +2960,147 @@ describe("StoryRuntime", () => {
     expect(runtime.getState()).toBe("waiting_input");
     expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
   });
+
+  it("registers labels in preprocess and lets warp jump to the line after the label", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[warp(name="jump")]',
+        '[name="A"]skipped',
+        '[label(name="jump")]',
+        '[name="B"]landed',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(renderer.dialogueTexts).toEqual(["landed"]);
+    expect(warnings).toEqual([]);
+  });
+
+  it("lets warp jump backward to an earlier label", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[label(name="back")]',
+        '[name="A"]first',
+        '[warp(name="back")]',
+        '[name="B"]never',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "first" });
+
+    await runtime.advance();
+    expect(renderer.dialogueTexts).toEqual(["first", "first"]);
+  });
+
+  it("consumes the one-shot warp cursor so consecutive warps each jump", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[warp(name="a")]',
+        '[name="A"]skipped1',
+        '[label(name="a")]',
+        '[warp(name="b")]',
+        '[name="B"]skipped2',
+        '[label(name="b")]',
+        '[name="C"]landed2',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(renderer.dialogueTexts).toEqual(["landed2"]);
+  });
+
+  it("overwrites duplicate label names with the later registration", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[warp(name="d")]',
+        '[label(name="d")]',
+        '[name="A"]first',
+        '[label(name="d")]',
+        '[name="B"]second',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.dialogueTexts).toEqual(["second"]);
+  });
+
+  it("treats a warp miss and a missing name as silent no-ops without warnings", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        "[label]",
+        '[warp(name="nowhere")]',
+        "[warp]",
+        '[name="A"]after',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
+    expect(warnings).toEqual([]);
+  });
+
+  it("keeps label lines silent no-ops that do not interrupt playback", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[name="A"]before',
+        '[label(name="x")]',
+        '[name="B"]after',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "before" });
+
+    await runtime.advance();
+    expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "after" });
+    expect(warnings).toEqual([]);
+  });
+
+  it("keeps gotostage a silent no-op that keeps the story moving", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext(['[Gotostage(target="main_15-02")]', '[name="A"]after']),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    expect(runtime.getState()).toBe("waiting_input");
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
+    expect(warnings).toEqual([]);
+  });
 });


### PR DESCRIPTION
# fix(story-player): 补齐 label/warp/gotostage 三条流程命令的原生语义

## 背景

Native 逆向关键结论（官服客户端 2.7.61 / build 2761 GameAssembly.dll，IDA 反编译复核；复核文档见 arknights-rev `docs/impl-review/`）：

- **label/warp 同注册于 `AVGGotoLabel`**（`GetExecutors` @ `0x183e55740`，key 明文 `label`/`warp`）。二者是一对：预处理登记 + 运行时消费。
  - `label` 执行体 `_ExecuteLabel` @ `0x183e55b80` 是**空 hotfix 壳**，无任何业务逻辑，恒返回 false（不阻塞）。label 的全部实际作用在预处理：`GotoLabelController.PreprocessCommands` @ `0x183e61ca0` 只扫 `label` 命令，`TryGetParam("name")` 失败则**静默忽略**（不登记、不告警）；`RegisterLabel` @ `0x183e61db0` 登记**裸索引**（label 自身下标，不 +1），重名后写覆盖先写。
  - `warp` 执行体 `_ExecuteGoto` @ `0x183e55a60`：缺 `name` → 静默 no-op；`m_labelMap.ContainsKey` 未命中 → **静默 no-op**（无告警无异常——当前语料 7 处 warp 全走此路径）；命中 → `m_gotoIndex = m_labelMap[name] + 1`（跳到 label 之后那条命令）。恒返回 false。
  - 消费点 `AVGController.MoveNext` @ `0x183e2bf26-0x183e2bf4c`：每轮 `++m_executeIndex` 之后、**取命令之前**，经 `GotoLabelController.GotoCommandIndex` @ `0x183e61c90` 消费一次性游标（读后即复位 -1），`m_executeIndex` 被原样覆写。向前/向后跳均允许。
- **decision 与 label/warp 完全无关**：`MoveNext` 里 flow-controller（`0x183e2bf26`，取命令前改索引）与 predicator（`0x183e2bfd5`，循环条件值谓词）是两段独立逻辑；decision 的 `references` 是分号分隔整数列表，全语料 4524 处 decision 无一引用 label 名。
- **gotostage** 独立注册于 `AVGGotoStagePanel.GetExecutors` @ `0x183e55d60`。执行体 `_ExecuteGotoStage` @ `0x183e55ee0`：读 `target`（默认空串，空 → no-op），`GetStageOrNull(target, now)` 查到后 `UIRouteUtil.RouteToStage` @ `0x181469680` 把玩家送进目标关卡的关卡选择/预览页——**纯客户端 UI 路由**，不结束剧情、不阻塞队列、不改命令索引。

此前前端三条命令均未注册，每行落入 `unknown_command` 警告路径；且若未来官方投放成对 label+warp，前端将无法跳转导致剧情顺序错播。

## 修复内容

对应三篇 review 差异清单的条目与改法（全部落在 `src/widgets/StoryPlayer/engine/runtime.ts`）：

| review 差异条目 | 改法 |
| --- | --- |
| label #1（P1）注册表未实现 | 新增 `preprocessLabelMap()` 预处理（构造时执行）：扫 `label` 命令，缺 `name` 键静默忽略，登记 `name → 裸行索引`，重名后写覆盖 |
| label #2（P2）unknown_command 误报 | `label` 注册进 `builtinCommandNames`，执行体为静默 no-op（与 native 空 hotfix 壳对齐） |
| label #5（P3）缺 `name=` 边界 | 静默忽略，不登记 |
| warp #1（P1）跳转未实现 | 新增一次性游标 `gotoIndex`；`case "warp"` 读 `name` 查 `labelMap`，命中置 `gotoIndex = labelIndex + 1` |
| warp #2/#3（P2/P3）未命中/缺 name 告警语义 | 两者均静默 no-op，不告警（区分「合法但未命中」与「真未知命令」） |
| warp #4（P3）一次性游标 | `processLoop` 取命令前消费：`gotoIndex >= 0` 时 `cursor = gotoIndex` 并复位 -1，读后即复位，连续两条 warp 各自生效、游标不复读 |
| warp #5（P3）与 decision 隔离 | 游标覆写在 `processLoop` 取命令前单独完成，**不并入** `passesGate` 值谓词闸门（native 顺序：flow 消费 → 取命令 → predicator 判定） |
| gotostage #1（P2）unknown_command 噪声 | `gotostage` 注册为静默 no-op，消除误报 |
| gotostage #2/#3（P3）导航副作用省略 | web widget 无游戏主界面可路由，导航有意省略（不结束剧情、不阻塞、不改索引，控制流与 native 一致）；`target` 仅被省略的路由消费，故不读取 |
| gotostage #4（P3）时间窗过滤 | widget 语境无关卡表概念，不实现（no-op 天然覆盖） |

大小写规则与现有约定一致：命令名小写化（parser + `CommandRegistry` 已做，`[Gotostage(...)]` 正常命中），参数键保留源大小写（`name`/`target` 按原生 `TryGetParam`/`GetString` 的 exact-key 语义用 `exactArg` 读取）。Web 适配一处并已注明：warp 跳转目标越界（label 在最后一行）时优雅结束播放，而非 native 越界索引的异常路径。

## 验证用剧情文件

语料：`latest`（26-08-07-14-53-29_30b8f0）story 全量。

- **warp 7 处**，全部 `[warp(name="chiyu01")]`，全语料无对应 label 定义 → native 与本实现均为静默 no-op，播放逐帧一致：
  - `obt/memory/story_blkkgt_1_1.txt:4`
  - `obt/memory/story_blackd_2_1.txt:4`
  - `obt/memory/story_ceylon_2_1.txt:4`
  - `obt/memory/story_rosesa_1_1.txt:4`
  - `activities/act28side/level_act28side_01_beg.txt:4`
  - `activities/act28side/level_act28side_07_end.txt:4`
  - `activities/act33side/level_act33side_01_end.txt:2`
- **gotostage 1 处**：`obt/guide/stage/stage_mainline_intro.txt:3`（`[Gotostage(target="main_15-02")]`，验证项：不再产生 unknown_command 警告，剧情继续推进，Tutorial 后续命令照常）。
- **label 0 处** → label+warp 成对跳转为**前瞻实现，由单测锁定**（`tests/runtime.spec.ts`：预处理登记 + 前向/后向命中跳转、重名后写覆盖、一次性游标连续 warp、未命中/缺 name 静默、label/gotostage no-op 不告警）。
- Log All（semantics/symbolicFlow/storyOracle）为全量行遍历、不受播放游标影响，且当前语料 label 0 命中、warp 全 no-op，**无需感知这三条命令**；已跑全语料对拍确认无回归（见下）。

## 测试

- `pnpm test`：**229 用例全绿**（基线 222 + 新增 7）。
- `pnpm exec vue-tsc -b`：通过。
- `pnpm exec eslint src/widgets/StoryPlayer/engine/runtime.ts tests/runtime.spec.ts`：通过。
- `STORY_CORPUS_ROOT=…/latest/story pnpm test:story-log` 全语料对拍：2608 个剧情文件、符号预算内全量分析 + 独立 oracle 对拍全部通过。
