### PR TITLE
fix(story-player): spellsticker 边界行为对齐 2.7.61 native 复核（alpha 缺省/分段缺失/孤儿注释/空 id 日志）

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/panels/SpellStickerPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/SpellStickerPanel.ts
@@ -13,18 +13,25 @@ interface SpellStickerView {
   style: string;
 }
 
-function splitContent(content: string): [string, string] {
+/**
+ * `<p=N>` segments keyed by their 1-based N. Native `FormatUtil.
+ * _HandleAvgSplitContentTextTags` stores `dict[N-1]` and `_ShowSticker`
+ * iterates child Texts by 0-based index, so N maps to the N-th child.
+ */
+function splitContent(content: string): Map<number, string> {
   const parts = new Map<number, string>();
   const pattern = /<p=(\d+)>([\s\S]*?)<\/>/gi;
   for (const match of content.matchAll(pattern))
     parts.set(Number(match[1]), match[2] ?? "");
-  return [parts.get(1) ?? "", parts.get(2) ?? ""];
+  return parts;
 }
 
 /**
- * Port scope: `Torappu.AVG.SpellStickerPanel._ExecuteSpellSticker` and
- * `_ExecuteSpellStickerClear` state transitions. The two supported styles are
- * lightweight PIXI approximations of their prefab visuals, not Animator ports.
+ * Port scope: `Torappu.AVG.AVGSpellStickerPanel._ExecuteSpellSticker` /
+ * `_ShowSticker` / `_HideSticker` / `_GetOrCreateSticker` state transitions.
+ * The two supported styles are lightweight PIXI approximations of their
+ * prefab visuals; native entrances replay a Legacy `Animation` clip per show,
+ * which is a declared omission here (no animator/clip ports).
  */
 export class SpellStickerPanel {
   private readonly orphans = new Set<Container>();
@@ -44,6 +51,9 @@ export class SpellStickerPanel {
 
     let view = this.views.get(input.id);
     if (view && view.style !== style) {
+      // Native `_GetOrCreateSticker`: same id with a different style removes
+      // the dict entry without destroying the GameObject, leaving a visible
+      // orphan that hide/clear-by-id can no longer address.
       this.views.delete(input.id);
       this.orphans.add(view.root);
       view = undefined;
@@ -53,13 +63,23 @@ export class SpellStickerPanel {
       this.views.set(input.id, view);
     }
 
-    const [mainText, subText] = splitContent(input.content);
+    // Native `_ShowSticker` only overwrites child Texts whose index exists in
+    // the split dict (`dict.ContainsKey(i)`), so a segment missing from the
+    // new content keeps the previous text — same optional-write philosophy as
+    // the transform fields below.
+    const parts = splitContent(input.content);
     const main = view.root.getChildByLabel("text_spell_main") as Text;
     const sub = view.root.getChildByLabel("text_spell_sub") as Text;
-    main.text = mainText;
-    sub.text = subText;
+    const mainText = parts.get(1);
+    const subText = parts.get(2);
+    if (mainText !== undefined) main.text = mainText;
+    if (subText !== undefined) sub.text = subText;
     view.root.visible = true;
-    view.root.alpha = Math.max(0, Math.min(1, input.alpha));
+    // Native inlines `_ApplyAlpha`: alpha is written (clamped to 0..1) only
+    // when the param exists; a reused sticker keeps its last alpha. New views
+    // default to PIXI's alpha 1, matching a fresh native CanvasGroup.
+    if (input.alpha !== undefined)
+      view.root.alpha = Math.max(0, Math.min(1, input.alpha));
     if (input.x !== undefined) view.root.x = STORY_WIDTH / 2 + input.x;
     if (input.y !== undefined) view.root.y = STORY_HEIGHT / 2 - input.y;
     if (input.xScale !== undefined) view.root.scale.x = input.xScale;
@@ -73,6 +93,14 @@ export class SpellStickerPanel {
   }
 
   clear(): void {
+    // Intentional deviation from native `_ClearAll` (also used for OnReset /
+    // ShouldResetOnSkip): native only scans the id→view dict, so a
+    // style-switched orphan stays visible on screen until the panel itself is
+    // destroyed. We destroy orphans too — a web player reuses renderer
+    // instances across stories, and a permanently visible leftover past
+    // `spellstickerclear`/skip would leak into later scenes. No corpus sample
+    // switches styles for the same id, so the divergent path is unreachable in
+    // production data.
     for (const view of this.views.values()) this.destroyRoot(view.root);
     for (const root of this.orphans) this.destroyRoot(root);
     this.views.clear();

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -3094,13 +3094,24 @@ export class StoryRuntime {
         // Native port: Torappu.AVG.AVGSpellStickerPanel._ExecuteSpellSticker.
         // `block` waits for a click, whose follow-up hides the sticker.
         const id = toString(this.exactArg(args, "id"));
-        if (!id) return "continue";
+        if (!id) {
+          // Native logs "[AVG.SpellSticker] Empty sticker id." and returns
+          // false before reading `block`; keep the passthrough silent-ish but
+          // surface a warning for log diffing.
+          this.warn("parse", "spellsticker: empty sticker id");
+          return "continue";
+        }
         const action = toString(this.exactArg(args, "action"), "show");
         const block = toBoolean(this.exactArg(args, "block"), false);
+        // Native `_ShowSticker` inlines `_ApplyAlpha`: CanvasGroup.alpha is
+        // only written when the alpha param exists (TryGetParam + clamp 0..1),
+        // so a reused sticker keeps its previous alpha. Keep the field
+        // optional instead of forcing the default 1.
+        const alpha = toOptionalNumber(this.exactArg(args, "alpha"));
         await (action.toLowerCase() === "hide"
           ? this.renderer.hideSpellSticker(id)
           : this.renderer.setSpellSticker({
-              alpha: clamp(toNumber(this.exactArg(args, "alpha"), 1), 0, 1),
+              alpha: alpha === undefined ? undefined : clamp(alpha, 0, 1),
               angle: toOptionalNumber(this.exactArg(args, "angle")),
               content: this.translateText(line.content),
               id,

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -481,7 +481,9 @@ export interface StickerTweenInput {
 }
 
 export interface SpellStickerInput {
-  alpha: number;
+  // Optional to mirror native TryGetParam: absent alpha leaves a reused
+  // sticker's previous alpha untouched (see SpellStickerPanel.show).
+  alpha?: number;
   angle?: number;
   content: string;
   id: string;

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -461,6 +461,65 @@ describe("StoryRuntime", () => {
     expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
   });
 
+  it("keeps spellsticker alpha unset when the param is missing", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[spellsticker(id="s",style="sami",block=false)]<p=1>x</>',
+        '[name="A"]after',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // Native _ShowSticker writes CanvasGroup.alpha only via TryGetParam, so
+    // the renderer must receive `undefined` (not a forced 1) and let the view
+    // keep its previous alpha.
+    expect(renderer.spellStickerCalls).toEqual([
+      {
+        alpha: undefined,
+        angle: undefined,
+        content: "<p=1>x</>",
+        id: "s",
+        style: "sami",
+        x: undefined,
+        xScale: undefined,
+        y: undefined,
+        yScale: undefined,
+      },
+    ]);
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
+  });
+
+  it("warns and continues on an empty spellsticker id", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[spellsticker(style="sami",block=true)]<p=1>x</>',
+        '[name="A"]after',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    // Native logs "[AVG.SpellSticker] Empty sticker id." and returns false
+    // before reading `block`, so the command neither renders nor blocks.
+    expect(renderer.spellStickerCalls).toEqual([]);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        detail: "spellsticker: empty sticker id",
+        type: "parse",
+      }),
+    ]);
+    expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
+  });
+
   it("keeps spellstickerclear independent and honors block", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(

--- a/tests/spellStickerPanel.spec.ts
+++ b/tests/spellStickerPanel.spec.ts
@@ -55,7 +55,58 @@ describe("SpellStickerPanel", () => {
     expect(layer.children).toHaveLength(2);
     expect(warning).toHaveBeenCalledWith("missing spellsticker style: unknown");
 
+    // Intentional deviation from native _ClearAll, which cannot see orphans
+    // and would leave them visible; see the comment in clear().
     panel.clear();
     expect(layer.children).toHaveLength(0);
+  });
+
+  it("keeps the previous alpha when the alpha param is missing", () => {
+    const layer = new Container();
+    const panel = new SpellStickerPanel(layer);
+
+    // A fresh view starts at PIXI's default alpha 1 (native: fresh
+    // CanvasGroup) when the first show has no alpha param.
+    panel.show({ content: "<p=1>a</>", id: "s", style: "sami" });
+    const root = layer.children[0] as Container;
+    expect(root.alpha).toBe(1);
+
+    // Native _ShowSticker only writes alpha via TryGetParam, so a reused view
+    // keeps its last value instead of snapping back to 1.
+    panel.show({ alpha: 0.25, content: "<p=1>a</>", id: "s", style: "sami" });
+    expect(root.alpha).toBe(0.25);
+    panel.show({ content: "<p=1>a</>", id: "s", style: "sami" });
+    expect(root.alpha).toBe(0.25);
+  });
+
+  it("keeps the previous text for segments missing from the new content", () => {
+    const layer = new Container();
+    const panel = new SpellStickerPanel(layer);
+    panel.show({
+      alpha: 1,
+      content: "<p=1>main</><p=2>sub</>",
+      id: "s",
+      style: "sami",
+    });
+    const root = layer.children[0] as Container;
+
+    // Native dict.ContainsKey(i) gating: <p=2> only updates the second slot.
+    panel.show({
+      alpha: 1,
+      content: "<p=2>new sub</>",
+      id: "s",
+      style: "sami",
+    });
+    expect((root.getChildByLabel("text_spell_main") as Text).text).toBe("main");
+    expect((root.getChildByLabel("text_spell_sub") as Text).text).toBe(
+      "new sub",
+    );
+
+    // No <p=N> tags at all: dict is empty, both slots keep their text.
+    panel.show({ alpha: 1, content: "plain", id: "s", style: "sami" });
+    expect((root.getChildByLabel("text_spell_main") as Text).text).toBe("main");
+    expect((root.getChildByLabel("text_spell_sub") as Text).text).toBe(
+      "new sub",
+    );
   });
 });


### PR DESCRIPTION
## 背景

基于官服客户端 2.7.61（build 2761）GameAssembly.dll 的 IDA 反编译复核
（逆向 review 文档：`arknights-rev/docs/impl-review/impl-review-spellsticker-command.md`），
对 `spellsticker` 命令的移植边界做对齐。关键 native 结论（VA 为 2.7.61）：

- `_ShowSticker`（`0x183e5e5a0`）内联展开 `_ApplyAlpha`：**`TryGetParam("alpha")`
  成功才写** CanvasGroup.alpha（clamp 0..1）；参数缺失时不写，复用实例保留上次 alpha。
- `_ShowSticker` 用 `FormatAvgSplitContentTextFromData` 解析 `<p=N>`
  （`FormatUtil._HandleAvgSplitContentTextTags` `0x181f017c0` 存 `dict[N-1]`），
  按 0 基子节点 index 遍历子 Text：**仅 `dict.ContainsKey(i)` 时覆盖**，
  新 content 缺失的段保留旧文本。
- `_GetOrCreateSticker`（`0x183e5e070`）：同 id 换 style 只从字典 Remove、不
  Destroy，产生存活孤儿；`_ClearAll` 只扫字典，**孤儿在 clear 后仍可见**，
  只随 panel 销毁消失。
- `_ExecuteSpellSticker`（`0x183e5db50`）：空 id 时
  `DLog.LogError("[AVG.SpellSticker] Empty sticker id.")` + return false（早于
  block 读取，不阻塞）。
- 入场动画为每次 show `Stop+Play` 的 **Legacy Animation clip**（非 Animator），
  属已声明的资源级省略。

## 修复内容

对照 review 差异清单（P2×3、P3×5）：

- **P2#1 alpha 缺省写入**：`runtime.ts` 不再用 `toNumber(alpha, 1)` 强制回 1，
  改为 `toOptionalNumber` + 存在时 clamp 0..1；`SpellStickerInput.alpha` 改可选；
  `SpellStickerPanel.show` 仅在 `input.alpha !== undefined` 时写
  `root.alpha`（新视图维持 PIXI 默认 1，等价 fresh CanvasGroup）。
- **P2#3 分段缺失时的旧文本**：`splitContent` 改返回段 Map，`show` 仅覆盖新
  content 中存在的 `<p=N>` 段（对齐 `dict.ContainsKey(i)` 门控），缺失段/无任何
  p 标签时两个文本槽都保留旧文本，不再清成空串。
- **P2#2 换 style 孤儿的最终命运**：**行为维持现状**（`clear()` 连孤儿一并销毁），
  按 review 建议保留这一历史文档 §10-7 已推荐的有意偏离，并在 `clear()` 注释中
  标注偏离原因（native 孤儿 clear 后仍可见只随 panel 销毁；web 播放器跨剧情复用
  renderer，残留孤儿会泄漏进后续场景；换 style 分支语料 0 样本）。
- **P3#6 空 id 日志**：空 id 时补 `warn("parse", "spellsticker: empty sticker id")`，
  便于与 native LogError 对拍；放行语义不变（不渲染、不阻塞）。
- 顺带修正 panel provenance 注释笔误：类名 `Torappu.AVG.AVGSpellStickerPanel`
  （双 AVG），"not Animator ports" 措辞更正为 Legacy Animation clip（声明省略）。

**按建议跳过**：P3#4 入场动画（已声明的资源级省略）、P3#5 富文本/`\n` 预处理
（样本均为纯文本）、P3#7 `p=0`/`p≥3` 对齐日志（行为等价、可选）、P3#8 视觉细节
（已是合理近似）。spellsticker 不进入 Log All 文本日志（log/ 子系统无此命令），
本次改动不影响文本可见性，无需同步 log 三件套。

## 验证用剧情文件

语料根：`torappu/storage/asset/gamedata/latest/story/`，`[spellsticker` 共 5 文件
15 处 show + 10 处 clear，全部带 `alpha=1` 且 `<p=1>`+`<p=2>` 成对、`spell1` 恒
sami / `spell2` 恒 fire（无换 style、无缺段、无缺 alpha 样本）——即本次修复的
三个边界均无场景样本覆盖，属**前瞻对齐，由单测锁定**；主路径（show 参数映射、
block 点击先隐藏、clear、skip 清理、同 id 同 style 复用换文案）由以下样本覆盖：

- `obt/main/level_st_17-03.txt:362-364` — 最小 show+clear 对（fire 单发）；
- `obt/main/level_main_17-09_end.txt:340-345` — 同 id 同 style 连续 6 次 show
  （每次点击隐藏→重播换文案，覆盖复用+分段覆盖路径）；
- `obt/main/level_main_17-04_beg.txt:797-809`、`level_main_17-17_end.txt:789-895`
  — fire 多轮 show/clear 交替；
- `obt/main/level_main_17-05_end.txt:579-657` — fire 两轮 show/clear。

## 测试

- `pnpm test`：226/226 通过（基线 222 + 新增 4：alpha 缺省保留上次值/新视图默认
  1、缺段保留旧文本/无 p 标签全保留、runtime alpha 透传 undefined、空 id warn 且
  不渲染不阻塞）。
- `STORY_CORPUS_ROOT=<语料> pnpm test:story-log`：全语料符号分析与独立 oracle
  对拍 2/2 通过（spellsticker 不影响 log 语义，保险回归）。
- `pnpm exec vue-tsc -b` 通过；改动文件 `eslint` 0 error 0 warning。
