### PR TITLE
fix(story-player): timersticker 对齐 native：递增秒表、skip 清理与 fade 会话失效

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -2485,8 +2485,9 @@ export class PixiStoryRenderer implements StoryRenderer {
     timer.visible = true;
     timer.x = input.x;
     timer.y = input.y;
-    // `_StartCountTimer` fires `_TimerTick(0)` once immediately, so the slot
-    // briefly shows 00:00:00 before the first real tick lands.
+    // `_StartCountTimer` fires `_TimerTick(0)` once immediately and the timer
+    // counts up from there, so the slot reads 00:00:00 until the first whole
+    // second elapses.
     timer.text = this.formatTimer(0);
 
     const fadeSessionId = this.timerFadeSessionId;
@@ -2505,31 +2506,34 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     if (input.limitSeconds === undefined || input.limitSeconds <= 0) return;
 
-    // Native counts down against a wall-clock deadline: `SetCountDown` stores
-    // endTime = start + time*1000 (ms) and `Update` feeds
-    // `_OverrideTimerTaskTick` = `Math.Max(endTime - curTime, 0)` into
-    // `_TimerTick` on every internal tick (~200ms). The first real value
-    // therefore lands within one tick, so the full initial value (time=9999
-    // -> 02:46:39) is visible almost immediately and each value holds for a
-    // whole second. A naive 1s interval that decrements a counter would park
-    // on 00:00:00 for a full second, never show the initial value, and drift
-    // under browser timer throttling.
-    const deadlineMs = Date.now() + input.limitSeconds * 1000;
+    // Native is a stopwatch, not a countdown: `SetCountDown` stores
+    // startTime = now, endTime = now + time*1000 (ms) on a wall clock, and
+    // `Update` feeds `_OverrideTimerTaskTick` = `Math.Max(curTime -
+    // startTime, 0)` -- elapsed milliseconds, verified at the instruction
+    // level in build 2761 (an earlier reading of `endTime - curTime` had the
+    // operands swapped) -- into `_TimerTick` =
+    // TimeSpan.FromMilliseconds(...). The text therefore climbs
+    // 00:00:00 -> 00:00:01 -> ...; reaching `time` fires `_TimerEnd`, which
+    // only clears the task, so the display freezes at the cap
+    // (time=9999 -> 02:46:39) and stays visible. Deriving elapsed from the
+    // wall clock also avoids interval drift under browser throttling.
+    const startMs = Date.now();
+    const capSeconds = input.limitSeconds;
     this.timerStickerInterval = setInterval(
       () => {
-        const remainingSeconds = Math.max(
-          0,
-          Math.ceil((deadlineMs - Date.now()) / 1000),
+        const elapsedSeconds = Math.min(
+          capSeconds,
+          Math.floor((Date.now() - startMs) / 1000),
         );
         const timerText = this.timerStickerText;
         if (!timerText) return;
 
-        const text = this.formatTimer(remainingSeconds);
+        const text = this.formatTimer(elapsedSeconds);
         if (timerText.text !== text) timerText.text = text;
-        if (remainingSeconds <= 0) this.clearTimerInterval();
+        if (elapsedSeconds >= capSeconds) this.clearTimerInterval();
       },
-      // 200ms mirrors the native CountDownTask internal tick; the deadline
-      // math makes extra fires harmless (same ceil value, no text rewrite).
+      // 200ms mirrors the native CountDownTask internal tick; the wall-clock
+      // math makes extra fires harmless (same floor value, no text rewrite).
       200,
     );
   }

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -358,6 +358,7 @@ export class PixiStoryRenderer implements StoryRenderer {
   private readonly stickerRichChars = new Map<string, RichChar[]>();
   private timerStickerInterval: ReturnType<typeof setInterval> | null = null;
   private timerStickerText: Text | null = null;
+  private timerFadeSessionId = 0;
 
   constructor(context: Context, onWarning?: (detail: string) => void) {
     this.context = context;
@@ -524,6 +525,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.subtitleText = null;
     this.timerStickerText = null;
     this.clearTimerInterval();
+    this.timerFadeSessionId += 1;
     this.stickerTexts.clear();
     this.stickerFadeSessionIds.clear();
     this.stickerTypingTargets.clear();
@@ -1926,6 +1928,11 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   async clearTimerSticker(input?: TimerClearInput): Promise<void> {
     this.clearTimerInterval();
+    // `AVGTimerView.StopTimer` precedes its fade with
+    // `DOKill(_canvas, complete: false)`; bumping the fade session is the Web
+    // equivalent -- an in-flight timersticker fade stops writing instead of
+    // fighting the fade-out.
+    this.timerFadeSessionId += 1;
 
     const timer = this.timerStickerText;
     if (!timer) return;
@@ -1944,12 +1951,15 @@ export class PixiStoryRenderer implements StoryRenderer {
       return;
     }
 
+    const fadeSessionId = this.timerFadeSessionId;
     void this.tween(
       input.durationMs,
       (progress) => {
+        if (this.timerFadeSessionId !== fadeSessionId) return;
         timer.alpha = fromAlpha * (1 - progress);
       },
       () => {
+        if (this.timerFadeSessionId !== fadeSessionId) return;
         timer.alpha = 0;
         timer.visible = false;
       },
@@ -2464,35 +2474,64 @@ export class PixiStoryRenderer implements StoryRenderer {
   async setTimerSticker(input: TimerStickerInput): Promise<void> {
     const timer = this.ensureTimerStickerText();
     this.clearTimerInterval();
+    // `AVGTimerView.RenderTimer` precedes every fade with
+    // `DOKill(_canvas, complete: true)`; bumping the fade session is the Web
+    // equivalent -- an in-flight timersticker/timerclear fade stops writing
+    // instead of racing the new one.
+    this.timerFadeSessionId += 1;
 
     timer.style = this.createOverlayTextStyle(input.sizePx, input.widthPx);
     timer.alpha = input.fromAlpha;
     timer.visible = true;
     timer.x = input.x;
     timer.y = input.y;
+    // `_StartCountTimer` fires `_TimerTick(0)` once immediately, so the slot
+    // briefly shows 00:00:00 before the first real tick lands.
     timer.text = this.formatTimer(0);
 
+    const fadeSessionId = this.timerFadeSessionId;
     void this.tween(
       input.durationMs > 0 ? input.durationMs : 130,
       (progress) => {
+        if (this.timerFadeSessionId !== fadeSessionId) return;
         timer.alpha =
           input.fromAlpha + (input.toAlpha - input.fromAlpha) * progress;
       },
       () => {
+        if (this.timerFadeSessionId !== fadeSessionId) return;
         timer.alpha = input.toAlpha;
       },
     );
 
     if (input.limitSeconds === undefined || input.limitSeconds <= 0) return;
 
-    let remainingSeconds = input.limitSeconds;
-    this.timerStickerInterval = setInterval(() => {
-      remainingSeconds = Math.max(0, remainingSeconds - 1);
-      if (!this.timerStickerText) return;
+    // Native counts down against a wall-clock deadline: `SetCountDown` stores
+    // endTime = start + time*1000 (ms) and `Update` feeds
+    // `_OverrideTimerTaskTick` = `Math.Max(endTime - curTime, 0)` into
+    // `_TimerTick` on every internal tick (~200ms). The first real value
+    // therefore lands within one tick, so the full initial value (time=9999
+    // -> 02:46:39) is visible almost immediately and each value holds for a
+    // whole second. A naive 1s interval that decrements a counter would park
+    // on 00:00:00 for a full second, never show the initial value, and drift
+    // under browser timer throttling.
+    const deadlineMs = Date.now() + input.limitSeconds * 1000;
+    this.timerStickerInterval = setInterval(
+      () => {
+        const remainingSeconds = Math.max(
+          0,
+          Math.ceil((deadlineMs - Date.now()) / 1000),
+        );
+        const timerText = this.timerStickerText;
+        if (!timerText) return;
 
-      this.timerStickerText.text = this.formatTimer(remainingSeconds);
-      if (remainingSeconds <= 0) this.clearTimerInterval();
-    }, 1000);
+        const text = this.formatTimer(remainingSeconds);
+        if (timerText.text !== text) timerText.text = text;
+        if (remainingSeconds <= 0) this.clearTimerInterval();
+      },
+      // 200ms mirrors the native CountDownTask internal tick; the deadline
+      // math makes extra fires harmless (same ceil value, no text rewrite).
+      200,
+    );
   }
 
   private async createUi(): Promise<void> {
@@ -3815,7 +3854,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   private formatTimer(totalSeconds: number): string {
-    const hours = Math.floor(totalSeconds / 3600);
+    // `_TimerTick` formats `TimeSpan.FromMilliseconds(...)`; `TimeSpan.Hours`
+    // wraps at 24, so time >= 86400 displays modulo a day (100000 -> 03:46:40).
+    const hours = Math.floor(totalSeconds / 3600) % 24;
     const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = Math.floor(totalSeconds % 60);
     return [hours, minutes, seconds]

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -749,6 +749,11 @@ export class StoryRuntime {
     // panel through OnReset -- alpha to 0 immediately (no tween) plus a
     // typewriter reset. A stale subtitle must not survive the skip.
     await this.renderer.clearSubtitle(0);
+    // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping fires
+    // `OnReset -> _RecycleStickers`, whose first step is `StopTimer(0)` -- the
+    // countdown hides instantly (the slot itself is kept for reuse). Story end
+    // keeps the timer on screen, matching `OnStoryEnd` (only unbinds Event=5).
+    void this.renderer.clearTimerSticker({ durationMs: 0 });
 
     this.cancelTyping();
     if (shouldResume) {
@@ -2640,6 +2645,10 @@ export class StoryRuntime {
 
       case "timersticker": {
         // Native port: Torappu.AVG.StickerPanel._ExcuteTimerSticker. This is a
+        // single-slot, never-blocking executor (native returns hardcoded
+        // false): the timer view is created once and reused, and only
+        // time/x/y/width/size/duration/afrom/ato are read -- id/text/block
+        // are ignored.
         await this.renderer.setTimerSticker({
           durationMs:
             Math.max(0, toNumber(this.exactArg(args, "duration"), 1) * 1000) ||

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -751,7 +751,7 @@ export class StoryRuntime {
     await this.renderer.clearSubtitle(0);
     // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping fires
     // `OnReset -> _RecycleStickers`, whose first step is `StopTimer(0)` -- the
-    // countdown hides instantly (the slot itself is kept for reuse). Story end
+    // timer hides instantly (the slot itself is kept for reuse). Story end
     // keeps the timer on screen, matching `OnStoryEnd` (only unbinds Event=5).
     void this.renderer.clearTimerSticker({ durationMs: 0 });
 

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1364,7 +1364,7 @@ describe("PixiStoryRenderer", () => {
     expect(360 - root.position.y).toBe(0);
   });
 
-  it("shows the timer sticker's full initial value instead of parking on 00:00:00", async () => {
+  it("counts the timer sticker up from 00:00:00 like the native stopwatch", async () => {
     vi.useFakeTimers();
     try {
       const renderer = new PixiStoryRenderer(createContext()) as any;
@@ -1392,27 +1392,27 @@ describe("PixiStoryRenderer", () => {
       });
 
       // `AVGTimerView._StartCountTimer` fires `_TimerTick(0)` once
-      // immediately, so 00:00:00 is visible for one internal tick at most.
+      // immediately and the value then counts up from zero -- `time` is a
+      // timeout cap, not the initial value (02:46:39 must never show here).
       expect(timer.text).toBe("00:00:00");
 
-      // The first real value lands within the ~200ms internal tick: the full
-      // initial value (time=9999 -> 02:46:39) shows right away instead of a
-      // whole second of 00:00:00 followed by a skip straight to 02:46:38.
+      // Within the ~200ms internal tick the elapsed value is still 0s; the
+      // first change lands on the whole-second boundary.
       vi.advanceTimersByTime(200);
-      expect(timer.text).toBe("02:46:39");
+      expect(timer.text).toBe("00:00:00");
 
-      // Each value holds for a whole second, and the countdown is
-      // deadline-based, so wall-clock gaps cannot drift it.
+      // Each value climbs by one per second, derived from the wall clock, so
+      // throttled intervals cannot drift it.
       vi.advanceTimersByTime(800);
-      expect(timer.text).toBe("02:46:38");
+      expect(timer.text).toBe("00:00:01");
       vi.advanceTimersByTime(10_000);
-      expect(timer.text).toBe("02:46:28");
+      expect(timer.text).toBe("00:00:11");
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("keeps the expired timer visible at 00:00:00 and wraps hours at 24", async () => {
+  it("freezes the timer at the time cap and wraps hours at 24", async () => {
     vi.useFakeTimers();
     try {
       const renderer = new PixiStoryRenderer(createContext()) as any;
@@ -1438,18 +1438,19 @@ describe("PixiStoryRenderer", () => {
       };
 
       // `TimeSpan.Hours` wraps at 24: 100000s renders as 03:46:40.
-      await renderer.setTimerSticker({ ...base, limitSeconds: 100_000 });
-      vi.advanceTimersByTime(200);
-      expect(timer.text).toBe("03:46:40");
+      expect(renderer.formatTimer(100_000)).toBe("03:46:40");
 
-      // `_TimerEnd` only clears the task; the view stays visible at 00:00:00
-      // and the interval stops once the deadline is reached.
+      // Reaching `time` fires `_TimerEnd`, which only clears the task; the
+      // view stays visible frozen at the cap (not 00:00:00) and the interval
+      // stops once the cap is reached.
       await renderer.setTimerSticker({ ...base, limitSeconds: 2 });
       expect(timer.text).toBe("00:00:00");
       vi.advanceTimersByTime(2200);
-      expect(timer.text).toBe("00:00:00");
+      expect(timer.text).toBe("00:00:02");
       expect(timer.visible).toBe(true);
       expect(renderer.timerStickerInterval).toBeNull();
+      vi.advanceTimersByTime(1000);
+      expect(timer.text).toBe("00:00:02");
     } finally {
       vi.useRealTimers();
     }

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1363,6 +1363,163 @@ describe("PixiStoryRenderer", () => {
     expect(root.position.x - 640).toBe(-160);
     expect(360 - root.position.y).toBe(0);
   });
+
+  it("shows the timer sticker's full initial value instead of parking on 00:00:00", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = new PixiStoryRenderer(createContext()) as any;
+      const timer = {
+        alpha: 1,
+        style: null,
+        text: "",
+        visible: false,
+        x: 0,
+        y: 0,
+      };
+      renderer.timerStickerText = timer;
+      renderer.ensureTimerStickerText = () => timer;
+      renderer.tween = vi.fn(async () => {});
+
+      await renderer.setTimerSticker({
+        durationMs: 0,
+        fromAlpha: 0,
+        limitSeconds: 9999,
+        sizePx: 24,
+        toAlpha: 1,
+        widthPx: 1280,
+        x: 935,
+        y: 80,
+      });
+
+      // `AVGTimerView._StartCountTimer` fires `_TimerTick(0)` once
+      // immediately, so 00:00:00 is visible for one internal tick at most.
+      expect(timer.text).toBe("00:00:00");
+
+      // The first real value lands within the ~200ms internal tick: the full
+      // initial value (time=9999 -> 02:46:39) shows right away instead of a
+      // whole second of 00:00:00 followed by a skip straight to 02:46:38.
+      vi.advanceTimersByTime(200);
+      expect(timer.text).toBe("02:46:39");
+
+      // Each value holds for a whole second, and the countdown is
+      // deadline-based, so wall-clock gaps cannot drift it.
+      vi.advanceTimersByTime(800);
+      expect(timer.text).toBe("02:46:38");
+      vi.advanceTimersByTime(10_000);
+      expect(timer.text).toBe("02:46:28");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the expired timer visible at 00:00:00 and wraps hours at 24", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = new PixiStoryRenderer(createContext()) as any;
+      const timer = {
+        alpha: 1,
+        style: null,
+        text: "",
+        visible: false,
+        x: 0,
+        y: 0,
+      };
+      renderer.timerStickerText = timer;
+      renderer.ensureTimerStickerText = () => timer;
+      renderer.tween = vi.fn(async () => {});
+      const base = {
+        durationMs: 0,
+        fromAlpha: 0,
+        sizePx: 24,
+        toAlpha: 1,
+        widthPx: 1280,
+        x: 0,
+        y: 0,
+      };
+
+      // `TimeSpan.Hours` wraps at 24: 100000s renders as 03:46:40.
+      await renderer.setTimerSticker({ ...base, limitSeconds: 100_000 });
+      vi.advanceTimersByTime(200);
+      expect(timer.text).toBe("03:46:40");
+
+      // `_TimerEnd` only clears the task; the view stays visible at 00:00:00
+      // and the interval stops once the deadline is reached.
+      await renderer.setTimerSticker({ ...base, limitSeconds: 2 });
+      expect(timer.text).toBe("00:00:00");
+      vi.advanceTimersByTime(2200);
+      expect(timer.text).toBe("00:00:00");
+      expect(timer.visible).toBe(true);
+      expect(renderer.timerStickerInterval).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops stale timer fades when a newer timersticker or clear takes over", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const timer = {
+      alpha: 1,
+      style: null,
+      text: "",
+      visible: false,
+      x: 0,
+      y: 0,
+    };
+    renderer.timerStickerText = timer;
+    renderer.ensureTimerStickerText = () => timer;
+    const tweens: Array<{
+      done: () => void;
+      step: (progress: number) => void;
+    }> = [];
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        step: (progress: number) => void,
+        done?: () => void,
+      ) => {
+        tweens.push({ done: done ?? (() => {}), step });
+      },
+    );
+    const base = {
+      durationMs: 1000,
+      fromAlpha: 0,
+      limitSeconds: undefined,
+      sizePx: 24,
+      toAlpha: 1,
+      widthPx: 1280,
+      x: 0,
+      y: 0,
+    };
+
+    // Fade-in half done when timerclear arrives: the stale fade-in's late
+    // step/done must not write alpha after the fade-out took over.
+    await renderer.setTimerSticker(base);
+    tweens[0]!.step(0.5);
+    expect(timer.alpha).toBe(0.5);
+    await renderer.clearTimerSticker({ durationMs: 300 });
+    tweens[0]!.step(1);
+    tweens[0]!.done();
+    expect(timer.alpha).toBe(0.5);
+    tweens[1]!.step(1);
+    tweens[1]!.done();
+    expect(timer.alpha).toBe(0);
+    expect(timer.visible).toBe(false);
+
+    // Fade-out half done when a new timersticker reactivates the slot: the
+    // stale fade-out's done must not re-hide it or clamp its alpha.
+    await renderer.setTimerSticker({ ...base, fromAlpha: 0.4 });
+    expect(timer.visible).toBe(true);
+    await renderer.clearTimerSticker({ durationMs: 300 });
+    tweens[3]!.step(0.5);
+    expect(timer.alpha).toBeCloseTo(0.2);
+    await renderer.setTimerSticker({ ...base, fromAlpha: 0.2, toAlpha: 0.9 });
+    tweens[3]!.step(1);
+    tweens[3]!.done();
+    expect(timer.visible).toBe(true);
+    expect(timer.alpha).toBe(0.2);
+    tweens[4]!.step(1);
+    expect(timer.alpha).toBeCloseTo(0.9);
+  });
 });
 
 describe("PixiStoryRenderer blocker", () => {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -3363,4 +3363,31 @@ describe("StoryRuntime", () => {
     expect(runtime.getState()).toBe("waiting_input");
     expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
   });
+
+  it("stops the timer sticker when skipping a node", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[name="A"]hello',
+        '[skipnode(mode="skip")]',
+        "[timersticker(x=30,y=90,size=24,time=10)]",
+        '[name="B"]next',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+    await runtime.advance();
+
+    expect(renderer.timerStickerCalls).toHaveLength(1);
+    expect(renderer.timerClearCalls).toEqual([]);
+
+    // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping fires
+    // `OnReset -> _RecycleStickers`, whose first step is `StopTimer(0)`.
+    await runtime.skipNode();
+
+    expect(renderer.timerClearCalls).toEqual([{ durationMs: 0 }]);
+    expect(runtime.getState()).toBe("finished");
+  });
 });


### PR DESCRIPTION
## 背景

依据 `arknights-rev/docs/impl-review/impl-review-timersticker-command.md`（基于官服客户端 2.7.61 / build 2761 GameAssembly.dll 的 IDA 反编译复核）修复 timersticker 命令的移植差异。

> **⚠ 2026-08-29 方向更正**（commit 347d0c38）：本 PR 初版把 native 方向做反了，源于 review 文档对 `_OverrideTimerTaskTick` 的误读（被减数看反）。指令级复核（`0x183ed55a0`：`mov rcx,[rbx]`(curTime) → `psrldq xmm2,8`(startTime) → `sub` → `Math.Max`）确证该函数 = `Math.Max(curTime - startTime, 0)`，即**经过毫秒，递增**。native 关键结论（更正后）：

- `CountDownTask._UpdateValue`（`0x181ceff60`）默认路径 `Math.Max((endTime-curTime)/1000, 0)` 才是"剩余秒递减"（基建/招募等 UI 用），但 `AVGTimerView._StartCountTimer`（`0x183ed5830`）注入了 `overrideUpdateTickValue = _OverrideTimerTaskTick`，默认路径被整体短路。
- 因此 timersticker 是**从 00:00:00 逐秒递增的秒表**：`SetCountDown`（`0x181cefc50`）存 `startTime = now`、`endTime = now + time*1000`（毫秒墙钟），`Update`（`0x183ed5530`）每帧驱动 200ms 门控的 `Tick`（`0x185156990`），`_TimerTick`（`0x183ed5bc0`）把经过毫秒按 `HH:MM:SS` 格式化。**`time` 是超时上限**：到达后 `_TimerEnd` 只清 task 引用，文本定格在 `time` 秒（9999 → 02:46:39）、视图保持可见。真机观察（`story_jnight_1_1.txt:73`）与代码一致：从 00:00:00 往上走。
- `StickerPanel.ShouldResetOnSkip`（`0x183e917a0`）默认 true：skip 触发 `OnReset → _RecycleStickers`（`0x183e93980`），第一步即 `StopTimer(0.0)`——计时器瞬时隐藏、计时停止（引用保留供复用）。`OnStoryEnd` 只解绑 Event=5，不清理计时器。
- `AVGTimerView.RenderTimer`（`0x183ed50f0`）起 fade 前先 `DOKill(_canvas, complete: true)`；`StopTimer` 前 `DOKill(_canvas, complete: false)`——连续命令的 fade 不互相打架。
- `_TimerTick` 格式化 `TimeSpan.FromMilliseconds(...)`，`TimeSpan.Hours` 0..23 回绕（走满 24h 后回绕；100000 → 03:46:40）。

arknights-rev 侧文档（`commands/avg-timersticker-command.md`、`avg-timerclear-command.md`、`impl-review/` 三篇）已同步更正。

## 修复内容

对照 review 差异清单（#1 为更正后表述）：

| 条目 | 严重度 | 改法 |
| --- | --- | --- |
| #1 **计时方向**（原判"倒计时首秒显示"，实为方向相反） | P1 | `setTimerSticker` 改为**递增秒表**：保留立即写 00:00:00（对应 `_TimerTick(0)`），以起点墙钟取 `floor(elapsed)` 每秒 +1，**到 `time` 上限定格并停 interval**（对应 `_TimerEnd` 只清 task、视图保持可见）；不再显示 02:46:38 起递减。200ms tick 保留（复刻 native 内部 tick，墙钟取值使多拍无害），顺带消除 #5 的累计漂移 / 后台节流问题 |
| #2 skip 不清理计时器 | P2 | `skipNode()` 在清 interlude / spell sticker 后增加 `void this.renderer.clearTimerSticker({ durationMs: 0 })`（与 stickerclear case 同款）。story 结束不清理，维持与 `OnStoryEnd` 一致 |
| #3 fade tween 无 DOKill | P2 | 新增 `timerFadeSessionId` 单槽 session（模式同 `subtitleFadeSessionId`）：`setTimerSticker` / `clearTimerSticker` 入口 bump + tween 回调守卫，`destroy()` 亦 bump。旧 fade 的 rAF 循环失效，不再与新 fade 互抢 alpha、不再把 alpha 定格在旧 toAlpha |
| #4 ≥24h 回绕 | P3 | `formatTimer` 小时 `% 24`（样本 max=9999 不触发，前瞻对齐） |
| #5 计时基准 | P3 | 随 #1 的墙钟计算自然消除 |
| #7 注释残句 | P3 | 补全 runtime.ts timersticker case 中 "This is a" 截断句 |

#6（复用槽初始文本）按 review 结论与样本流等价，不动；story 结束不清理同上。

## 验证用剧情文件

语料根：`torappu` 2.7.61 story 全量。`timersticker` 共 8 条样本、全部 `time=9999`，逐条可见方向修复：

- `obt/memory/story_jnight_1_1.txt:73/154/204` — 三次复用单槽（配 `:142/196/236` 的 timerclear）：每次从 00:00:00 起每秒递增（修复前 00:00:00 停 1s 跳 02:46:38 递减）；上一条 fade 未完时新命令直接接管（fade session）
- `obt/memory/story_bobb_1_1.txt:355`、`obt/memory/story_mantra_1_1.txt:90/335` — 与 timerclear(duration=2) 成对：淡出期间不抖动（fade session），clear 后槽隐藏不销毁、下一条复用
- `activities/act27side/level_act27side_07_end.txt:117`、`activities/act35side/level_act35side_st03.txt:135` — 常规单次使用
- skip 瞬时清计时器：8 个样本文件均不含 skipnode/SkipToThis 锚点，语料内无法端到端触发，由单测 `stops the timer sticker when skipping a node` 锁定

## 测试

- `pnpm test`：226 通过（基线 222 + 新增 4：renderer 秒表递增 / 到顶定格与 %24 回绕 / fade 失效两方向，runtime skip 清理）
- `pnpm test:story-log`：全语料对拍 2/2 通过
- `pnpm exec vue-tsc -b`：通过
- `pnpm exec eslint`（4 个改动文件）：无告警

## 与 PR #394 的关系

#394（fix/story-player-timerclear）聚焦 timerclear 的 StopTimer 语义，其中 skip 清理与 fade session 两项与本 PR 重叠（各自基于 origin/main 独立实现，语义一致）；合并时以本 PR 文档链为准 reconcile 保留一份。
