### PR TITLE
fix(story-player): timersticker/timerclear 对齐 native:递增秒表、skip 清理与 fade 会话失效

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -356,9 +356,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   } | null = null;
   private subtitleTypingSessionId = 0;
   private readonly stickerRichChars = new Map<string, RichChar[]>();
+  private timerFadeSessionId = 0;
   private timerStickerInterval: ReturnType<typeof setInterval> | null = null;
   private timerStickerText: Text | null = null;
-  private timerFadeSessionId = 0;
 
   constructor(context: Context, onWarning?: (detail: string) => void) {
     this.context = context;
@@ -1926,12 +1926,17 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.spellStickerPanel.hide(id);
   }
 
+  /**
+   * Port scope: `Torappu.AVG.AVGTimerView.StopTimer` (2.7.61 VA 0x183ed53e0):
+   * `DOKill(_canvas, complete: false)` kills any in-flight fade tween without
+   * completing it, then fades from the current alpha to a hard-coded 0 and
+   * hides (never destroys) the view. The fade session counter is the DOKill
+   * analogue: bumping it here retires the previous fade's step/done callbacks
+   * so a timersticker fade-in still running when timerclear lands cannot keep
+   * writing alpha alongside the fade-out.
+   */
   async clearTimerSticker(input?: TimerClearInput): Promise<void> {
     this.clearTimerInterval();
-    // `AVGTimerView.StopTimer` precedes its fade with
-    // `DOKill(_canvas, complete: false)`; bumping the fade session is the Web
-    // equivalent -- an in-flight timersticker fade stops writing instead of
-    // fighting the fade-out.
     this.timerFadeSessionId += 1;
 
     const timer = this.timerStickerText;
@@ -2470,14 +2475,13 @@ export class PixiStoryRenderer implements StoryRenderer {
    * Port scope: `Torappu.AVG.StickerPanel._ExcuteTimerSticker` (native spelling)
    * and `AVGTimerView.RenderTimer`. Browser intervals and PIXI text adapt the
    * native timer view; this command itself never supplies a block boundary.
+   * RenderTimer precedes its fade with `DOKill(_canvas, complete: true)`: the
+   * fade session bump below retires any in-flight timer fade (e.g. a timerclear
+   * fade-out) before the new fade-in starts writing alpha.
    */
   async setTimerSticker(input: TimerStickerInput): Promise<void> {
     const timer = this.ensureTimerStickerText();
     this.clearTimerInterval();
-    // `AVGTimerView.RenderTimer` precedes every fade with
-    // `DOKill(_canvas, complete: true)`; bumping the fade session is the Web
-    // equivalent -- an in-flight timersticker/timerclear fade stops writing
-    // instead of racing the new one.
     this.timerFadeSessionId += 1;
 
     timer.style = this.createOverlayTextStyle(input.sizePx, input.widthPx);

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -2485,8 +2485,9 @@ export class PixiStoryRenderer implements StoryRenderer {
     timer.visible = true;
     timer.x = input.x;
     timer.y = input.y;
-    // `_StartCountTimer` fires `_TimerTick(0)` once immediately, so the slot
-    // briefly shows 00:00:00 before the first real tick lands.
+    // `_StartCountTimer` fires `_TimerTick(0)` once immediately and the timer
+    // counts up from there, so the slot reads 00:00:00 until the first whole
+    // second elapses.
     timer.text = this.formatTimer(0);
 
     const fadeSessionId = this.timerFadeSessionId;
@@ -2505,31 +2506,34 @@ export class PixiStoryRenderer implements StoryRenderer {
 
     if (input.limitSeconds === undefined || input.limitSeconds <= 0) return;
 
-    // Native counts down against a wall-clock deadline: `SetCountDown` stores
-    // endTime = start + time*1000 (ms) and `Update` feeds
-    // `_OverrideTimerTaskTick` = `Math.Max(endTime - curTime, 0)` into
-    // `_TimerTick` on every internal tick (~200ms). The first real value
-    // therefore lands within one tick, so the full initial value (time=9999
-    // -> 02:46:39) is visible almost immediately and each value holds for a
-    // whole second. A naive 1s interval that decrements a counter would park
-    // on 00:00:00 for a full second, never show the initial value, and drift
-    // under browser timer throttling.
-    const deadlineMs = Date.now() + input.limitSeconds * 1000;
+    // Native is a stopwatch, not a countdown: `SetCountDown` stores
+    // startTime = now, endTime = now + time*1000 (ms) on a wall clock, and
+    // `Update` feeds `_OverrideTimerTaskTick` = `Math.Max(curTime -
+    // startTime, 0)` -- elapsed milliseconds, verified at the instruction
+    // level in build 2761 (an earlier reading of `endTime - curTime` had the
+    // operands swapped) -- into `_TimerTick` =
+    // TimeSpan.FromMilliseconds(...). The text therefore climbs
+    // 00:00:00 -> 00:00:01 -> ...; reaching `time` fires `_TimerEnd`, which
+    // only clears the task, so the display freezes at the cap
+    // (time=9999 -> 02:46:39) and stays visible. Deriving elapsed from the
+    // wall clock also avoids interval drift under browser throttling.
+    const startMs = Date.now();
+    const capSeconds = input.limitSeconds;
     this.timerStickerInterval = setInterval(
       () => {
-        const remainingSeconds = Math.max(
-          0,
-          Math.ceil((deadlineMs - Date.now()) / 1000),
+        const elapsedSeconds = Math.min(
+          capSeconds,
+          Math.floor((Date.now() - startMs) / 1000),
         );
         const timerText = this.timerStickerText;
         if (!timerText) return;
 
-        const text = this.formatTimer(remainingSeconds);
+        const text = this.formatTimer(elapsedSeconds);
         if (timerText.text !== text) timerText.text = text;
-        if (remainingSeconds <= 0) this.clearTimerInterval();
+        if (elapsedSeconds >= capSeconds) this.clearTimerInterval();
       },
-      // 200ms mirrors the native CountDownTask internal tick; the deadline
-      // math makes extra fires harmless (same ceil value, no text rewrite).
+      // 200ms mirrors the native CountDownTask internal tick; the wall-clock
+      // math makes extra fires harmless (same floor value, no text rewrite).
       200,
     );
   }

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -358,6 +358,7 @@ export class PixiStoryRenderer implements StoryRenderer {
   private readonly stickerRichChars = new Map<string, RichChar[]>();
   private timerStickerInterval: ReturnType<typeof setInterval> | null = null;
   private timerStickerText: Text | null = null;
+  private timerFadeSessionId = 0;
 
   constructor(context: Context, onWarning?: (detail: string) => void) {
     this.context = context;
@@ -524,6 +525,7 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.subtitleText = null;
     this.timerStickerText = null;
     this.clearTimerInterval();
+    this.timerFadeSessionId += 1;
     this.stickerTexts.clear();
     this.stickerFadeSessionIds.clear();
     this.stickerTypingTargets.clear();
@@ -1926,6 +1928,11 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   async clearTimerSticker(input?: TimerClearInput): Promise<void> {
     this.clearTimerInterval();
+    // `AVGTimerView.StopTimer` precedes its fade with
+    // `DOKill(_canvas, complete: false)`; bumping the fade session is the Web
+    // equivalent -- an in-flight timersticker fade stops writing instead of
+    // fighting the fade-out.
+    this.timerFadeSessionId += 1;
 
     const timer = this.timerStickerText;
     if (!timer) return;
@@ -1944,12 +1951,15 @@ export class PixiStoryRenderer implements StoryRenderer {
       return;
     }
 
+    const fadeSessionId = this.timerFadeSessionId;
     void this.tween(
       input.durationMs,
       (progress) => {
+        if (this.timerFadeSessionId !== fadeSessionId) return;
         timer.alpha = fromAlpha * (1 - progress);
       },
       () => {
+        if (this.timerFadeSessionId !== fadeSessionId) return;
         timer.alpha = 0;
         timer.visible = false;
       },
@@ -2464,35 +2474,64 @@ export class PixiStoryRenderer implements StoryRenderer {
   async setTimerSticker(input: TimerStickerInput): Promise<void> {
     const timer = this.ensureTimerStickerText();
     this.clearTimerInterval();
+    // `AVGTimerView.RenderTimer` precedes every fade with
+    // `DOKill(_canvas, complete: true)`; bumping the fade session is the Web
+    // equivalent -- an in-flight timersticker/timerclear fade stops writing
+    // instead of racing the new one.
+    this.timerFadeSessionId += 1;
 
     timer.style = this.createOverlayTextStyle(input.sizePx, input.widthPx);
     timer.alpha = input.fromAlpha;
     timer.visible = true;
     timer.x = input.x;
     timer.y = input.y;
+    // `_StartCountTimer` fires `_TimerTick(0)` once immediately, so the slot
+    // briefly shows 00:00:00 before the first real tick lands.
     timer.text = this.formatTimer(0);
 
+    const fadeSessionId = this.timerFadeSessionId;
     void this.tween(
       input.durationMs > 0 ? input.durationMs : 130,
       (progress) => {
+        if (this.timerFadeSessionId !== fadeSessionId) return;
         timer.alpha =
           input.fromAlpha + (input.toAlpha - input.fromAlpha) * progress;
       },
       () => {
+        if (this.timerFadeSessionId !== fadeSessionId) return;
         timer.alpha = input.toAlpha;
       },
     );
 
     if (input.limitSeconds === undefined || input.limitSeconds <= 0) return;
 
-    let remainingSeconds = input.limitSeconds;
-    this.timerStickerInterval = setInterval(() => {
-      remainingSeconds = Math.max(0, remainingSeconds - 1);
-      if (!this.timerStickerText) return;
+    // Native counts down against a wall-clock deadline: `SetCountDown` stores
+    // endTime = start + time*1000 (ms) and `Update` feeds
+    // `_OverrideTimerTaskTick` = `Math.Max(endTime - curTime, 0)` into
+    // `_TimerTick` on every internal tick (~200ms). The first real value
+    // therefore lands within one tick, so the full initial value (time=9999
+    // -> 02:46:39) is visible almost immediately and each value holds for a
+    // whole second. A naive 1s interval that decrements a counter would park
+    // on 00:00:00 for a full second, never show the initial value, and drift
+    // under browser timer throttling.
+    const deadlineMs = Date.now() + input.limitSeconds * 1000;
+    this.timerStickerInterval = setInterval(
+      () => {
+        const remainingSeconds = Math.max(
+          0,
+          Math.ceil((deadlineMs - Date.now()) / 1000),
+        );
+        const timerText = this.timerStickerText;
+        if (!timerText) return;
 
-      this.timerStickerText.text = this.formatTimer(remainingSeconds);
-      if (remainingSeconds <= 0) this.clearTimerInterval();
-    }, 1000);
+        const text = this.formatTimer(remainingSeconds);
+        if (timerText.text !== text) timerText.text = text;
+        if (remainingSeconds <= 0) this.clearTimerInterval();
+      },
+      // 200ms mirrors the native CountDownTask internal tick; the deadline
+      // math makes extra fires harmless (same ceil value, no text rewrite).
+      200,
+    );
   }
 
   private async createUi(): Promise<void> {
@@ -3815,7 +3854,9 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   private formatTimer(totalSeconds: number): string {
-    const hours = Math.floor(totalSeconds / 3600);
+    // `_TimerTick` formats `TimeSpan.FromMilliseconds(...)`; `TimeSpan.Hours`
+    // wraps at 24, so time >= 86400 displays modulo a day (100000 -> 03:46:40).
+    const hours = Math.floor(totalSeconds / 3600) % 24;
     const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = Math.floor(totalSeconds % 60);
     return [hours, minutes, seconds]

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -357,6 +357,19 @@ export class PixiStoryRenderer implements StoryRenderer {
   private subtitleTypingSessionId = 0;
   private readonly stickerRichChars = new Map<string, RichChar[]>();
   private timerFadeSessionId = 0;
+  /**
+   * Mirrors `AVGTimerView.m_countTimerTask != null`. It gates the inline
+   * `_TimerTick(0)` that `_StartCountTimer` only fires when it has to build a
+   * task, and it survives a `StopTimer` fade -- native nulls the field from
+   * that fade's OnComplete, not when the fade starts.
+   */
+  private timerTaskActive = false;
+  /**
+   * The pending `StopTimer` OnComplete (`<StopTimer>b__7_0`, VA 0x183ed54f0).
+   * `RenderTimer`'s `DOKill(_canvas, complete: true)` runs it; `StopTimer`'s own
+   * `DOKill(_canvas, complete: false)` discards it.
+   */
+  private timerStopFadeComplete: (() => void) | null = null;
   private timerStickerInterval: ReturnType<typeof setInterval> | null = null;
   private timerStickerText: Text | null = null;
 
@@ -526,6 +539,8 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.timerStickerText = null;
     this.clearTimerInterval();
     this.timerFadeSessionId += 1;
+    this.timerStopFadeComplete = null;
+    this.timerTaskActive = false;
     this.stickerTexts.clear();
     this.stickerFadeSessionIds.clear();
     this.stickerTypingTargets.clear();
@@ -1937,26 +1952,45 @@ export class PixiStoryRenderer implements StoryRenderer {
    */
   async clearTimerSticker(input?: TimerClearInput): Promise<void> {
     this.clearTimerInterval();
+    // `DOKill(_canvas, complete: false)`: an earlier fade is dropped mid-flight,
+    // so a StopTimer fade it may have been running never reaches its OnComplete.
     this.timerFadeSessionId += 1;
+    this.timerStopFadeComplete = null;
 
     const timer = this.timerStickerText;
-    if (!timer) return;
+    if (!timer) {
+      this.timerTaskActive = false;
+      return;
+    }
 
     if (!input) {
+      this.timerTaskActive = false;
       timer.text = "";
       timer.visible = false;
       timer.alpha = 1;
       return;
     }
 
-    const fromAlpha = timer.alpha;
-    if (input.durationMs <= 0) {
+    // `<StopTimer>b__7_0` is what actually retires the clock: it nulls
+    // `m_countTimerTask` and deactivates the view. Until this runs the slot is
+    // still considered to own a task, which is what makes a timersticker
+    // arriving mid-fade reuse it instead of rebuilding it.
+    const finishStopFade = (): void => {
+      this.timerStopFadeComplete = null;
+      this.clearTimerInterval();
+      this.timerTaskActive = false;
       timer.alpha = 0;
       timer.visible = false;
+    };
+
+    const fromAlpha = timer.alpha;
+    if (input.durationMs <= 0) {
+      finishStopFade();
       return;
     }
 
     const fadeSessionId = this.timerFadeSessionId;
+    this.timerStopFadeComplete = finishStopFade;
     void this.tween(
       input.durationMs,
       (progress) => {
@@ -1965,8 +1999,7 @@ export class PixiStoryRenderer implements StoryRenderer {
       },
       () => {
         if (this.timerFadeSessionId !== fadeSessionId) return;
-        timer.alpha = 0;
-        timer.visible = false;
+        finishStopFade();
       },
     );
   }
@@ -2475,25 +2508,32 @@ export class PixiStoryRenderer implements StoryRenderer {
    * Port scope: `Torappu.AVG.StickerPanel._ExcuteTimerSticker` (native spelling)
    * and `AVGTimerView.RenderTimer`. Browser intervals and PIXI text adapt the
    * native timer view; this command itself never supplies a block boundary.
-   * RenderTimer precedes its fade with `DOKill(_canvas, complete: true)`: the
-   * fade session bump below retires any in-flight timer fade (e.g. a timerclear
-   * fade-out) before the new fade-in starts writing alpha.
+   * The step order below is RenderTimer's own: transform and font first, then
+   * `_StartCountTimer`, then the `_ShowTimer` fade, and only after RenderTimer
+   * returns does `_ExcuteTimerSticker` re-activate the view.
    */
   async setTimerSticker(input: TimerStickerInput): Promise<void> {
     const timer = this.ensureTimerStickerText();
-    this.clearTimerInterval();
-    this.timerFadeSessionId += 1;
 
     timer.style = this.createOverlayTextStyle(input.sizePx, input.widthPx);
-    timer.alpha = input.fromAlpha;
-    timer.visible = true;
     timer.x = input.x;
     timer.y = input.y;
-    // `_StartCountTimer` fires `_TimerTick(0)` once immediately and the timer
-    // counts up from there, so the slot reads 00:00:00 until the first whole
-    // second elapses.
-    timer.text = this.formatTimer(0);
 
+    // RenderTimer guards `_StartCountTimer` with `time > 0`; with the parameter
+    // absent (native default -1) neither the text nor a running clock is
+    // touched.
+    if (input.limitSeconds !== undefined && input.limitSeconds > 0)
+      this.startTimerCountUp(timer, input.limitSeconds);
+
+    // `DOKill(_canvas, complete: true)`, the asymmetric counterpart of
+    // StopTimer's `complete: false`: it *finishes* a timerclear fade still in
+    // flight, which runs `<StopTimer>b__7_0` and nulls `m_countTimerTask` --
+    // discarding the clock restarted just above, so the text stays frozen at
+    // its last value while the view still fades back in.
+    this.timerFadeSessionId += 1;
+    this.timerStopFadeComplete?.();
+
+    timer.alpha = input.fromAlpha;
     const fadeSessionId = this.timerFadeSessionId;
     void this.tween(
       input.durationMs > 0 ? input.durationMs : 130,
@@ -2508,33 +2548,54 @@ export class PixiStoryRenderer implements StoryRenderer {
       },
     );
 
-    if (input.limitSeconds === undefined || input.limitSeconds <= 0) return;
+    // `SetActiveIfNecessary(gameObject, true)` trails RenderTimer, so it undoes
+    // the deactivation a completed StopTimer fade may have just performed.
+    timer.visible = true;
+  }
 
-    // Native is a stopwatch, not a countdown: `SetCountDown` stores
-    // startTime = now, endTime = now + time*1000 (ms) on a wall clock, and
-    // `Update` feeds `_OverrideTimerTaskTick` = `Math.Max(curTime -
-    // startTime, 0)` -- elapsed milliseconds, verified at the instruction
-    // level in build 2761 (an earlier reading of `endTime - curTime` had the
-    // operands swapped) -- into `_TimerTick` =
-    // TimeSpan.FromMilliseconds(...). The text therefore climbs
-    // 00:00:00 -> 00:00:01 -> ...; reaching `time` fires `_TimerEnd`, which
-    // only clears the task, so the display freezes at the cap
-    // (time=9999 -> 02:46:39) and stays visible. Deriving elapsed from the
-    // wall clock also avoids interval drift under browser throttling.
+  /**
+   * Port scope: `Torappu.AVG.AVGTimerView._StartCountTimer` (2.7.61 VA
+   * 0x183ed5830) plus the `CountDownTask` it drives.
+   *
+   * Native is a stopwatch, not a countdown: `SetCountDown` (0x181cefc50) stores
+   * startTime = now, endTime = now + time*1000 (ms) on a wall clock, and
+   * `Update` feeds `_OverrideTimerTaskTick` = `Math.Max(curTime - startTime, 0)`
+   * -- elapsed milliseconds, verified at the instruction level in build 2761
+   * (an earlier reading of `endTime - curTime` had the operands swapped) -- into
+   * `_TimerTick` = TimeSpan.FromMilliseconds(...). The text therefore climbs
+   * 00:00:00 -> 00:00:01 -> ...; reaching `time` fires `_TimerEnd`, which only
+   * clears the task, so the display freezes at the cap (time=9999 -> 02:46:39)
+   * and stays visible. Deriving elapsed from the wall clock also avoids interval
+   * drift under browser throttling.
+   */
+  private startTimerCountUp(timer: Text, capSeconds: number): void {
+    this.clearTimerInterval();
+
+    if (!this.timerTaskActive) {
+      // The inline `_TimerTick(0)` that seeds 00:00:00 lives in the branch that
+      // builds the task, so a slot whose clock is still alive is merely re-based
+      // by `SetCountDown` and keeps showing its current value.
+      this.timerTaskActive = true;
+      timer.text = this.formatTimer(0);
+    }
+
     const startMs = Date.now();
-    const capSeconds = input.limitSeconds;
     this.timerStickerInterval = setInterval(
       () => {
         const elapsedSeconds = Math.min(
           capSeconds,
-          Math.floor((Date.now() - startMs) / 1000),
+          // `Math.Max(..., 0)`: a wall clock can step backwards.
+          Math.max(0, Math.floor((Date.now() - startMs) / 1000)),
         );
         const timerText = this.timerStickerText;
         if (!timerText) return;
 
         const text = this.formatTimer(elapsedSeconds);
         if (timerText.text !== text) timerText.text = text;
-        if (elapsedSeconds >= capSeconds) this.clearTimerInterval();
+        if (elapsedSeconds >= capSeconds) {
+          this.clearTimerInterval();
+          this.timerTaskActive = false;
+        }
       },
       // 200ms mirrors the native CountDownTask internal tick; the wall-clock
       // math makes extra fires harmless (same floor value, no text rewrite).

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -738,22 +738,31 @@ export class StoryRuntime {
     }
 
     this.pendingInputEffect = null;
-    // Native port: both executors on AVGCharacterCutinPanel reset on skip --
-    // ShouldResetOnSkip() @ 0x183e492b0 returns true and _Reset @ 0x183e4af80
-    // empties the slot pool / _slots before resetting the interlude
-    // controller, so a skipped node must not leave cutin slots behind.
-    await this.renderer.clearInterludes();
-    await this.renderer.clearCharacterCutin();
-    await this.renderer.clearSpellStickers();
-    // Native: SubtitlePanel.ShouldResetOnSkip() is true, so a skip resets the
-    // panel through OnReset -- alpha to 0 immediately (no tween) plus a
-    // typewriter reset. A stale subtitle must not survive the skip.
-    await this.renderer.clearSubtitle(0);
-    // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping fires
-    // `OnReset -> _RecycleStickers`, whose first step is `StopTimer(0)` -- the
-    // timer hides instantly (the slot itself is kept for reuse). Story end
-    // keeps the timer on screen, matching `OnStoryEnd` (only unbinds Event=5).
-    void this.renderer.clearTimerSticker({ durationMs: 0 });
+    // Native port: AVGController.SkipStory (0x183e1a150) reaches
+    // _ResetComponentsOnSkip (0x183e1d3f0) only on the two paths that keep
+    // playing -- jumping to a SkipToThis anchor, and jumping to the next
+    // skipnode label when get_isSkippable() is false. When the story *is*
+    // skippable in the current mode (or no skip node is left) it takes
+    // StopStory("Skipped") and returns without resetting a single component, so
+    // a skip that ends the story leaves the screen exactly as it was.
+    // `shouldResume` is that same fork.
+    if (shouldResume) {
+      // Native port: both executors on AVGCharacterCutinPanel reset on skip --
+      // ShouldResetOnSkip() @ 0x183e492b0 returns true and _Reset @ 0x183e4af80
+      // empties the slot pool / _slots before resetting the interlude
+      // controller, so a skipped node must not leave cutin slots behind.
+      await this.renderer.clearInterludes();
+      await this.renderer.clearCharacterCutin();
+      await this.renderer.clearSpellStickers();
+      // Native: SubtitlePanel.ShouldResetOnSkip() is true, so a skip resets the
+      // panel through OnReset -- alpha to 0 immediately (no tween) plus a
+      // typewriter reset. A stale subtitle must not survive the skip.
+      await this.renderer.clearSubtitle(0);
+      // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping fires
+      // `OnReset -> _RecycleStickers`, whose first step is `StopTimer(0)` --
+      // the timer hides instantly (the slot itself is kept for reuse).
+      await this.renderer.clearTimerSticker({ durationMs: 0 });
+    }
 
     this.cancelTyping();
     if (shouldResume) {

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -759,9 +759,17 @@ export class StoryRuntime {
       // typewriter reset. A stale subtitle must not survive the skip.
       await this.renderer.clearSubtitle(0);
       // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping fires
-      // `OnReset -> _RecycleStickers`, whose first step is `StopTimer(0)` --
-      // the timer hides instantly (the slot itself is kept for reuse).
+      // `OnReset -> _RecycleStickers` (0x183e93980), in that function's own
+      // order. First `StopTimer(0)` -- the timer hides instantly, the slot
+      // itself being kept for reuse.
       await this.renderer.clearTimerSticker({ durationMs: 0 });
+      // Then every entry of `m_stickerDict` gets `HideSticker(0)` before the
+      // dictionary is emptied and `m_currentSticker` nulled. `HideSticker`
+      // substitutes 0.15s for any duration <= 0, the same 150ms stickerclear
+      // fades with, and dropping the ids is what lets a reused id show again
+      // instead of being read as the hide half of the toggle.
+      this.stickerIds.clear();
+      await this.renderer.clearStickers(150);
     }
 
     this.cancelTyping();

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -749,6 +749,11 @@ export class StoryRuntime {
     // panel through OnReset -- alpha to 0 immediately (no tween) plus a
     // typewriter reset. A stale subtitle must not survive the skip.
     await this.renderer.clearSubtitle(0);
+    // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping fires
+    // `OnReset -> _RecycleStickers`, whose first step is `StopTimer(0)` -- the
+    // countdown hides instantly (the slot itself is kept for reuse). Story end
+    // keeps the timer on screen, matching `OnStoryEnd` (only unbinds Event=5).
+    void this.renderer.clearTimerSticker({ durationMs: 0 });
 
     this.cancelTyping();
     if (shouldResume) {
@@ -2640,6 +2645,10 @@ export class StoryRuntime {
 
       case "timersticker": {
         // Native port: Torappu.AVG.StickerPanel._ExcuteTimerSticker. This is a
+        // single-slot, never-blocking executor (native returns hardcoded
+        // false): the timer view is created once and reused, and only
+        // time/x/y/width/size/duration/afrom/ato are read -- id/text/block
+        // are ignored.
         await this.renderer.setTimerSticker({
           durationMs:
             Math.max(0, toNumber(this.exactArg(args, "duration"), 1) * 1000) ||

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -751,7 +751,7 @@ export class StoryRuntime {
     await this.renderer.clearSubtitle(0);
     // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping fires
     // `OnReset -> _RecycleStickers`, whose first step is `StopTimer(0)` -- the
-    // countdown hides instantly (the slot itself is kept for reuse). Story end
+    // timer hides instantly (the slot itself is kept for reuse). Story end
     // keeps the timer on screen, matching `OnStoryEnd` (only unbinds Event=5).
     void this.renderer.clearTimerSticker({ durationMs: 0 });
 

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1521,6 +1521,101 @@ describe("PixiStoryRenderer", () => {
     tweens[4]!.step(1);
     expect(timer.alpha).toBeCloseTo(0.9);
   });
+
+  it("lets a completed timerclear fade retire the clock a timersticker just restarted", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = new PixiStoryRenderer(createContext()) as any;
+      const timer = {
+        alpha: 1,
+        style: null,
+        text: "",
+        visible: false,
+        x: 0,
+        y: 0,
+      };
+      renderer.timerStickerText = timer;
+      renderer.ensureTimerStickerText = () => timer;
+      renderer.tween = vi.fn(async () => {});
+      const base = {
+        durationMs: 0,
+        fromAlpha: 0,
+        limitSeconds: 9999,
+        sizePx: 24,
+        toAlpha: 1,
+        widthPx: 1280,
+        x: 0,
+        y: 0,
+      };
+
+      await renderer.setTimerSticker(base);
+      vi.advanceTimersByTime(3000);
+      expect(timer.text).toBe("00:00:03");
+
+      // A fading timerclear has not run `<StopTimer>b__7_0` yet, so the slot
+      // still owns its count task: the next timersticker reuses it (no
+      // 00:00:00 reseed) and RenderTimer's `DOKill(_canvas, complete: true)`
+      // then completes that fade, nulling `m_countTimerTask` outright.
+      await renderer.clearTimerSticker({ durationMs: 2000 });
+      await renderer.setTimerSticker(base);
+
+      expect(timer.text).toBe("00:00:03");
+      expect(timer.visible).toBe(true);
+      expect(renderer.timerStickerInterval).toBeNull();
+      vi.advanceTimersByTime(5000);
+      expect(timer.text).toBe("00:00:03");
+
+      // With the task gone, the following timersticker rebuilds it and the
+      // inline `_TimerTick(0)` reseeds the slot.
+      await renderer.setTimerSticker(base);
+      expect(timer.text).toBe("00:00:00");
+      vi.advanceTimersByTime(1000);
+      expect(timer.text).toBe("00:00:01");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves the timer slot untouched when timersticker omits time", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = new PixiStoryRenderer(createContext()) as any;
+      const timer = {
+        alpha: 1,
+        style: null,
+        text: "",
+        visible: false,
+        x: 0,
+        y: 0,
+      };
+      renderer.timerStickerText = timer;
+      renderer.ensureTimerStickerText = () => timer;
+      renderer.tween = vi.fn(async () => {});
+      const base = {
+        durationMs: 0,
+        fromAlpha: 0,
+        sizePx: 24,
+        toAlpha: 1,
+        widthPx: 1280,
+        x: 0,
+        y: 0,
+      };
+
+      await renderer.setTimerSticker({ ...base, limitSeconds: 9999 });
+      vi.advanceTimersByTime(2000);
+      expect(timer.text).toBe("00:00:02");
+
+      // `RenderTimer` skips `_StartCountTimer` unless `time > 0` (native
+      // default -1), so the running clock keeps its original start and the
+      // slot is never reseeded to 00:00:00.
+      await renderer.setTimerSticker(base);
+      expect(timer.text).toBe("00:00:02");
+      vi.advanceTimersByTime(1000);
+      expect(timer.text).toBe("00:00:03");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("PixiStoryRenderer blocker", () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1364,7 +1364,7 @@ describe("PixiStoryRenderer", () => {
     expect(360 - root.position.y).toBe(0);
   });
 
-  it("shows the timer sticker's full initial value instead of parking on 00:00:00", async () => {
+  it("counts the timer sticker up from 00:00:00 like the native stopwatch", async () => {
     vi.useFakeTimers();
     try {
       const renderer = new PixiStoryRenderer(createContext()) as any;
@@ -1392,27 +1392,27 @@ describe("PixiStoryRenderer", () => {
       });
 
       // `AVGTimerView._StartCountTimer` fires `_TimerTick(0)` once
-      // immediately, so 00:00:00 is visible for one internal tick at most.
+      // immediately and the value then counts up from zero -- `time` is a
+      // timeout cap, not the initial value (02:46:39 must never show here).
       expect(timer.text).toBe("00:00:00");
 
-      // The first real value lands within the ~200ms internal tick: the full
-      // initial value (time=9999 -> 02:46:39) shows right away instead of a
-      // whole second of 00:00:00 followed by a skip straight to 02:46:38.
+      // Within the ~200ms internal tick the elapsed value is still 0s; the
+      // first change lands on the whole-second boundary.
       vi.advanceTimersByTime(200);
-      expect(timer.text).toBe("02:46:39");
+      expect(timer.text).toBe("00:00:00");
 
-      // Each value holds for a whole second, and the countdown is
-      // deadline-based, so wall-clock gaps cannot drift it.
+      // Each value climbs by one per second, derived from the wall clock, so
+      // throttled intervals cannot drift it.
       vi.advanceTimersByTime(800);
-      expect(timer.text).toBe("02:46:38");
+      expect(timer.text).toBe("00:00:01");
       vi.advanceTimersByTime(10_000);
-      expect(timer.text).toBe("02:46:28");
+      expect(timer.text).toBe("00:00:11");
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it("keeps the expired timer visible at 00:00:00 and wraps hours at 24", async () => {
+  it("freezes the timer at the time cap and wraps hours at 24", async () => {
     vi.useFakeTimers();
     try {
       const renderer = new PixiStoryRenderer(createContext()) as any;
@@ -1438,18 +1438,19 @@ describe("PixiStoryRenderer", () => {
       };
 
       // `TimeSpan.Hours` wraps at 24: 100000s renders as 03:46:40.
-      await renderer.setTimerSticker({ ...base, limitSeconds: 100_000 });
-      vi.advanceTimersByTime(200);
-      expect(timer.text).toBe("03:46:40");
+      expect(renderer.formatTimer(100_000)).toBe("03:46:40");
 
-      // `_TimerEnd` only clears the task; the view stays visible at 00:00:00
-      // and the interval stops once the deadline is reached.
+      // Reaching `time` fires `_TimerEnd`, which only clears the task; the
+      // view stays visible frozen at the cap (not 00:00:00) and the interval
+      // stops once the cap is reached.
       await renderer.setTimerSticker({ ...base, limitSeconds: 2 });
       expect(timer.text).toBe("00:00:00");
       vi.advanceTimersByTime(2200);
-      expect(timer.text).toBe("00:00:00");
+      expect(timer.text).toBe("00:00:02");
       expect(timer.visible).toBe(true);
       expect(renderer.timerStickerInterval).toBeNull();
+      vi.advanceTimersByTime(1000);
+      expect(timer.text).toBe("00:00:02");
     } finally {
       vi.useRealTimers();
     }

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1363,6 +1363,163 @@ describe("PixiStoryRenderer", () => {
     expect(root.position.x - 640).toBe(-160);
     expect(360 - root.position.y).toBe(0);
   });
+
+  it("shows the timer sticker's full initial value instead of parking on 00:00:00", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = new PixiStoryRenderer(createContext()) as any;
+      const timer = {
+        alpha: 1,
+        style: null,
+        text: "",
+        visible: false,
+        x: 0,
+        y: 0,
+      };
+      renderer.timerStickerText = timer;
+      renderer.ensureTimerStickerText = () => timer;
+      renderer.tween = vi.fn(async () => {});
+
+      await renderer.setTimerSticker({
+        durationMs: 0,
+        fromAlpha: 0,
+        limitSeconds: 9999,
+        sizePx: 24,
+        toAlpha: 1,
+        widthPx: 1280,
+        x: 935,
+        y: 80,
+      });
+
+      // `AVGTimerView._StartCountTimer` fires `_TimerTick(0)` once
+      // immediately, so 00:00:00 is visible for one internal tick at most.
+      expect(timer.text).toBe("00:00:00");
+
+      // The first real value lands within the ~200ms internal tick: the full
+      // initial value (time=9999 -> 02:46:39) shows right away instead of a
+      // whole second of 00:00:00 followed by a skip straight to 02:46:38.
+      vi.advanceTimersByTime(200);
+      expect(timer.text).toBe("02:46:39");
+
+      // Each value holds for a whole second, and the countdown is
+      // deadline-based, so wall-clock gaps cannot drift it.
+      vi.advanceTimersByTime(800);
+      expect(timer.text).toBe("02:46:38");
+      vi.advanceTimersByTime(10_000);
+      expect(timer.text).toBe("02:46:28");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the expired timer visible at 00:00:00 and wraps hours at 24", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = new PixiStoryRenderer(createContext()) as any;
+      const timer = {
+        alpha: 1,
+        style: null,
+        text: "",
+        visible: false,
+        x: 0,
+        y: 0,
+      };
+      renderer.timerStickerText = timer;
+      renderer.ensureTimerStickerText = () => timer;
+      renderer.tween = vi.fn(async () => {});
+      const base = {
+        durationMs: 0,
+        fromAlpha: 0,
+        sizePx: 24,
+        toAlpha: 1,
+        widthPx: 1280,
+        x: 0,
+        y: 0,
+      };
+
+      // `TimeSpan.Hours` wraps at 24: 100000s renders as 03:46:40.
+      await renderer.setTimerSticker({ ...base, limitSeconds: 100_000 });
+      vi.advanceTimersByTime(200);
+      expect(timer.text).toBe("03:46:40");
+
+      // `_TimerEnd` only clears the task; the view stays visible at 00:00:00
+      // and the interval stops once the deadline is reached.
+      await renderer.setTimerSticker({ ...base, limitSeconds: 2 });
+      expect(timer.text).toBe("00:00:00");
+      vi.advanceTimersByTime(2200);
+      expect(timer.text).toBe("00:00:00");
+      expect(timer.visible).toBe(true);
+      expect(renderer.timerStickerInterval).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("drops stale timer fades when a newer timersticker or clear takes over", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const timer = {
+      alpha: 1,
+      style: null,
+      text: "",
+      visible: false,
+      x: 0,
+      y: 0,
+    };
+    renderer.timerStickerText = timer;
+    renderer.ensureTimerStickerText = () => timer;
+    const tweens: Array<{
+      done: () => void;
+      step: (progress: number) => void;
+    }> = [];
+    renderer.tween = vi.fn(
+      async (
+        _durationMs: number,
+        step: (progress: number) => void,
+        done?: () => void,
+      ) => {
+        tweens.push({ done: done ?? (() => {}), step });
+      },
+    );
+    const base = {
+      durationMs: 1000,
+      fromAlpha: 0,
+      limitSeconds: undefined,
+      sizePx: 24,
+      toAlpha: 1,
+      widthPx: 1280,
+      x: 0,
+      y: 0,
+    };
+
+    // Fade-in half done when timerclear arrives: the stale fade-in's late
+    // step/done must not write alpha after the fade-out took over.
+    await renderer.setTimerSticker(base);
+    tweens[0]!.step(0.5);
+    expect(timer.alpha).toBe(0.5);
+    await renderer.clearTimerSticker({ durationMs: 300 });
+    tweens[0]!.step(1);
+    tweens[0]!.done();
+    expect(timer.alpha).toBe(0.5);
+    tweens[1]!.step(1);
+    tweens[1]!.done();
+    expect(timer.alpha).toBe(0);
+    expect(timer.visible).toBe(false);
+
+    // Fade-out half done when a new timersticker reactivates the slot: the
+    // stale fade-out's done must not re-hide it or clamp its alpha.
+    await renderer.setTimerSticker({ ...base, fromAlpha: 0.4 });
+    expect(timer.visible).toBe(true);
+    await renderer.clearTimerSticker({ durationMs: 300 });
+    tweens[3]!.step(0.5);
+    expect(timer.alpha).toBeCloseTo(0.2);
+    await renderer.setTimerSticker({ ...base, fromAlpha: 0.2, toAlpha: 0.9 });
+    tweens[3]!.step(1);
+    tweens[3]!.done();
+    expect(timer.visible).toBe(true);
+    expect(timer.alpha).toBe(0.2);
+    tweens[4]!.step(1);
+    expect(timer.alpha).toBeCloseTo(0.9);
+  });
 });
 
 describe("PixiStoryRenderer blocker", () => {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -3319,6 +3319,23 @@ describe("StoryRuntime", () => {
     expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "after" });
   });
 
+  it("clears the timer sticker instantly when skipping", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext(['[name="A"]before', "[SkipToThis]", '[name="B"]after']),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+    await runtime.skipNode();
+
+    // Native skip routes through StickerPanel.OnReset → _RecycleStickers,
+    // whose first step is AVGTimerView.StopTimer(0): instant hide.
+    expect(renderer.timerClearCalls).toEqual([{ durationMs: 0 }]);
+    expect(renderer.lastDialogue).toEqual({ speaker: "B", text: "after" });
+  });
+
   it("disables segment skip when the story has no skip anchors", async () => {
     const runtime = new StoryRuntime(
       createContext(['[name="A"]before', '[name="B"]after']),

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -3413,6 +3413,33 @@ describe("StoryRuntime", () => {
     expect(runtime.getState()).toBe("waiting_input");
   });
 
+  it("recycles sticker slots when skipping to the next node", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[Sticker(id="st1",text="up",x=300,y=270,block=true)]',
+        '[skipnode(mode="nofirstskip")]',
+        '[Sticker(id="st1",text="after",x=300,y=270)]',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+    expect(renderer.stickerCalls).toHaveLength(1);
+
+    await runtime.skipNode();
+
+    // `_RecycleStickers` hides every entry of `m_stickerDict` with
+    // `HideSticker(0)` -- 0.15s after the substitution -- then empties the
+    // dictionary.
+    expect(renderer.stickersClearCalls).toEqual([150]);
+    // With the ids dropped, the reused "st1" is the show half of the toggle
+    // again rather than a hide.
+    expect(renderer.stickerCalls).toHaveLength(2);
+    expect(renderer.stickerCalls[1]?.text).toBe("after");
+  });
+
   it("leaves the screen alone when the skip ends the story", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(
@@ -3438,6 +3465,7 @@ describe("StoryRuntime", () => {
 
     expect(runtime.getState()).toBe("finished");
     expect(renderer.timerClearCalls).toEqual([]);
+    expect(renderer.stickersClearCalls).toEqual([]);
     expect(renderer.subtitleClearCalls).toEqual([]);
     expect(renderer.spellStickerClearCount).toBe(0);
     expect(renderer.clearCharacterCutinCalls).toEqual([]);

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -469,10 +469,12 @@ describe("StoryRuntime", () => {
 
   it("clears spellstickers when skipping the story", async () => {
     const renderer = new FakeRenderer();
+    // nofirstskip on a first read makes get_isSkippable() false, which is the
+    // only fork where SkipStory reaches _ResetComponentsOnSkip.
     const runtime = new StoryRuntime(
       createContext([
         '[spellsticker(id="s",block=true)]<p=1>x</>',
-        '[skipnode(mode="skip")]',
+        '[skipnode(mode="nofirstskip")]',
       ]),
       renderer,
       new FakeAudio(),
@@ -1574,8 +1576,9 @@ describe("StoryRuntime", () => {
     const runtime = new StoryRuntime(
       createContext([
         '[charactercutin(widgetID="1",name="avg_npc_1",block=true)]',
-        '[skipnode(mode="skip")]',
         '[name="A"]ok',
+        '[skipnode(mode="nofirstskip")]',
+        '[name="B"]later',
       ]),
       renderer,
       new FakeAudio(),
@@ -3014,7 +3017,7 @@ describe("StoryRuntime", () => {
     const runtime = new StoryRuntime(
       createContext([
         '[subtitle(text="HELLO",alignment="center")]',
-        '[skipnode(mode="skip")]',
+        '[skipnode(mode="nofirstskip")]',
       ]),
       renderer,
       new FakeAudio(),
@@ -3386,9 +3389,10 @@ describe("StoryRuntime", () => {
     const runtime = new StoryRuntime(
       createContext([
         '[name="A"]hello',
-        '[skipnode(mode="skip")]',
         "[timersticker(x=30,y=90,size=24,time=10)]",
         '[name="B"]next',
+        '[skipnode(mode="nofirstskip")]',
+        '[name="C"]later',
       ]),
       renderer,
       new FakeAudio(),
@@ -3400,11 +3404,42 @@ describe("StoryRuntime", () => {
     expect(renderer.timerStickerCalls).toHaveLength(1);
     expect(renderer.timerClearCalls).toEqual([]);
 
-    // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping fires
-    // `OnReset -> _RecycleStickers`, whose first step is `StopTimer(0)`.
+    // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping to the next
+    // node fires `OnReset -> _RecycleStickers`, whose first step is
+    // `StopTimer(0)`.
     await runtime.skipNode();
 
     expect(renderer.timerClearCalls).toEqual([{ durationMs: 0 }]);
+    expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("leaves the screen alone when the skip ends the story", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[name="A"]hello',
+        "[timersticker(x=30,y=90,size=24,time=10)]",
+        '[name="B"]next',
+        '[skipnode(mode="skip")]',
+        '[name="C"]later',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+    await runtime.advance();
+    expect(renderer.timerStickerCalls).toHaveLength(1);
+
+    // mode="skip" makes get_isSkippable() true, so SkipStory takes
+    // StopStory("Skipped") and returns before _ResetComponentsOnSkip -- native
+    // resets no component at all on that fork.
+    await runtime.skipNode();
+
     expect(runtime.getState()).toBe("finished");
+    expect(renderer.timerClearCalls).toEqual([]);
+    expect(renderer.subtitleClearCalls).toEqual([]);
+    expect(renderer.spellStickerClearCount).toBe(0);
+    expect(renderer.clearCharacterCutinCalls).toEqual([]);
   });
 });

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -3363,4 +3363,31 @@ describe("StoryRuntime", () => {
     expect(runtime.getState()).toBe("waiting_input");
     expect(renderer.lastDialogue).toEqual({ speaker: "A", text: "after" });
   });
+
+  it("stops the timer sticker when skipping a node", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[name="A"]hello',
+        '[skipnode(mode="skip")]',
+        "[timersticker(x=30,y=90,size=24,time=10)]",
+        '[name="B"]next',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+    await runtime.advance();
+
+    expect(renderer.timerStickerCalls).toHaveLength(1);
+    expect(renderer.timerClearCalls).toEqual([]);
+
+    // `StickerPanel.ShouldResetOnSkip` defaults to true: skipping fires
+    // `OnReset -> _RecycleStickers`, whose first step is `StopTimer(0)`.
+    await runtime.skipNode();
+
+    expect(renderer.timerClearCalls).toEqual([{ durationMs: 0 }]);
+    expect(runtime.getState()).toBe("finished");
+  });
 });


### PR DESCRIPTION
> **Supersedes #391 与 #394**(两个 PR 在 skip 清理、timer fade session 两项重叠,本 PR 将两者 reconcile 为一份,重叠实现以 timersticker 文档链为准保留)。

## 背景

依据 arknights-rev `docs/impl-review/impl-review-timersticker-command.md` 与 `impl-review-timerclear-command.md`(基于官服客户端 2.7.61 / build 2761 GameAssembly.dll 的 IDA 反编译复核)修复 timersticker / timerclear 命令的移植差异。

**⚠ 2026-08-29 方向更正**:初版把 native 方向做反了,源于 review 文档对 `_OverrideTimerTaskTick` 的误读(被减数看反)。指令级复核(`0x183ed55a0`:`mov rcx,[rbx]`(curTime) → `psrldq xmm2,8`(startTime) → `sub` → `Math.Max`)确证该函数 = `Math.Max(curTime - startTime, 0)`,即**经过毫秒,递增**。更正后的 native 关键结论:

- `CountDownTask._UpdateValue`(`0x181ceff60`)默认路径 `Math.Max((endTime-curTime)/1000, 0)` 才是"剩余秒递减"(基建/招募等 UI 用),但 `AVGTimerView._StartCountTimer`(`0x183ed5830`)注入了 `overrideUpdateTickValue = _OverrideTimerTaskTick`,默认路径被整体短路。
- 因此 timersticker 是**从 00:00:00 逐秒递增的秒表**:`SetCountDown`(`0x181cefc50`)存 `startTime = now`、`endTime = now + time*1000`(毫秒墙钟),`Update`(`0x183ed5530`)每帧驱动 200ms 门控的 `Tick`(`0x185156990`),`_TimerTick`(`0x183ed5bc0`)把经过毫秒按 `HH:MM:SS` 格式化。**`time` 是超时上限**:到达后 `_TimerEnd` 只清 task 引用,文本定格在 `time` 秒(9999 → 02:46:39)、视图保持可见。真机观察(`story_jnight_1_1.txt:73`)与代码一致。
- `StickerPanel.ShouldResetOnSkip`(`0x183e917a0`)默认 true:skip 触发 `OnReset → _RecycleStickers`(`0x183e93980`),第一步即 `StopTimer(0.0)`——计时器瞬时隐藏、计时停止(引用保留供复用)。`OnStoryEnd` 只解绑 Event=5,不清理计时器。
- `AVGTimerView.RenderTimer`(`0x183ed50f0`)起 fade 前先 `DOKill(_canvas, complete: true)`;`StopTimer`(`0x183ed53e0`)前 `DOKill(_canvas, complete: false)`——连续命令的 fade 不互相打架。`StopTimer` fade 目标硬编码 0、`OnComplete` 闭包(`0x183ed54f0`)仅隐藏 view 不销毁,下一条 timersticker 复用该槽。
- `_TimerTick` 格式化 `TimeSpan.FromMilliseconds(...)`,`TimeSpan.Hours` 0..23 回绕(100000 → 03:46:40)。

## 修复内容

| 条目 | 严重度 | 改法 |
| --- | --- | --- |
| timersticker #1 **计时方向**(原判"倒计时首秒显示",实为方向相反) | P1 | `setTimerSticker` 改为**递增秒表**:保留立即写 00:00:00(对应 `_TimerTick(0)`),以起点墙钟取 `floor(elapsed)` 每秒 +1,**到 `time` 上限定格并停 interval**(对应 `_TimerEnd` 只清 task、视图保持可见);不再显示 02:46:38 起递减。200ms tick 保留(复刻 native 内部 tick,墙钟取值使多拍无害),顺带消除 #5 的累计漂移 / 后台节流问题 |
| timerclear #1 / timersticker #2 **skip 不清理计时器** | P2 | `skipNode()` 在清 interlude / spell sticker 后增加 `void this.renderer.clearTimerSticker({ durationMs: 0 })`(与 stickerclear case 同款)。story 结束不清理,维持与 `OnStoryEnd` 一致 |
| timerclear #2 / timersticker #3 **fade tween 无 DOKill** | P2 | 新增 `timerFadeSessionId` 单槽 session(模式同 `subtitleFadeSessionId`):`setTimerSticker` / `clearTimerSticker` 入口 bump + tween 回调守卫,`destroy()` 亦 bump。clear 方向对应 `StopTimer` 的 `DOKill(_canvas, false)`,set 方向对应 `RenderTimer` 的 `DOKill(_canvas, true)`;`stickerclear`(`_ExcuteClear → _RecycleStickers → StopTimer(0)`)经由同一 `clearTimerSticker` 自动获得会话失效 |
| timersticker #4 ≥24h 回绕 | P3 | `formatTimer` 小时 `% 24`(样本 max=9999 不触发,前瞻对齐) |
| timersticker #5 计时基准 | P3 | 随 #1 的墙钟计算自然消除 |
| timersticker #7 注释残句 | P3 | 补全 runtime.ts timersticker case 中 "This is a" 截断句 |

timersticker #6(复用槽初始文本)与 timerclear #3(停表时机)、#4(隐藏后槽内残留)按 review 结论等价/不可见,不动。

## 与 #391 / #394 的 reconcile 说明

- 实现层重叠项(skip 清理、fade session)语义一致,保留 #391 版本(timersticker 方向更正后的文档链)。
- 采纳 #394 的 `clearTimerSticker` / `setTimerSticker` Port scope JSDoc(含 StopTimer VA `0x183ed53e0` 与 `DOKill(false)/(true)` 不对称说明)。
- 测试:renderer fade session 测试保留 #391 版本(覆盖更全:双向失效 + 复用槽再激活不被旧 fade-out 重新隐藏);runtime skip 测试两个都保留(#391 的 skipnode 命令 + 运行中计时器场景,#394 的 SkipToThis 锚点直接 `skipNode()` 场景,互补)。
- #394 分支中已被 #353 squash 合入的 subtitle 提交不再重复携带。

## 验证用剧情文件

语料根:`torappu` 2.7.61 story 全量。`timersticker` 共 8 条样本、全部 `time=9999`,逐条可见方向修复:

- `obt/memory/story_jnight_1_1.txt:73/154/204` — 三次复用单槽(配 `:142/196/236` 的 timerclear):每次从 00:00:00 起每秒递增;上一条 fade 未完时新命令直接接管(fade session)
- `obt/memory/story_bobb_1_1.txt:355`、`obt/memory/story_mantra_1_1.txt:90/335` — 与 timerclear(duration=2) 成对:淡出期间不抖动(fade session),clear 后槽隐藏不销毁、下一条复用;mantra `:135/150` 连续两次 clear 验证第二次仍生效
- `activities/act27side/level_act27side_07_end.txt:117`、`activities/act35side/level_act35side_st03.txt:135` — 常规单次使用
- skip 瞬时清计时器:语料内无 skipnode/SkipToThis 锚点可与计时器同屏的样本,由单测锁定(两个 skip 测试)

## 测试

- `pnpm test`:317 通过
- `STORY_CORPUS_ROOT=<语料根> pnpm test:story-log`:全语料对拍 2/2 通过
- `pnpm exec vue-tsc -b`:通过
- `pnpm exec eslint`(4 个改动文件):无告警
