### PR TITLE
fix(story-player): timerclear 对齐 native skip 清理与 fade 会话失效

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -112,6 +112,21 @@ function easeOutCubic(progress: number): number {
 }
 
 /**
+ * Native `Torappu.AVG.AVGTypeWriterText.BeginText` hides the unrevealed tail
+ * behind a fully transparent `<color=#00000000>` span so the whole message is
+ * laid out (and wrapped) from t0 -- revealing characters never re-wraps the
+ * lines already on screen.
+ */
+const SUBTITLE_HIDDEN_TAIL_COLOR = "#00000000";
+
+function subtitleHiddenTail(chars: RichChar[]): RichChar[] {
+  return chars.map(({ char }) => ({
+    char,
+    color: SUBTITLE_HIDDEN_TAIL_COLOR,
+  }));
+}
+
+/**
  * Canvas 渲染分辨率：逻辑坐标系固定 1280x720，实际像素数按宿主 CSS 尺寸
  * × devicePixelRatio 反推，避免画布被 CSS 拉伸发糊。取宽高比例的较大值，
  * 宿主短暂偏离 16:9 时也不会欠采样。
@@ -310,6 +325,12 @@ export class PixiStoryRenderer implements StoryRenderer {
   >();
   private readonly stickerTypingSessionIds = new Map<string, number>();
   private subtitleFadeSessionId = 0;
+  /**
+   * Native port: `SubtitlePanel._SetHiddenInternal`'s `m_hidden`. Flips the
+   * moment `set_isHidden` is called, while the alpha tween catches up. A
+   * `setSubtitle` on an already-shown panel must not replay the fade-in.
+   */
+  private subtitleHidden = true;
   private subtitleText: Text | null = null;
   private subtitleTypingTarget: {
     alignment: SubtitleInput["alignment"];
@@ -492,6 +513,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.stickerTypingTargets.clear();
     this.stickerTypingSessionIds.clear();
     this.subtitleFadeSessionId += 1;
+    this.subtitleHidden = true;
     this.subtitleTypingTarget = null;
     this.subtitleTypingSessionId += 1;
     this.stickerRichChars.clear();
@@ -1791,6 +1813,9 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.subtitleTypingSessionId += 1;
     this.subtitleFadeSessionId += 1;
     this.subtitleTypingTarget = null;
+    // Native `set_isHidden(true)` flips `m_hidden` immediately; the fade only
+    // animates the visible alpha towards it.
+    this.subtitleHidden = true;
 
     const subtitle = this.subtitleText;
     if (!subtitle) return;
@@ -2260,20 +2285,28 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.subtitleTypingSessionId += 1;
     this.subtitleFadeSessionId += 1;
     this.subtitleTypingTarget = null;
-    subtitle.alpha = 0;
-    subtitle.visible = true;
 
-    const fadeSessionId = this.subtitleFadeSessionId;
-    void this.tween(
-      150,
-      (progress) => {
-        if (this.subtitleFadeSessionId === fadeSessionId)
-          subtitle.alpha = progress;
-      },
-      () => {
-        if (this.subtitleFadeSessionId === fadeSessionId) subtitle.alpha = 1;
-      },
-    );
+    // Native `SubtitlePanel._SetHiddenInternal` (2.7.61 VA 0x183e94ff0):
+    // `set_isHidden(false)` is a no-op while the panel is already visible, so
+    // consecutive subtitles swap text seamlessly without replaying the 150ms
+    // Linear fade-in. A hidden panel fades in from its current alpha, which
+    // also covers interrupting an in-flight fade-out (DOKill + DOFade).
+    if (this.subtitleHidden) {
+      this.subtitleHidden = false;
+      const startAlpha = subtitle.visible ? subtitle.alpha : 0;
+      subtitle.visible = true;
+      const fadeSessionId = this.subtitleFadeSessionId;
+      void this.tween(
+        150,
+        (progress) => {
+          if (this.subtitleFadeSessionId === fadeSessionId)
+            subtitle.alpha = startAlpha + (1 - startAlpha) * progress;
+        },
+        () => {
+          if (this.subtitleFadeSessionId === fadeSessionId) subtitle.alpha = 1;
+        },
+      );
+    }
 
     const prevChars: RichChar[] = [];
     const newChars = parseRichChars(input.text);
@@ -2281,7 +2314,17 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     const colors = collectColors(allChars);
     const style = this.createOverlayTextStyle(input.sizePx, input.widthPx);
-    if (colors.length > 0) style.tagStyles = buildTagStyles(colors);
+    // Native maps alignment to TextAnchor.UpperLeft/UpperCenter/UpperRight,
+    // which horizontally aligns *every wrapped line* inside the width box;
+    // PIXI needs the per-line `align` style in addition to the whole-block
+    // offset that layoutSubtitle applies.
+    style.align = input.alignment;
+    // The transparent hidden tail below needs its tag registered while typing.
+    const tagStyles = buildTagStyles([
+      ...colors,
+      ...(input.delayMs > 0 ? [SUBTITLE_HIDDEN_TAIL_COLOR] : []),
+    ]);
+    if (Object.keys(tagStyles).length > 0) style.tagStyles = tagStyles;
     subtitle.style = style;
     subtitle.y = input.y;
 
@@ -2289,11 +2332,20 @@ export class PixiStoryRenderer implements StoryRenderer {
     if (input.delayMs <= 0) {
       subtitle.text = fullText;
       this.layoutSubtitle(subtitle, input.x, input.widthPx, input.alignment);
+      // Nothing to type: the typewriter is done the moment the text is shown.
+      input.onTypingComplete?.();
       return;
     }
 
     const sessionId = this.subtitleTypingSessionId;
-    subtitle.text = richCharsToTaggedText(prevChars);
+    // Native `AVGTypeWriterText.BeginText` lays out the full message from t0
+    // by keeping the unrevealed tail in the text wrapped in a fully
+    // transparent <color=#00000000> span; revealing chars never re-wraps the
+    // lines that are already on screen.
+    subtitle.text = richCharsToTaggedText([
+      ...prevChars,
+      ...subtitleHiddenTail(newChars),
+    ]);
     this.layoutSubtitle(subtitle, input.x, input.widthPx, input.alignment);
     this.subtitleTypingTarget = {
       alignment: input.alignment,
@@ -2305,8 +2357,9 @@ export class PixiStoryRenderer implements StoryRenderer {
       alignment: input.alignment,
       baseX: input.x,
       delayMs: input.delayMs,
-      prevChars,
       newChars,
+      onTypingComplete: input.onTypingComplete,
+      prevChars,
       widthPx: input.widthPx,
     });
   }
@@ -3776,8 +3829,9 @@ export class PixiStoryRenderer implements StoryRenderer {
       alignment: SubtitleInput["alignment"];
       baseX: number;
       delayMs: number;
-      prevChars: RichChar[];
       newChars: RichChar[];
+      onTypingComplete?: () => void;
+      prevChars: RichChar[];
       widthPx: number;
     },
   ): Promise<void> {
@@ -3788,9 +3842,12 @@ export class PixiStoryRenderer implements StoryRenderer {
 
       if (!this.app || this.subtitleTypingSessionId !== sessionId) return;
 
+      // The transparent tail keeps the full-text line layout fixed while the
+      // visible prefix grows (native BeginText hidden-string port).
       subtitle.text = richCharsToTaggedText([
         ...input.prevChars,
         ...input.newChars.slice(0, index + 1),
+        ...subtitleHiddenTail(input.newChars.slice(index + 1)),
       ]);
       this.layoutSubtitle(
         subtitle,
@@ -3800,8 +3857,13 @@ export class PixiStoryRenderer implements StoryRenderer {
       );
     }
 
-    if (this.subtitleTypingSessionId === sessionId)
+    if (this.subtitleTypingSessionId === sessionId) {
       this.subtitleTypingTarget = null;
+      // Native `SubtitlePanel._OnTypeWriterEnd` (2.7.61 VA 0x183e94e80):
+      // typing that finishes on its own raises the auto click; without this,
+      // auto mode would sit on the subtitle waiting for a manual click.
+      input.onTypingComplete?.();
+    }
   }
 
   private async runStickerTyping(

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -340,6 +340,7 @@ export class PixiStoryRenderer implements StoryRenderer {
   } | null = null;
   private subtitleTypingSessionId = 0;
   private readonly stickerRichChars = new Map<string, RichChar[]>();
+  private timerFadeSessionId = 0;
   private timerStickerInterval: ReturnType<typeof setInterval> | null = null;
   private timerStickerText: Text | null = null;
 
@@ -508,6 +509,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.subtitleText = null;
     this.timerStickerText = null;
     this.clearTimerInterval();
+    this.timerFadeSessionId += 1;
     this.stickerTexts.clear();
     this.stickerFadeSessionIds.clear();
     this.stickerTypingTargets.clear();
@@ -1908,7 +1910,17 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.spellStickerPanel.hide(id);
   }
 
+  /**
+   * Port scope: `Torappu.AVG.AVGTimerView.StopTimer` (2.7.61 VA 0x183ed53e0):
+   * `DOKill(_canvas, complete: false)` kills any in-flight fade tween without
+   * completing it, then fades from the current alpha to a hard-coded 0 and
+   * hides (never destroys) the view. The fade session counter is the DOKill
+   * analogue: bumping it here retires the previous fade's step/done callbacks
+   * so a timersticker fade-in still running when timerclear lands cannot keep
+   * writing alpha alongside the fade-out.
+   */
   async clearTimerSticker(input?: TimerClearInput): Promise<void> {
+    this.timerFadeSessionId += 1;
     this.clearTimerInterval();
 
     const timer = this.timerStickerText;
@@ -1921,6 +1933,7 @@ export class PixiStoryRenderer implements StoryRenderer {
       return;
     }
 
+    const sessionId = this.timerFadeSessionId;
     const fromAlpha = timer.alpha;
     if (input.durationMs <= 0) {
       timer.alpha = 0;
@@ -1931,9 +1944,11 @@ export class PixiStoryRenderer implements StoryRenderer {
     void this.tween(
       input.durationMs,
       (progress) => {
+        if (this.timerFadeSessionId !== sessionId) return;
         timer.alpha = fromAlpha * (1 - progress);
       },
       () => {
+        if (this.timerFadeSessionId !== sessionId) return;
         timer.alpha = 0;
         timer.visible = false;
       },
@@ -2437,6 +2452,9 @@ export class PixiStoryRenderer implements StoryRenderer {
    * Port scope: `Torappu.AVG.StickerPanel._ExcuteTimerSticker` (native spelling)
    * and `AVGTimerView.RenderTimer`. Browser intervals and PIXI text adapt the
    * native timer view; this command itself never supplies a block boundary.
+   * RenderTimer precedes its fade with `DOKill(_canvas, complete: true)`: the
+   * fade session bump below retires any in-flight timer fade (e.g. a timerclear
+   * fade-out) before the new fade-in starts writing alpha.
    */
   async setTimerSticker(input: TimerStickerInput): Promise<void> {
     const timer = this.ensureTimerStickerText();
@@ -2449,13 +2467,17 @@ export class PixiStoryRenderer implements StoryRenderer {
     timer.y = input.y;
     timer.text = this.formatTimer(0);
 
+    this.timerFadeSessionId += 1;
+    const fadeSessionId = this.timerFadeSessionId;
     void this.tween(
       input.durationMs > 0 ? input.durationMs : 130,
       (progress) => {
+        if (this.timerFadeSessionId !== fadeSessionId) return;
         timer.alpha =
           input.fromAlpha + (input.toAlpha - input.fromAlpha) * progress;
       },
       () => {
+        if (this.timerFadeSessionId !== fadeSessionId) return;
         timer.alpha = input.toAlpha;
       },
     );

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -745,6 +745,10 @@ export class StoryRuntime {
     await this.renderer.clearInterludes();
     await this.renderer.clearCharacterCutin();
     await this.renderer.clearSpellStickers();
+    // Native: SubtitlePanel.ShouldResetOnSkip() is true, so a skip resets the
+    // panel through OnReset -- alpha to 0 immediately (no tween) plus a
+    // typewriter reset. A stale subtitle must not survive the skip.
+    await this.renderer.clearSubtitle(0);
 
     this.cancelTyping();
     if (shouldResume) {
@@ -2551,11 +2555,19 @@ export class StoryRuntime {
         if (x < 0 || x > 1280 || y < 0 || y > 720) return "continue";
 
         this.displayedLineIndex = line.lineNumber;
+        // Native `_OnTypeWriterEnd` (2.7.61 VA 0x183e94e80) raises the auto
+        // click with the subtitle's own `typeWriter.messageLength`. Track the
+        // subtitle in the shared typing state so auto mode both advances when
+        // typing ends naturally and waits for the subtitle's length instead of
+        // the previous dialogue's leftovers.
+        this.cancelTyping();
+        this.currentMessageLength = parseRichChars(text).length;
         await this.renderer.setSubtitle({
           alignment:
             this.parseSubtitleAlignment(this.exactArg(args, "alignment")) ??
             "left",
           delayMs: this.getCurrentSpeed().typeWriterDelayMs,
+          onTypingComplete: () => this.onTypingComplete(),
           sizePx: toNumber(this.exactArg(args, "size"), 24),
           text,
           widthPx: Math.min(

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -749,6 +749,11 @@ export class StoryRuntime {
     // panel through OnReset -- alpha to 0 immediately (no tween) plus a
     // typewriter reset. A stale subtitle must not survive the skip.
     await this.renderer.clearSubtitle(0);
+    // Native port: `Torappu.AVG.StickerPanel.ShouldResetOnSkip` (default true)
+    // routes skip into OnReset → _RecycleStickers, whose first step is
+    // `m_currentTimer?.StopTimer(0.0)` — the timer hides instantly and its
+    // countdown task stops, instead of keep ticking on screen after skip.
+    void this.renderer.clearTimerSticker({ durationMs: 0 });
 
     this.cancelTyping();
     if (shouldResume) {

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -389,6 +389,15 @@ export interface CgItemInput {
 export interface SubtitleInput {
   alignment: "center" | "left" | "right";
   delayMs: number;
+  /**
+   * Native port: `Torappu.AVG.SubtitlePanel._OnTypeWriterEnd` (2.7.61 VA
+   * 0x183e94e80). Invoked exactly once when the subtitle typewriter finishes
+   * on its own (or shows instantly with `delayMs <= 0`) so the runtime can
+   * run its `RaiseAutoClick(typeWriter.messageLength)` equivalent. The
+   * click-to-finish path never invokes it -- native `_OnClicked` ->
+   * `TryFinish()` is driven by the runtime's own click handler.
+   */
+  onTypingComplete?: () => void;
   sizePx: number;
   text: string;
   widthPx: number;

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -13,7 +13,10 @@ import { TweenRunner } from "../src/widgets/StoryPlayer/engine/rendering/core/Tw
 
 import type { Context } from "../src/widgets/StoryPlayer/context";
 import type { AnimationClock } from "../src/widgets/StoryPlayer/engine/execution";
-import type { GridBackgroundInput } from "../src/widgets/StoryPlayer/engine/types";
+import type {
+  GridBackgroundInput,
+  TimerStickerInput,
+} from "../src/widgets/StoryPlayer/engine/types";
 
 function createContext(): Context {
   return {
@@ -1362,6 +1365,70 @@ describe("PixiStoryRenderer", () => {
 
     expect(root.position.x - 640).toBe(-160);
     expect(360 - root.position.y).toBe(0);
+  });
+
+  it("retires stale timer sticker fades when a new fade starts", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const timer = new Text({ text: "" });
+    timer.alpha = 1;
+    timer.visible = true;
+    renderer.timerStickerText = timer;
+
+    const tweens: Array<{
+      done: (() => void) | undefined;
+      step: (progress: number) => void;
+    }> = [];
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        step: (progress: number) => void,
+        done?: () => void,
+      ) => {
+        tweens.push({ done, step });
+      },
+    );
+
+    const input = {
+      durationMs: 1000,
+      fromAlpha: 0,
+      limitSeconds: undefined,
+      sizePx: 24,
+      toAlpha: 1,
+      widthPx: 300,
+      x: 935,
+      y: 80,
+    } satisfies TimerStickerInput;
+
+    // A timersticker fade-in is still mid-flight when timerclear lands, like
+    // native StopTimer's DOKill(_canvas, false) scenario.
+    await renderer.setTimerSticker(input);
+    tweens[0]?.step(0.5);
+    expect(timer.alpha).toBeCloseTo(0.5);
+
+    await renderer.clearTimerSticker({ durationMs: 200 });
+
+    // The retired fade-in can neither keep writing alpha nor snap it to the
+    // fade-in's toAlpha; the fade-out fades the captured alpha down to 0 and
+    // hides the slot on completion.
+    tweens[0]?.step(1);
+    tweens[0]?.done?.();
+    expect(timer.alpha).toBeCloseTo(0.5);
+    tweens[1]?.step(0.5);
+    expect(timer.alpha).toBeCloseTo(0.25);
+    tweens[1]?.done?.();
+    expect(timer.alpha).toBe(0);
+    expect(timer.visible).toBe(false);
+
+    // Symmetrically, a fresh timersticker retires a still-running fade-out:
+    // driving the stale fade-out's completion must not re-hide the slot that
+    // RenderTimer has just made visible again.
+    await renderer.clearTimerSticker({ durationMs: 200 });
+    await renderer.setTimerSticker({ ...input, fromAlpha: 0.3 });
+    tweens[2]?.step(1);
+    tweens[2]?.done?.();
+    expect(timer.visible).toBe(true);
+    tweens[3]?.step(0.5);
+    expect(timer.alpha).toBeCloseTo(0.65);
   });
 });
 

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1,6 +1,7 @@
 import {
   Container,
   Sprite,
+  Text,
   Texture,
   TextureSource,
   TilingSprite,
@@ -1697,5 +1698,98 @@ describe("PixiStoryRenderer blocker", () => {
     expect(renderer.blockerSlideFilter).toBe(filter);
     // The instant color write still routes through the attached filter.
     expect(filter.alpha).toBe(0);
+  });
+});
+
+function createSubtitleRenderer() {
+  const renderer = new PixiStoryRenderer(createContext()) as any;
+  renderer.subtitleText = new Text({
+    style: renderer.createOverlayTextStyle(24, 1280),
+    text: "",
+  });
+  renderer.subtitleText.visible = false;
+  renderer.app = {};
+  renderer.tween = vi.fn(async () => {});
+  renderer.layoutSubtitle = vi.fn();
+  return renderer;
+}
+
+describe("PixiStoryRenderer subtitle", () => {
+  const baseInput = {
+    alignment: "left" as const,
+    delayMs: 0,
+    sizePx: 24,
+    text: "hello",
+    widthPx: 1280,
+    x: 0,
+    y: 100,
+  };
+
+  it("fades a hidden subtitle in but never replays the fade for consecutive ones", async () => {
+    const renderer = createSubtitleRenderer();
+    const subtitle = renderer.subtitleText;
+
+    await renderer.setSubtitle({ ...baseInput });
+    expect(subtitle.visible).toBe(true);
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+    expect(renderer.tween.mock.calls[0][0]).toBe(150);
+
+    renderer.tween.mockClear();
+    await renderer.setSubtitle({ ...baseInput, text: "world" });
+    // Native `_SetHiddenInternal`: set_isHidden(false) is a no-op while the
+    // panel is already visible -- seamless text swap, no second fade-in.
+    expect(renderer.tween).not.toHaveBeenCalled();
+    expect(subtitle.text).toBe("world");
+
+    // After a real hide, the next subtitle fades in again.
+    await renderer.clearSubtitle(0);
+    expect(subtitle.visible).toBe(false);
+    await renderer.setSubtitle({ ...baseInput, text: "again" });
+    expect(renderer.tween).toHaveBeenCalledTimes(1);
+    expect(subtitle.text).toBe("again");
+  });
+
+  it("types against a transparent tail so the full-text layout is fixed from t0", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = createSubtitleRenderer();
+      const onTypingComplete = vi.fn();
+
+      const pending = renderer.setSubtitle({
+        ...baseInput,
+        delayMs: 10,
+        onTypingComplete,
+      });
+      const subtitle = renderer.subtitleText;
+      // t0 already carries the whole message as a hidden span, so wrapping
+      // matches the final layout instead of re-flowing per character.
+      expect(subtitle.text).toBe("<_c00000000>hello</_c00000000>");
+      await vi.advanceTimersByTimeAsync(10);
+      expect(subtitle.text).toBe("h<_c00000000>ello</_c00000000>");
+      await vi.advanceTimersByTimeAsync(40);
+      expect(subtitle.text).toBe("hello");
+      await pending;
+
+      expect(onTypingComplete).toHaveBeenCalledTimes(1);
+      expect(renderer.subtitleTypingTarget).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reports instant subtitles as finished and applies per-line alignment", async () => {
+    const renderer = createSubtitleRenderer();
+    const onTypingComplete = vi.fn();
+
+    await renderer.setSubtitle({
+      ...baseInput,
+      alignment: "center",
+      onTypingComplete,
+    });
+
+    expect(onTypingComplete).toHaveBeenCalledTimes(1);
+    // Native TextAnchor.UpperCenter aligns every wrapped line, not just the
+    // block.
+    expect(renderer.subtitleText.style.align).toBe("center");
   });
 });

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -3319,6 +3319,23 @@ describe("StoryRuntime", () => {
     expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "after" });
   });
 
+  it("clears the timer sticker instantly when skipping", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext(['[name="A"]before', "[SkipToThis]", '[name="B"]after']),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+    await runtime.skipNode();
+
+    // Native skip routes through StickerPanel.OnReset → _RecycleStickers,
+    // whose first step is AVGTimerView.StopTimer(0): instant hide.
+    expect(renderer.timerClearCalls).toEqual([{ durationMs: 0 }]);
+    expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "after" });
+  });
+
   it("disables segment skip when the story has no skip anchors", async () => {
     const runtime = new StoryRuntime(
       createContext(['[name="A"]before', '[name="B"]after']),

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -298,6 +298,19 @@ class FakeRenderer implements StoryRenderer {
   async setSubtitle(input: SubtitleInput): Promise<void> {
     this.subtitleCalls.push(input);
     this.typingActive = input.delayMs > 0;
+    // Faithful to PixiStoryRenderer: an instant subtitle is done typing the
+    // moment it is shown.
+    if (input.delayMs <= 0) input.onTypingComplete?.();
+  }
+
+  /**
+   * Emulates the real renderer clearing its typing target and running the
+   * `SubtitlePanel._OnTypeWriterEnd` callback when the typewriter ends on its
+   * own (as opposed to a click finishing it).
+   */
+  finishSubtitleTypingNaturally(): void {
+    this.typingActive = false;
+    this.subtitleCalls.at(-1)?.onTypingComplete?.();
   }
 
   async setTimerSticker(input: TimerStickerInput): Promise<void> {
@@ -2859,6 +2872,7 @@ describe("StoryRuntime", () => {
       {
         alignment: "center",
         delayMs: 0,
+        onTypingComplete: expect.any(Function),
         sizePx: 24,
         text: "HELLO",
         widthPx: 400,
@@ -2957,6 +2971,62 @@ describe("StoryRuntime", () => {
     await runtime.advance();
     expect(runtime.getState()).toBe("waiting_input");
     expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "ok" });
+  });
+
+  it("auto mode advances a subtitle once its typewriter ends naturally", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = new FakeRenderer();
+      const runtime = new StoryRuntime(
+        createContext([
+          '[subtitle(text="HELLO",alignment="center")]',
+          '[name="A"]ok',
+        ]),
+        renderer,
+        new FakeAudio(),
+        { typingIntervalMs: 40 },
+      );
+
+      await runtime.start();
+      expect(runtime.getState()).toBe("waiting_input");
+
+      runtime.setAutoPlayMode("button_auto");
+      // Enabling auto mid-typing must not fire a click before the typewriter
+      // has ended (native only raises the auto click from _OnTypeWriterEnd).
+      await vi.advanceTimersByTimeAsync(1600);
+      expect(renderer.lastDialogue).toEqual({ speaker: "", text: "" });
+
+      renderer.finishSubtitleTypingNaturally();
+      // Auto wait = 1.5s + messageLength(5) * 0.03s = 1.65s; the subtitle's
+      // own length must drive the wait, not the previous message's.
+      await vi.advanceTimersByTimeAsync(1500);
+      expect(renderer.lastDialogue).toEqual({ speaker: "", text: "" });
+      await vi.advanceTimersByTimeAsync(200);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "ok" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the subtitle immediately when skipping the story", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[subtitle(text="HELLO",alignment="center")]',
+        '[skipnode(mode="skip")]',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+    expect(runtime.getState()).toBe("waiting_input");
+
+    await runtime.skipNode();
+    // Native OnReset on skip clears the panel immediately (alpha=0, no fade).
+    expect(renderer.subtitleClearCalls).toEqual([0]);
+    expect(runtime.getState()).toBe("finished");
   });
 
   it("click skips typewriter first, then advances", async () => {


### PR DESCRIPTION
## 背景

基于官服客户端 2.7.61(build 2761)GameAssembly.dll 的 IDA 反编译复核(逆向笔记:arknights-rev `docs/impl-review/impl-review-timerclear-command.md`),timerclear 的 native 语义:

- `StickerPanel._ExcuteTimerClier`(VA `0x183e91a80`):只读 `duration`(默认 0.13),`afrom`/`ato`/`block` 全不读;无计时器时 no-op;`return 0` 永不阻塞。
- `AVGTimerView.StopTimer`(VA `0x183ed53e0`):先 `DOKill(_canvas, complete: false)` 杀掉进行中的 fade(直接杀、不清成完成态),再从当前 alpha `DOFade` 到硬编码 0;OnComplete 闭包(VA `0x183ed54f0`)仅隐藏 view 不销毁,下一条 timersticker 复用该槽。
- skip 侧:`StickerPanel.ShouldResetOnSkip` 默认 true → `OnReset → _RecycleStickers`(VA `0x183e93980`)第一步 `m_currentTimer?.StopTimer(0.0)`,计时器瞬时隐藏、倒计时 task 停止。
- `RenderTimer` 前置 `DOKill(_canvas, complete: true)`:新计时条开始前先终结旧 fade。

前端 review 差异计 P0×0、P1×0、P2×2、P3×2。本 PR 修复两个 P2;两个 P3(停表时机、隐藏后槽内残留)按 review 建议维持现状不动。

## 修复内容

| # | 严重度 | 差异 | 改法 |
| --- | --- | --- | --- |
| 1 | P2 | skip 路径不清理计时器:native skip 会 `StopTimer(0)`,前端 skip 后计时器仍在画面上走秒 | `engine/runtime.ts` `skipNode()` 在清理 interlude/spellsticker 之后追加 `void this.renderer.clearTimerSticker({ durationMs: 0 })`,附 `_RecycleStickers` provenance 注释 |
| 2 | P2 | fade tween 无 DOKill:clear 落在上一条 timersticker 的 1s fade-in 窗口内时,新旧两个 rAF 循环交替写 alpha(淡出轻微抖动),旧 tween 完成还会把 alpha 定格在其 toAlpha | `engine/rendering/PixiStoryRenderer.ts` 新增 `timerFadeSessionId` 计数器(仿既有 subtitle/sticker fade session 模式):`clearTimerSticker`/`setTimerSticker` 启动新 tween 前 bump 使旧失效,旧 tween 的 step/done 回调先校验 session;`destroy()` 时同样 bump |

补充说明:

- #2 中 clear 方向对应 native `StopTimer` 的 `DOKill(_canvas, false)`(杀掉 fade-in、从当前 alpha 淡到 0),set 方向对应 `RenderTimer` 的 `DOKill(_canvas, true)`(新 fade-in 前终结旧 fade-out,且不让旧回调把复用槽重新隐藏)。
- `stickerclear`(`_ExcuteClear → _RecycleStickers → StopTimer(0)`)经由同一 `clearTimerSticker` 自动获得会话失效,原行为不变。
- **与 PR #391(timersticker review)存在潜在重叠**:skip 清理与 fade session 两项在本 PR 基于 origin/main 独立实现,语义以 timerclear review 文档为准;合并时如两 PR 都改到 `clearTimerSticker`/`skipNode`,需 reconcile 后保留一份。

## 验证用剧情文件

语料根:`/home/xwbx/Documents/torappu/storage/asset/gamedata/latest/story/`,全语料 `[timerclear]` 共 5 文件 9 处:

- `obt/memory/story_jnight_1_1.txt`:73/142、154/196、204/236 —— 三轮 `timersticker → timerclear(duration=0)`,验证瞬时归零+隐藏、单槽复用。
- `obt/memory/story_mantra_1_1.txt`:90/135/150/335/382 —— `duration=2` 淡出路径;135+150 为连续两次 clear,验证 fade 目标固定 0、第二次仍生效。
- `activities/act35side/level_act35side_st03.txt`:167 —— `duration=2` 淡出。
- `activities/act27side/level_act27side_07_end.txt`:129 —— `duration=2` 淡出。
- `obt/memory/story_bobb_1_1.txt`:372 —— `duration=2` 淡出。

skip 路径(修复 #1)在上述文件中无 skipnode/SkipToThis 锚点组合可与计时器同屏,属前瞻对齐,由单测锁定。

## 测试

- `pnpm test`:224/224 通过(基线 222 + 新增 2:`tests/renderer.spec.ts` fade session 双向失效、`tests/runtime.spec.ts` skip 瞬时清理)。
- `STORY_CORPUS_ROOT=<语料根> pnpm test:story-log`:全语料对拍 2/2 通过。
- `pnpm exec vue-tsc -b`、`pnpm exec eslint <四个改动文件>`:均无错误。
