### PR TITLE
fix(story-player): 补 spellstickerclear 孤儿清理有意偏离注释与单测锁定

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/panels/SpellStickerPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/SpellStickerPanel.ts
@@ -72,6 +72,15 @@ export class SpellStickerPanel {
     if (view) view.root.visible = false;
   }
 
+  /**
+   * Native port: `Torappu.AVG.AVGSpellStickerPanel._ClearAll` (2.7.61 VA
+   * 0x183e5d770) destroys only the values left in `m_spellStickerDict`, then
+   * clears both dicts. Orphans created by a style switch were already removed
+   * from that dict, so in the native client they stay visible after
+   * `spellstickerclear` and only disappear when the panel/scene GameObject is
+   * destroyed (a known native leak). Intentional deviation: this port destroys
+   * orphans here as well, so clear actually clears the screen.
+   */
   clear(): void {
     for (const view of this.views.values()) this.destroyRoot(view.root);
     for (const root of this.orphans) this.destroyRoot(root);

--- a/tests/spellStickerPanel.spec.ts
+++ b/tests/spellStickerPanel.spec.ts
@@ -57,5 +57,12 @@ describe("SpellStickerPanel", () => {
 
     panel.clear();
     expect(layer.children).toHaveLength(0);
+
+    // Intentional deviation from native `_ClearAll`: the orphan was already
+    // removed from the dict, so it stays visible in the native client; here
+    // clear() destroys it. Both dicts are cleared, so a re-show after clear
+    // builds a fresh view.
+    panel.show({ alpha: 1, content: "", id: "spell1", style: "sami" });
+    expect(layer.children).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## 背景

基于明日方舟官服客户端 2.7.61(build 2761)GameAssembly.dll 的 IDA 反编译复核(review 文档 `arknights-rev/docs/impl-review/impl-review-spellstickerclear-command.md`,差异计 P2×1 / P3×2,四条贴纸命令里对齐度最高的一条),native 关键结论:

- executor `AVGSpellStickerPanel._ExecuteSpellStickerClear`(VA `0x183e5d9a0`):只读 `block`(`GetOrDefault<bool>("block", false)`)、不读 `id`;流程为 `_ClearAll()` → `m_blockingStickerId = null` → `!block` 返回 false;`block=true` 注册 `Event.Click` 后 `return block`。
- `_ClearAll`(VA `0x183e5d770`):空字典静默 no-op;非空则 `foreach value → Object.Destroy`(`op_Inequality` 判活),随后清空 `m_spellStickerDict` + `m_stickerStyleDict`。§9.28 C 态:瞬间销毁、无 fade。
- **孤儿泄露**:换 style 时被 `Remove` 出字典的实例不在 `Values` 里,`_ClearAll` 扫不到 —— `spellstickerclear` 后孤儿仍可见,只随 panel/场景销毁消失(native 缺陷行为,全库真实样本 0 触发)。
- `block=true` 的 Click(`_OnClicked`,VA `0x183e5e4a0`)因阻塞 id 已清空,只做 `InvokeNextFrame(FinishCommand)` 纯推进,无视图副作用;与普通 `StickerPanel` 的 `m_stickerDict` / `m_currentTimer` 完全隔离。

前端 `runtime.ts` 的 `case "spellstickerclear"`(`clearSpellStickers()` → `pendingInputEffect = null` → `return block ? "wait_input" : "continue"`)与 native 三段语义一一对应,行为已一致。

## 修复内容

差异清单三条中仅 P2 #1 需要处理:

| # | 严重度 | 差异 | 处理 |
| --- | --- | --- | --- |
| 1 | P2 | 孤儿 view 的清理:native `spellstickerclear` 后孤儿仍可见(已知泄露),前端一并销毁 | **行为保留**(历史文档 avg-spellsticker-command.md §10-7 明示此为推荐的有意偏离);在 `SpellStickerPanel.clear()` 补 Native provenance 注释,写明 native 孤儿不随 clear 消失、此处有意销毁 |
| 2 | P3 | `block=true` 等待期间同 id 再 show 的极端脚本差异 | 无需改动(全库 0 样本) |
| 3 | P3 | 清理时序(读取 → 清屏 → 清阻塞 id) | 无需改动(顺序一致) |

改动文件(共享的 SpellSticker panel 仅 +9 行注释,零行为变更,最小 diff;与姊妹篇 spellsticker PR 无逻辑冲突):

- `src/widgets/StoryPlayer/engine/rendering/panels/SpellStickerPanel.ts`:`clear()` 补 doc 注释(含 `_ClearAll` 2.7.61 VA `0x183e5d770` 与有意偏离说明)。
- `tests/spellStickerPanel.spec.ts`:在既有孤儿用例末尾补断言 —— clear 后重 show 同 id 应新建 view(锁住"清空两张表 + 有意销毁孤儿"的偏离行为)。

## 验证用剧情文件

语料库 `/home/xwbx/Documents/torappu/storage/asset/gamedata/latest/story/`,生产剧情全库 4 文件命中(命令为小写 `[spellstickerclear(block=false)]`),最小两个:

- `obt/main/level_main_17-05_end.txt`:581、657 行 —— 验证 `block=false` 的 clear 瞬时清屏(前一 show 为 block=true,点击推进后 clear)、无 fade、后续命令直接 continue。
- `obt/main/level_st_17-03.txt`:364 行 —— 同上。
- 另:`obt/main/level_main_17-04_beg.txt`(799、809 行)、`obt/main/level_main_17-17_end.txt`(791、807、832、895、1201 行,含结尾无前置 show 的收尾 clear)。

全库无 `block=true` 的 clear、无同 id 换 style 触发孤儿分支 —— P2 #1 的有意偏离行为本身由单测锁定(前瞻对齐)。

## 测试

- `pnpm test`:20 个 spec 文件 / 222 用例全绿(基线 222,新增断言并入既有用例)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint <改动文件>`:通过。
