### PR TITLE
fix(sentry): disable screenshot input in feedback form

### DIFF
--- a/src/entries/sentry.ts
+++ b/src/entries/sentry.ts
@@ -3,6 +3,7 @@ import * as Sentry from "@sentry/browser";
 const feedback = Sentry.feedbackIntegration({
   autoInject: false,
   colorScheme: "system",
+  enableScreenshot: false,
 });
 
 Sentry.init({


### PR DESCRIPTION
## Summary
- StoryPlayer 的反馈入口拉起 Sentry Feedback 表单时，截图（图片）输入默认开启
- 在 `feedbackIntegration` 配置中显式设置 `enableScreenshot: false`，禁用反馈表单的图片附件输入

## Test plan
- [ ] 本地打开 StoryPlayer，点击反馈按钮，确认表单中不再出现添加截图按钮