### PR TITLE
refactor(story-player): 抽出共享 DOTween ease 曲线库与 TweenRunner ease/loop 选项

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -71,7 +71,7 @@ import {
 } from "./core/SceneGeometry";
 import { buildShakePath, sampleShakePath } from "./core/ShakePath";
 import { SlideMaskFilter } from "./core/SlideMaskFilter";
-import { TweenRunner } from "./core/TweenRunner";
+import { TweenRunner, type TweenRunOptions } from "./core/TweenRunner";
 import { AnimTextPanel } from "./panels/AnimTextPanel";
 import { AvgDisplayPanel } from "./panels/AvgDisplayPanel";
 import { CgItemPanel } from "./panels/CgItemPanel";
@@ -4772,8 +4772,9 @@ export class PixiStoryRenderer implements StoryRenderer {
     durationMs: number,
     step: (progress: number) => void,
     done?: () => void,
+    options?: TweenRunOptions,
   ): Promise<void> {
-    return this.tweenRunner.run(durationMs, step, done);
+    return this.tweenRunner.run(durationMs, step, done, options);
   }
 }
 

--- a/src/widgets/StoryPlayer/engine/rendering/core/DotweenEase.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/DotweenEase.ts
@@ -1,0 +1,263 @@
+/**
+ * Native provenance: DOTween `Ease` curves compiled into 2.7.61 (build 2761)
+ * `GameAssembly.dll` — `DG.Tweening.Core.Easing.EaseManager.Evaluate` @
+ * 0x184140b40 (Robert Penner equations) plus the `Flash` helper class @
+ * 0x1841433b0-0x1841438a0. `Torappu.AVG` executors select one of these via
+ * `SetEase` after `DotNetExtensionMethods.GetEnum<Ease>(param, "ease",
+ * Ease.Linear, ignoreCase: false)`.
+ *
+ * Curves take normalized time in [0, 1]; Back/Elastic curves may legitimately
+ * overshoot outside that range.
+ */
+
+export type EaseCurve = (time: number) => number;
+
+export const linearEase: EaseCurve = (time) => time;
+
+function outBounceEase(time: number): number {
+  const d1 = 2.75;
+  if (time < 1 / d1) {
+    return 7.5625 * time * time;
+  }
+  if (time < 2 / d1) {
+    const t = time - 1.5 / d1;
+    return 7.5625 * t * t + 0.75;
+  }
+  if (time < 2.5 / d1) {
+    const t = time - 2.25 / d1;
+    return 7.5625 * t * t + 0.9375;
+  }
+  const t = time - 2.625 / d1;
+  return 7.5625 * t * t + 0.984_375;
+}
+
+const easeBackC1 = 1.701_58;
+const easeBackC2 = easeBackC1 * 1.525;
+const easeBackC3 = easeBackC1 + 1;
+const easeElasticC4 = (2 * Math.PI) / 3;
+const easeElasticC5 = (2 * Math.PI) / 4.5;
+
+/**
+ * Port of `DG.Tweening.Core.Easing.Flash` (2.7.61 `Flash.Ease` @ 0x184143780,
+ * `EaseIn` @ 0x184143520, `EaseOut` @ 0x184143640, `EaseInOut` @ 0x1841433b0,
+ * `WeightedEase` @ 0x1841438a0). Unlike the Elastic/Back curves, these flash
+ * implementations apply no sentinel guards to `overshootOrAmplitude`/`period`,
+ * so the library-wide `SetEase(Ease)` defaults (-1 / 0) flow through the math
+ * verbatim; with them each wave collapses into the plain quadratic below.
+ */
+const FLASH_DEFAULT_AMPLITUDE = -1;
+const FLASH_DEFAULT_PERIOD = 0;
+
+function flashWeightedEase(
+  amplitude: number,
+  period: number,
+  stepIndex: number,
+  dir: number,
+  res: number,
+): number {
+  if (
+    (dir > 0 && (Math.trunc(amplitude) & 1) === 0) ||
+    (dir < 0 && (Math.trunc(amplitude) & 1) !== 0)
+  ) {
+    stepIndex += 1;
+  }
+  let weighted: number;
+  let lerp: number;
+  if (period > 0) {
+    let frac = amplitude - Math.trunc(amplitude);
+    if (dir > 0) {
+      frac = 1 - frac;
+    }
+    lerp = (stepIndex * frac) / amplitude;
+    weighted = ((amplitude - stepIndex) * res) / amplitude;
+  } else if (period < 0) {
+    period = -period;
+    lerp = 0;
+    weighted = (stepIndex * res) / amplitude;
+  } else {
+    return Math.min(1, res);
+  }
+  return Math.min(1, (weighted - res) * period + lerp + res);
+}
+
+function flashEase(easeVal: (waveProgress: number) => number): EaseCurve {
+  return (time) => {
+    // `time` is normalized, so `duration` is 1 and each wave lasts
+    // `1 / amplitude`.
+    const amplitude = FLASH_DEFAULT_AMPLITUDE;
+    const stepDuration = 1 / amplitude;
+    const step = Math.ceil(time / stepDuration);
+    let stepTime = time - (step - 1) * stepDuration;
+    const dir = 2 * (Math.trunc(step) & 1) - 1;
+    if (dir < 0) {
+      stepTime -= stepDuration;
+    }
+    return flashWeightedEase(
+      amplitude,
+      FLASH_DEFAULT_PERIOD,
+      step,
+      dir,
+      easeVal((dir * stepTime) / stepDuration),
+    );
+  };
+}
+
+function flashInOutVal(waveProgress: number): number {
+  const doubled = waveProgress / 0.5;
+  if (doubled >= 1) {
+    return ((doubled - 1 - 2) * (doubled - 1) - 1) * -0.5;
+  }
+  return doubled * 0.5 * doubled;
+}
+
+const dotweenEaseCurves: Record<string, EaseCurve> = {
+  Flash: flashEase((waveProgress) => waveProgress),
+  InBack: (time) => easeBackC3 * time ** 3 - easeBackC1 * time ** 2,
+  InBounce: (time) => 1 - outBounceEase(1 - time),
+  InCirc: (time) => 1 - Math.sqrt(1 - time ** 2),
+  InCubic: (time) => time ** 3,
+  // Elastic applies its in-curve defaults (`overshootOrAmplitude < 1` → 1,
+  // `period == 0` → duration * 0.3), which collapse to the constants folded
+  // into the equations below.
+  InElastic: (time) =>
+    time === 0 || time === 1
+      ? time
+      : -(2 ** (10 * time - 10)) *
+        Math.sin((10 * time - 10.75) * easeElasticC4),
+  InExpo: (time) => (time === 0 ? 0 : 2 ** (10 * time - 10)),
+  InFlash: flashEase((waveProgress) => waveProgress * waveProgress),
+  InOutBack: (time) =>
+    time < 0.5
+      ? ((2 * time) ** 2 * ((easeBackC2 + 1) * 2 * time - easeBackC2)) / 2
+      : ((2 * time - 2) ** 2 *
+          ((easeBackC2 + 1) * (2 * time - 2) + easeBackC2) +
+          2) /
+        2,
+  InOutBounce: (time) =>
+    time < 0.5
+      ? (1 - outBounceEase(1 - 2 * time)) / 2
+      : (1 + outBounceEase(2 * time - 1)) / 2,
+  InOutCirc: (time) =>
+    time < 0.5
+      ? (1 - Math.sqrt(1 - (2 * time) ** 2)) / 2
+      : (Math.sqrt(1 - (-2 * time + 2) ** 2) + 1) / 2,
+  InOutCubic: (time) =>
+    time < 0.5 ? 4 * time ** 3 : 1 - (-2 * time + 2) ** 3 / 2,
+  InOutElastic: (time) => {
+    if (time === 0 || time === 1) return time;
+    if (time < 0.5) {
+      return (
+        -(
+          2 ** (20 * time - 10) *
+          Math.sin((20 * time - 11.125) * easeElasticC5)
+        ) / 2
+      );
+    }
+    return (
+      (2 ** (-20 * time + 10) *
+        Math.sin((20 * time - 11.125) * easeElasticC5)) /
+        2 +
+      1
+    );
+  },
+  InOutExpo: (time) => {
+    if (time === 0) return 0;
+    if (time === 1) return 1;
+    if (time < 0.5) return 2 ** (20 * time - 10) / 2;
+    return (2 - 2 ** (-20 * time + 10)) / 2;
+  },
+  InOutFlash: flashEase(flashInOutVal),
+  InOutQuad: (time) =>
+    time < 0.5 ? 2 * time * time : 1 - (-2 * time + 2) ** 2 / 2,
+  InOutQuart: (time) =>
+    time < 0.5 ? 8 * time ** 4 : 1 - (-2 * time + 2) ** 4 / 2,
+  InOutQuint: (time) =>
+    time < 0.5 ? 16 * time ** 5 : 1 - (-2 * time + 2) ** 5 / 2,
+  InOutSine: (time) => -(Math.cos(Math.PI * time) - 1) / 2,
+  InQuad: (time) => time * time,
+  InQuart: (time) => time ** 4,
+  InQuint: (time) => time ** 5,
+  InSine: (time) => 1 - Math.cos((time * Math.PI) / 2),
+  Linear: linearEase,
+  OutBack: (time) =>
+    1 + easeBackC3 * (time - 1) ** 3 + easeBackC1 * (time - 1) ** 2,
+  OutBounce: outBounceEase,
+  OutCirc: (time) => Math.sqrt(1 - (time - 1) ** 2),
+  OutCubic: (time) => 1 - (1 - time) ** 3,
+  OutElastic: (time) =>
+    time === 0 || time === 1
+      ? time
+      : 2 ** (-10 * time) * Math.sin((10 * time - 0.75) * easeElasticC4) + 1,
+  OutExpo: (time) => (time === 1 ? 1 : 1 - 2 ** (-10 * time)),
+  OutFlash: flashEase((waveProgress) => (waveProgress - 2) * -waveProgress),
+  OutQuad: (time) => 1 - (1 - time) * (1 - time),
+  OutQuart: (time) => 1 - (1 - time) ** 4,
+  OutQuint: (time) => 1 - (1 - time) ** 5,
+  OutSine: (time) => Math.sin((time * Math.PI) / 2),
+};
+
+/**
+ * DOTween `Ease` ordinal table: `Unset` = 0 through `INTERNAL_Custom` = 37.
+ * Out-of-table ordinals keep native's `EaseManager.Evaluate` default branch
+ * (`-(t/d) * (t/d - 2)`, the OutQuad parabola); `INTERNAL_Custom` would throw
+ * on a null custom ease in native and degrades to Linear here.
+ */
+const dotweenEaseByOrdinal: readonly EaseCurve[] = [
+  linearEase, // 0: Ease.Unset — GetEnum's parse fallback value.
+  dotweenEaseCurves.Linear,
+  dotweenEaseCurves.InSine,
+  dotweenEaseCurves.OutSine,
+  dotweenEaseCurves.InOutSine,
+  dotweenEaseCurves.InQuad,
+  dotweenEaseCurves.OutQuad,
+  dotweenEaseCurves.InOutQuad,
+  dotweenEaseCurves.InCubic,
+  dotweenEaseCurves.OutCubic,
+  dotweenEaseCurves.InOutCubic,
+  dotweenEaseCurves.InQuart,
+  dotweenEaseCurves.OutQuart,
+  dotweenEaseCurves.InOutQuart,
+  dotweenEaseCurves.InQuint,
+  dotweenEaseCurves.OutQuint,
+  dotweenEaseCurves.InOutQuint,
+  dotweenEaseCurves.InExpo,
+  dotweenEaseCurves.OutExpo,
+  dotweenEaseCurves.InOutExpo,
+  dotweenEaseCurves.InCirc,
+  dotweenEaseCurves.OutCirc,
+  dotweenEaseCurves.InOutCirc,
+  dotweenEaseCurves.InElastic,
+  dotweenEaseCurves.OutElastic,
+  dotweenEaseCurves.InOutElastic,
+  dotweenEaseCurves.InBack,
+  dotweenEaseCurves.OutBack,
+  dotweenEaseCurves.InOutBack,
+  dotweenEaseCurves.InBounce,
+  dotweenEaseCurves.OutBounce,
+  dotweenEaseCurves.InOutBounce,
+  dotweenEaseCurves.Flash,
+  dotweenEaseCurves.InFlash,
+  dotweenEaseCurves.OutFlash,
+  dotweenEaseCurves.InOutFlash,
+  () => 1, // 36: Ease.INTERNAL_Zero — completes instantly.
+  linearEase, // 37: Ease.INTERNAL_Custom — no custom ease available.
+];
+
+/**
+ * Resolves the `ease` parameter the way `GetEnum<Ease>(param, "ease",
+ * Ease.Linear, ignoreCase: false)` does: enum names match case-sensitively,
+ * integer strings (including negatives) parse as ordinals (`"6"` is OutQuad),
+ * and anything else falls back to the Ease.Linear default.
+ */
+export function dotweenEaseCurve(ease: string | undefined): EaseCurve {
+  if (ease === undefined) {
+    return linearEase;
+  }
+  if (/^-?\d+$/.test(ease)) {
+    return (
+      dotweenEaseByOrdinal[Number.parseInt(ease, 10)] ??
+      dotweenEaseCurves.OutQuad
+    );
+  }
+  return dotweenEaseCurves[ease] ?? linearEase;
+}

--- a/src/widgets/StoryPlayer/engine/rendering/core/DotweenEase.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/DotweenEase.ts
@@ -1,10 +1,17 @@
 /**
- * Native provenance: DOTween `Ease` curves compiled into 2.7.61 (build 2761)
+ * Native provenance: DOTween 1.2.760 compiled into 2.7.71 (build 2771)
  * `GameAssembly.dll` — `DG.Tweening.Core.Easing.EaseManager.Evaluate` @
- * 0x184140b40 (Robert Penner equations) plus the `Flash` helper class @
- * 0x1841433b0-0x1841438a0. `Torappu.AVG` executors select one of these via
- * `SetEase` after `DotNetExtensionMethods.GetEnum<Ease>(param, "ease",
- * Ease.Linear, ignoreCase: false)`.
+ * 0x1841f1170 (Robert Penner equations), `Bounce` @ 0x1841f0180-0x1841f03a0
+ * and `Flash` @ 0x1841f39e0-0x1841f3ed0. `Torappu.AVG` executors select one of
+ * these via `SetEase` after `DotNetExtensionMethods.GetEnum<Ease>(param,
+ * "ease", Ease.Linear, ignoreCase: false)`.
+ *
+ * The overshoot/period the curves receive are the library defaults, because
+ * `TweenSettingsExtensions.SetEase<T>(t, Ease)` @ 0x1848859d0 only assigns
+ * `easeType` (plus an int truncation for the flash eases) and never touches
+ * them: `DOTween..cctor` @ 0x1841bb710 sets `defaultEaseOvershootOrAmplitude =
+ * 1.70158` / `defaultEasePeriod = 0`, and `Tweener.Setup` @ 0x184896a60 copies
+ * both into every tween. Every constant below is folded from those two values.
  *
  * Curves take normalized time in [0, 1]; Back/Elastic curves may legitimately
  * overshoot outside that range.
@@ -31,101 +38,71 @@ function outBounceEase(time: number): number {
   return 7.5625 * t * t + 0.984_375;
 }
 
-const easeBackC1 = 1.701_58;
+/** `DOTween.defaultEaseOvershootOrAmplitude` (cctor @ 0x1841bb710). */
+const defaultOvershootOrAmplitude = 1.701_58;
+
+const easeBackC1 = defaultOvershootOrAmplitude;
 const easeBackC2 = easeBackC1 * 1.525;
 const easeBackC3 = easeBackC1 + 1;
-const easeElasticC4 = (2 * Math.PI) / 3;
-const easeElasticC5 = (2 * Math.PI) / 4.5;
+
+const twoPi = 2 * Math.PI;
+/** `period == 0` sentinel in `Evaluate`: `duration * 0.3` (normalized to 1). */
+const elasticPeriod = 0.3;
+/** The In/Out variant uses `duration * (0.3 * 1.5)` instead. */
+const elasticInOutPeriod = 0.45;
 
 /**
- * Port of `DG.Tweening.Core.Easing.Flash` (2.7.61 `Flash.Ease` @ 0x184143780,
- * `EaseIn` @ 0x184143520, `EaseOut` @ 0x184143640, `EaseInOut` @ 0x1841433b0,
- * `WeightedEase` @ 0x1841438a0). Unlike the Elastic/Back curves, these flash
- * implementations apply no sentinel guards to `overshootOrAmplitude`/`period`,
- * so the library-wide `SetEase(Ease)` defaults (-1 / 0) flow through the math
- * verbatim; with them each wave collapses into the plain quadratic below.
+ * `Evaluate`'s elastic branches only clamp the amplitude to 1 and shift by
+ * `period / 4` when `overshootOrAmplitude < 1`. The library default is
+ * 1.70158, so they take the other branch: the amplitude stays 1.70158 and the
+ * phase shift is `period / 2pi * asin(1 / amplitude)`. (This is why the
+ * textbook `2pi/3` / `2pi/4.5` easings.net constants do not apply here.)
  */
-const FLASH_DEFAULT_AMPLITUDE = -1;
-const FLASH_DEFAULT_PERIOD = 0;
-
-function flashWeightedEase(
-  amplitude: number,
-  period: number,
-  stepIndex: number,
-  dir: number,
-  res: number,
-): number {
-  if (
-    (dir > 0 && (Math.trunc(amplitude) & 1) === 0) ||
-    (dir < 0 && (Math.trunc(amplitude) & 1) !== 0)
-  ) {
-    stepIndex += 1;
-  }
-  let weighted: number;
-  let lerp: number;
-  if (period > 0) {
-    let frac = amplitude - Math.trunc(amplitude);
-    if (dir > 0) {
-      frac = 1 - frac;
-    }
-    lerp = (stepIndex * frac) / amplitude;
-    weighted = ((amplitude - stepIndex) * res) / amplitude;
-  } else if (period < 0) {
-    period = -period;
-    lerp = 0;
-    weighted = (stepIndex * res) / amplitude;
-  } else {
-    return Math.min(1, res);
-  }
-  return Math.min(1, (weighted - res) * period + lerp + res);
+function elasticShift(period: number): number {
+  return (period / twoPi) * Math.asin(1 / defaultOvershootOrAmplitude);
 }
 
-function flashEase(easeVal: (waveProgress: number) => number): EaseCurve {
-  return (time) => {
-    // `time` is normalized, so `duration` is 1 and each wave lasts
-    // `1 / amplitude`.
-    const amplitude = FLASH_DEFAULT_AMPLITUDE;
-    const stepDuration = 1 / amplitude;
-    const step = Math.ceil(time / stepDuration);
-    let stepTime = time - (step - 1) * stepDuration;
-    const dir = 2 * (Math.trunc(step) & 1) - 1;
-    if (dir < 0) {
-      stepTime -= stepDuration;
-    }
-    return flashWeightedEase(
-      amplitude,
-      FLASH_DEFAULT_PERIOD,
-      step,
-      dir,
-      easeVal((dir * stepTime) / stepDuration),
-    );
-  };
+const elasticS = elasticShift(elasticPeriod);
+const elasticInOutS = elasticShift(elasticInOutPeriod);
+
+function inOutQuadEase(time: number): number {
+  return time < 0.5 ? 2 * time * time : 1 - (-2 * time + 2) ** 2 / 2;
 }
 
-function flashInOutVal(waveProgress: number): number {
-  const doubled = waveProgress / 0.5;
-  if (doubled >= 1) {
-    return ((doubled - 1 - 2) * (doubled - 1) - 1) * -0.5;
-  }
-  return doubled * 0.5 * doubled;
+/**
+ * Port of `DG.Tweening.Core.Easing.Flash` (`Ease` @ 0x1841f3db0, `EaseIn` @
+ * 0x1841f3b50, `EaseOut` @ 0x1841f3c70, `EaseInOut` @ 0x1841f39e0,
+ * `WeightedEase` @ 0x1841f3ed0).
+ *
+ * `SetEase<T>(t, Ease)` @ 0x1848859d0 runs `easeOvershootOrAmplitude =
+ * (int)easeOvershootOrAmplitude` for the flash eases, so the 1.70158 library
+ * default arrives as an amplitude of exactly 1 while `easePeriod` keeps its 0
+ * default. Amplitude 1 makes `Flash.Ease` compute a single wave spanning the
+ * whole duration (`stepIndex = 1`, `dir = 1`, wave progress = `time`), and
+ * `WeightedEase` short-circuits its weighting on `period == 0` and returns
+ * `Math.Min(1, res)`. So every flash ease is just its wave equation clamped at
+ * 1 -- the multi-wave machinery is unreachable with the library defaults.
+ */
+function flashEase(wave: EaseCurve): EaseCurve {
+  return (time) => Math.min(1, wave(time));
 }
 
-const dotweenEaseCurves: Record<string, EaseCurve> = {
-  Flash: flashEase((waveProgress) => waveProgress),
+const dotweenEaseCurves = {
+  Flash: flashEase(linearEase),
   InBack: (time) => easeBackC3 * time ** 3 - easeBackC1 * time ** 2,
   InBounce: (time) => 1 - outBounceEase(1 - time),
   InCirc: (time) => 1 - Math.sqrt(1 - time ** 2),
   InCubic: (time) => time ** 3,
-  // Elastic applies its in-curve defaults (`overshootOrAmplitude < 1` → 1,
-  // `period == 0` → duration * 0.3), which collapse to the constants folded
-  // into the equations below.
   InElastic: (time) =>
     time === 0 || time === 1
       ? time
-      : -(2 ** (10 * time - 10)) *
-        Math.sin((10 * time - 10.75) * easeElasticC4),
+      : -(
+          defaultOvershootOrAmplitude *
+          2 ** (10 * (time - 1)) *
+          Math.sin(((time - 1 - elasticS) * twoPi) / elasticPeriod)
+        ),
   InExpo: (time) => (time === 0 ? 0 : 2 ** (10 * time - 10)),
-  InFlash: flashEase((waveProgress) => waveProgress * waveProgress),
+  InFlash: flashEase((time) => time * time),
   InOutBack: (time) =>
     time < 0.5
       ? ((2 * time) ** 2 * ((easeBackC2 + 1) * 2 * time - easeBackC2)) / 2
@@ -145,20 +122,15 @@ const dotweenEaseCurves: Record<string, EaseCurve> = {
     time < 0.5 ? 4 * time ** 3 : 1 - (-2 * time + 2) ** 3 / 2,
   InOutElastic: (time) => {
     if (time === 0 || time === 1) return time;
+    // `Evaluate` doubles the time first, so the wave argument is `2 * time - 1`.
+    const doubled = 2 * time - 1;
+    const wave =
+      defaultOvershootOrAmplitude *
+      Math.sin(((doubled - elasticInOutS) * twoPi) / elasticInOutPeriod);
     if (time < 0.5) {
-      return (
-        -(
-          2 ** (20 * time - 10) *
-          Math.sin((20 * time - 11.125) * easeElasticC5)
-        ) / 2
-      );
+      return -0.5 * (2 ** (10 * doubled) * wave);
     }
-    return (
-      (2 ** (-20 * time + 10) *
-        Math.sin((20 * time - 11.125) * easeElasticC5)) /
-        2 +
-      1
-    );
+    return 2 ** (-10 * doubled) * wave * 0.5 + 1;
   },
   InOutExpo: (time) => {
     if (time === 0) return 0;
@@ -166,9 +138,8 @@ const dotweenEaseCurves: Record<string, EaseCurve> = {
     if (time < 0.5) return 2 ** (20 * time - 10) / 2;
     return (2 - 2 ** (-20 * time + 10)) / 2;
   },
-  InOutFlash: flashEase(flashInOutVal),
-  InOutQuad: (time) =>
-    time < 0.5 ? 2 * time * time : 1 - (-2 * time + 2) ** 2 / 2,
+  InOutFlash: flashEase(inOutQuadEase),
+  InOutQuad: inOutQuadEase,
   InOutQuart: (time) =>
     time < 0.5 ? 8 * time ** 4 : 1 - (-2 * time + 2) ** 4 / 2,
   InOutQuint: (time) =>
@@ -187,23 +158,31 @@ const dotweenEaseCurves: Record<string, EaseCurve> = {
   OutElastic: (time) =>
     time === 0 || time === 1
       ? time
-      : 2 ** (-10 * time) * Math.sin((10 * time - 0.75) * easeElasticC4) + 1,
+      : defaultOvershootOrAmplitude *
+          2 ** (-10 * time) *
+          Math.sin(((time - elasticS) * twoPi) / elasticPeriod) +
+        1,
   OutExpo: (time) => (time === 1 ? 1 : 1 - 2 ** (-10 * time)),
-  OutFlash: flashEase((waveProgress) => (waveProgress - 2) * -waveProgress),
+  OutFlash: flashEase((time) => -time * (time - 2)),
   OutQuad: (time) => 1 - (1 - time) * (1 - time),
   OutQuart: (time) => 1 - (1 - time) ** 4,
   OutQuint: (time) => 1 - (1 - time) ** 5,
   OutSine: (time) => Math.sin((time * Math.PI) / 2),
-};
+} satisfies Record<string, EaseCurve>;
 
 /**
  * DOTween `Ease` ordinal table: `Unset` = 0 through `INTERNAL_Custom` = 37.
- * Out-of-table ordinals keep native's `EaseManager.Evaluate` default branch
- * (`-(t/d) * (t/d - 2)`, the OutQuad parabola); `INTERNAL_Custom` would throw
- * on a null custom ease in native and degrades to Linear here.
+ * `EaseManager.Evaluate` gates its switch on `(uint)(easeType - 1) > 0x24`, so
+ * only 1..37 get a case of their own and everything else — `Unset` included —
+ * falls through to the default branch (`-(t/d) * (t/d - 2)`, the OutQuad
+ * parabola). `INTERNAL_Custom` would throw on a null custom ease in native and
+ * degrades to Linear here.
  */
 const dotweenEaseByOrdinal: readonly EaseCurve[] = [
-  linearEase, // 0: Ease.Unset — GetEnum's parse fallback value.
+  // 0: Ease.Unset — not a switch case, so it lands on the OutQuad default
+  // branch just like any out-of-table ordinal. (`GetEnum`'s own parse fallback
+  // is Ease.Linear = ordinal 1, which the executors pass as the default.)
+  dotweenEaseCurves.OutQuad,
   dotweenEaseCurves.Linear,
   dotweenEaseCurves.InSine,
   dotweenEaseCurves.OutSine,
@@ -243,21 +222,39 @@ const dotweenEaseByOrdinal: readonly EaseCurve[] = [
   linearEase, // 37: Ease.INTERNAL_Custom — no custom ease available.
 ];
 
+const INT32_MIN = -2_147_483_648;
+const INT32_MAX = 2_147_483_647;
+
+/**
+ * Own-property lookup only: `dotweenEaseCurves` is an object literal, so a bare
+ * index would resolve inherited `Object.prototype` members (`"toString"`,
+ * `"valueOf"`, `"__proto__"`, ...) into non-curve values that slip past a
+ * nullish fallback and then throw or poison the progress with NaN.
+ */
+function easeCurveByName(name: string): EaseCurve | undefined {
+  return Object.hasOwn(dotweenEaseCurves, name)
+    ? (dotweenEaseCurves as Record<string, EaseCurve>)[name]
+    : undefined;
+}
+
 /**
  * Resolves the `ease` parameter the way `GetEnum<Ease>(param, "ease",
- * Ease.Linear, ignoreCase: false)` does: enum names match case-sensitively,
- * integer strings (including negatives) parse as ordinals (`"6"` is OutQuad),
- * and anything else falls back to the Ease.Linear default.
+ * Ease.Linear, ignoreCase: false)` does: enum names match case-sensitively and
+ * integer strings (including negatives) parse as ordinals (`"6"` is OutQuad).
+ * Anything `Enum.Parse` would reject — an unknown name, or an integer outside
+ * int32 — throws in native, and `GetEnum` swallows that into a
+ * `DLog.LogError("Can not parse enum ...")` plus the Ease.Linear default.
  */
 export function dotweenEaseCurve(ease: string | undefined): EaseCurve {
   if (ease === undefined) {
     return linearEase;
   }
   if (/^-?\d+$/.test(ease)) {
-    return (
-      dotweenEaseByOrdinal[Number.parseInt(ease, 10)] ??
-      dotweenEaseCurves.OutQuad
-    );
+    const ordinal = Number.parseInt(ease, 10);
+    if (ordinal < INT32_MIN || ordinal > INT32_MAX) {
+      return linearEase;
+    }
+    return dotweenEaseByOrdinal[ordinal] ?? dotweenEaseCurves.OutQuad;
   }
-  return dotweenEaseCurves[ease] ?? linearEase;
+  return easeCurveByName(ease) ?? linearEase;
 }

--- a/src/widgets/StoryPlayer/engine/rendering/core/TweenRunner.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/TweenRunner.ts
@@ -1,5 +1,23 @@
 import { browserAnimationClock, type AnimationClock } from "../../execution";
 
+import { linearEase, type EaseCurve } from "./DotweenEase";
+
+/** Optional DOTween `SetEase`/`SetLoops` behaviour for {@link TweenRunner.run}. */
+export interface TweenRunOptions {
+  /**
+   * Curve applied to each loop cycle's raw progress, mirroring DOTween's
+   * `SetEase(ease)`; defaults to Linear.
+   */
+  ease?: EaseCurve;
+  /**
+   * DOTween `SetLoops` count: 1 = single pass (default), negative = infinite
+   * Restart loop that replays from the start value every cycle and never
+   * completes (so `run` only settles once `isAlive` turns false — callers
+   * must not block on it).
+   */
+  loops?: number;
+}
+
 /**
  * Web-only animation adapter. AVG executors create DOTween sequences; callers
  * preserve their documented command timing while this class uses browser frames
@@ -15,12 +33,16 @@ export class TweenRunner {
     durationMs: number,
     step: (progress: number) => void,
     done?: () => void,
+    options?: TweenRunOptions,
   ): Promise<void> {
     if (durationMs <= 0) {
       step(1);
       done?.();
       return Promise.resolve();
     }
+    const ease = options?.ease ?? linearEase;
+    const loops = options?.loops ?? 1;
+    const totalMs = loops > 0 ? durationMs * loops : Number.POSITIVE_INFINITY;
     return new Promise((resolve) => {
       const start = this.clock.now();
       const tick = () => {
@@ -29,13 +51,20 @@ export class TweenRunner {
           resolve();
           return;
         }
-        const progress = Math.min(1, (this.clock.now() - start) / durationMs);
-        step(progress);
-        if (progress >= 1) {
+        const elapsed = this.clock.now() - start;
+        if (elapsed >= totalMs) {
+          step(ease(1));
           done?.();
           resolve();
           return;
         }
+        // DOTween's default Restart loop type replays from the start value
+        // at every cycle boundary.
+        const cycleProgress =
+          loops === 1
+            ? elapsed / durationMs
+            : (elapsed % durationMs) / durationMs;
+        step(ease(cycleProgress));
         this.clock.requestFrame(tick);
       };
       this.clock.requestFrame(tick);

--- a/src/widgets/StoryPlayer/engine/rendering/core/TweenRunner.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/TweenRunner.ts
@@ -13,7 +13,8 @@ export interface TweenRunOptions {
    * DOTween `SetLoops` count: 1 = single pass (default), negative = infinite
    * Restart loop that replays from the start value every cycle and never
    * completes (so `run` only settles once `isAlive` turns false — callers
-   * must not block on it).
+   * must not block on it). Clamped like `SetLoops` @ 0x184885f00: 0 becomes a
+   * single pass and anything below -1 becomes -1.
    */
   loops?: number;
 }
@@ -41,7 +42,9 @@ export class TweenRunner {
       return Promise.resolve();
     }
     const ease = options?.ease ?? linearEase;
-    const loops = options?.loops ?? 1;
+    const requestedLoops = options?.loops ?? 1;
+    const loops =
+      requestedLoops === 0 ? 1 : Math.max(-1, Math.trunc(requestedLoops));
     const totalMs = loops > 0 ? durationMs * loops : Number.POSITIVE_INFINITY;
     return new Promise((resolve) => {
       const start = this.clock.now();
@@ -60,11 +63,7 @@ export class TweenRunner {
         }
         // DOTween's default Restart loop type replays from the start value
         // at every cycle boundary.
-        const cycleProgress =
-          loops === 1
-            ? elapsed / durationMs
-            : (elapsed % durationMs) / durationMs;
-        step(ease(cycleProgress));
+        step(ease((elapsed % durationMs) / durationMs));
         this.clock.requestFrame(tick);
       };
       this.clock.requestFrame(tick);

--- a/src/widgets/StoryPlayer/engine/rendering/panels/CgItemPanel.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/panels/CgItemPanel.ts
@@ -1,6 +1,7 @@
 import { Container, Sprite, type Texture } from "pixi.js";
 
 import { STORY_HEIGHT, STORY_WIDTH, type CgItemInput } from "../../types";
+import { dotweenEaseCurve } from "../core/DotweenEase";
 
 type TextureLoader = (key: string) => Promise<Texture | null>;
 type Tween = (
@@ -21,26 +22,6 @@ function lerp(from: number, to: number, progress: number): number {
 
 function colorChannel(value: number): number {
   return Math.max(0, Math.min(255, Math.round(value * 255)));
-}
-
-function easeProgress(raw: number, ease: string): number {
-  switch (ease.toLowerCase()) {
-    case "inquad": {
-      return raw * raw;
-    }
-    case "inoutquad": {
-      return raw < 0.5 ? 2 * raw * raw : 1 - (-2 * raw + 2) ** 2 / 2;
-    }
-    case "outquad": {
-      return 1 - (1 - raw) * (1 - raw);
-    }
-    // `AVGShowItemCgSlot.Show` / `.Hide` read the curve with
-    // `GetEnum<Ease>(param, "ease", Ease.Linear, ignoreCase: false)`, which
-    // also returns that fallback for any name it cannot parse.
-    default: {
-      return raw;
-    }
-  }
 }
 
 function rgb(color: { r: number; g: number; b: number }): number {
@@ -95,6 +76,10 @@ export class CgItemPanel {
     if (input.width > 0 && input.height > 0)
       sprite.setSize(input.width, input.height);
 
+    // `AVGShowItemCgSlot.Show` reads the curve with `GetEnum<Ease>(param,
+    // "ease", Ease.Linear, ignoreCase: false)` — same resolution as every
+    // other AVG tween command, so share the DOTween curve library.
+    const ease = dotweenEaseCurve(input.ease);
     const runs: Promise<void>[] = [];
     const run = (
       delayMs: number,
@@ -110,7 +95,7 @@ export class CgItemPanel {
             durationMs <= 0
               ? 1
               : Math.max(0, Math.min(1, (elapsed - delayMs) / durationMs));
-          update(easeProgress(local, input.ease));
+          update(ease(local));
         }),
       );
     };
@@ -201,6 +186,8 @@ export class CgItemPanel {
     block: boolean,
   ): Promise<void> {
     if (this.states.size === 0) return;
+    // `AVGShowItemCgSlot.Hide` uses the same `GetEnum<Ease>` resolution.
+    const easeCurve = dotweenEaseCurve(ease);
     if (key) {
       const state = this.states.get(key);
       if (!state) return;
@@ -209,7 +196,7 @@ export class CgItemPanel {
       const task = this.tween(
         fadeMs,
         (raw) => {
-          state.root.alpha = lerp(startAlpha, 0, easeProgress(raw, ease));
+          state.root.alpha = lerp(startAlpha, 0, easeCurve(raw));
         },
         () => {
           if (state.sessionId === sessionId) this.dispose(key);
@@ -227,7 +214,7 @@ export class CgItemPanel {
       void this.tween(
         fadeMs,
         (raw) => {
-          state.root.alpha = lerp(startAlpha, 0, easeProgress(raw, ease));
+          state.root.alpha = lerp(startAlpha, 0, easeCurve(raw));
         },
         () => state.root.destroy({ children: true }),
       );

--- a/tests/tweenEase.spec.ts
+++ b/tests/tweenEase.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  dotweenEaseCurve,
+  linearEase,
+} from "../src/widgets/StoryPlayer/engine/rendering/core/DotweenEase";
+
+describe("dotweenEaseCurve resolution (GetEnum<Ease> port)", () => {
+  it("resolves enum names case-sensitively", () => {
+    expect(dotweenEaseCurve("OutQuad")(0.5)).toBeCloseTo(0.75);
+    expect(dotweenEaseCurve("InOutCubic")(0.25)).toBeCloseTo(0.0625);
+    expect(dotweenEaseCurve("InQuart")(0.5)).toBeCloseTo(0.0625);
+    expect(dotweenEaseCurve("InOutSine")(0.5)).toBeCloseTo(0.5);
+    // `GetEnum` runs with ignoreCase: false, so a lowercase name misses the
+    // enum and falls back to the Ease.Linear default.
+    expect(dotweenEaseCurve("outquad")(0.5)).toBe(0.5);
+    expect(dotweenEaseCurve("Nonsense")(0.25)).toBe(0.25);
+    expect(dotweenEaseCurve(undefined)(0.7)).toBe(0.7);
+  });
+
+  it("resolves integer strings as Ease ordinals", () => {
+    // `ease="6"` is OutQuad and `ease="1"` is Linear in the story corpus.
+    expect(dotweenEaseCurve("6")(0.5)).toBeCloseTo(0.75);
+    expect(dotweenEaseCurve("1")(0.5)).toBe(0.5);
+    expect(dotweenEaseCurve("0")(0.5)).toBe(0.5);
+    // `ease="34"` is OutFlash (story_mizuki_1_1).
+    expect(dotweenEaseCurve("34")(0.4)).toBeCloseTo(0.64);
+  });
+
+  it("keeps the native default branch for out-of-enum ordinals", () => {
+    // EaseManager.Evaluate's switch default computes the OutQuad parabola
+    // (2.7.61 GameAssembly @ 0x184140b40), not Linear.
+    expect(dotweenEaseCurve("38")(0.5)).toBeCloseTo(0.75);
+    expect(dotweenEaseCurve("99")(0.25)).toBeCloseTo(0.4375);
+    // Negative integer strings parse as (out-of-table) ordinals and land on
+    // the same default branch rather than the Linear name fallback.
+    expect(dotweenEaseCurve("-3")(0.5)).toBeCloseTo(0.75);
+  });
+
+  it("keeps curve endpoints anchored at 0 and 1", () => {
+    for (const ease of [
+      "Linear",
+      "OutQuad",
+      "InOutCubic",
+      "OutQuart",
+      "InOutQuint",
+      "OutExpo",
+      "InOutCirc",
+      "OutBack",
+      "OutBounce",
+      "InFlash",
+      "OutFlash",
+      "InOutFlash",
+    ]) {
+      const curve = dotweenEaseCurve(ease);
+      expect(curve(0)).toBeCloseTo(0);
+      expect(curve(1)).toBeCloseTo(1);
+    }
+  });
+});
+
+describe("Flash ease curves (Flash class port, default amplitude/period)", () => {
+  it("collapses each wave to the plain quadratic with DOTween's -1/0 defaults", () => {
+    // The Flash implementation applies no sentinel guards to
+    // overshootOrAmplitude/period, so the library-wide SetEase(Ease)
+    // defaults (-1 / 0) make WeightedEase return the raw wave value.
+    expect(dotweenEaseCurve("OutFlash")(0.4)).toBeCloseTo(2 * 0.4 - 0.4 ** 2);
+    expect(dotweenEaseCurve("InFlash")(0.4)).toBeCloseTo(0.4 ** 2);
+    expect(dotweenEaseCurve("Flash")(0.4)).toBeCloseTo(0.4);
+    expect(dotweenEaseCurve("OutFlash")(0.75)).toBeCloseTo(2 * 0.75 - 0.5625);
+  });
+});
+
+describe("linearEase", () => {
+  it("maps progress unchanged", () => {
+    expect(linearEase(0.5)).toBe(0.5);
+  });
+});

--- a/tests/tweenEase.spec.ts
+++ b/tests/tweenEase.spec.ts
@@ -22,19 +22,42 @@ describe("dotweenEaseCurve resolution (GetEnum<Ease> port)", () => {
     // `ease="6"` is OutQuad and `ease="1"` is Linear in the story corpus.
     expect(dotweenEaseCurve("6")(0.5)).toBeCloseTo(0.75);
     expect(dotweenEaseCurve("1")(0.5)).toBe(0.5);
-    expect(dotweenEaseCurve("0")(0.5)).toBe(0.5);
-    // `ease="34"` is OutFlash (story_mizuki_1_1).
+    // `ease="34"` is OutFlash; the corpus spells that one by name
+    // (story_mizuki_1_1), but the ordinal has to resolve the same way.
     expect(dotweenEaseCurve("34")(0.4)).toBeCloseTo(0.64);
+    expect(dotweenEaseCurve("OutFlash")(0.4)).toBeCloseTo(0.64);
   });
 
   it("keeps the native default branch for out-of-enum ordinals", () => {
-    // EaseManager.Evaluate's switch default computes the OutQuad parabola
-    // (2.7.61 GameAssembly @ 0x184140b40), not Linear.
+    // EaseManager.Evaluate gates its switch on `(uint)(easeType - 1) > 0x24`;
+    // everything else computes the OutQuad parabola (@ 0x1841f1170), not
+    // Linear.
     expect(dotweenEaseCurve("38")(0.5)).toBeCloseTo(0.75);
     expect(dotweenEaseCurve("99")(0.25)).toBeCloseTo(0.4375);
     // Negative integer strings parse as (out-of-table) ordinals and land on
     // the same default branch rather than the Linear name fallback.
     expect(dotweenEaseCurve("-3")(0.5)).toBeCloseTo(0.75);
+    // Ordinal 0 is Ease.Unset. `SetEase` assigns it verbatim, so it misses the
+    // switch too and takes that same OutQuad default branch.
+    expect(dotweenEaseCurve("0")(0.5)).toBeCloseTo(0.75);
+    expect(dotweenEaseCurve("0")(0.25)).toBeCloseTo(0.4375);
+    // Int32.Parse overflows before Enum.Parse can look at the value, and
+    // GetEnum swallows that into the Ease.Linear default.
+    expect(dotweenEaseCurve("99999999999")(0.5)).toBe(0.5);
+  });
+
+  it("ignores inherited Object.prototype keys", () => {
+    // The curve table is an object literal; a bare index would hand back
+    // `Object.prototype.toString` & co. and blow up mid-tween.
+    for (const name of [
+      "toString",
+      "valueOf",
+      "constructor",
+      "hasOwnProperty",
+      "__proto__",
+    ]) {
+      expect(dotweenEaseCurve(name)(0.25)).toBe(0.25);
+    }
   });
 
   it("keeps curve endpoints anchored at 0 and 1", () => {
@@ -60,14 +83,40 @@ describe("dotweenEaseCurve resolution (GetEnum<Ease> port)", () => {
 });
 
 describe("Flash ease curves (Flash class port, default amplitude/period)", () => {
-  it("collapses each wave to the plain quadratic with DOTween's -1/0 defaults", () => {
-    // The Flash implementation applies no sentinel guards to
-    // overshootOrAmplitude/period, so the library-wide SetEase(Ease)
-    // defaults (-1 / 0) make WeightedEase return the raw wave value.
+  it("collapses each wave to the plain quadratic with SetEase's 1/0 defaults", () => {
+    // SetEase truncates overshootOrAmplitude to an int for the flash eases, so
+    // the 1.70158 default arrives as 1 -- a single wave -- and WeightedEase
+    // short-circuits on period == 0 and returns min(1, wave).
     expect(dotweenEaseCurve("OutFlash")(0.4)).toBeCloseTo(2 * 0.4 - 0.4 ** 2);
     expect(dotweenEaseCurve("InFlash")(0.4)).toBeCloseTo(0.4 ** 2);
     expect(dotweenEaseCurve("Flash")(0.4)).toBeCloseTo(0.4);
     expect(dotweenEaseCurve("OutFlash")(0.75)).toBeCloseTo(2 * 0.75 - 0.5625);
+  });
+});
+
+describe("Elastic ease curves (library overshoot/period defaults)", () => {
+  it("keeps native's 1.70158 amplitude instead of the easings.net amplitude 1", () => {
+    // `SetEase(Ease)` never resets easeOvershootOrAmplitude, so Evaluate's
+    // elastic branches see 1.70158 (>= 1): the amplitude stays 1.70158 and the
+    // phase shift is period / 2pi * asin(1 / amplitude), not period / 4.
+    // Reference values computed from EaseManager.Evaluate @ 0x1841f1170 with
+    // duration = 1, overshootOrAmplitude = 1.70158, period = 0.
+    expect(dotweenEaseCurve("OutElastic")(0.1)).toBeCloseTo(1.846_14, 4);
+    expect(dotweenEaseCurve("OutElastic")(0.25)).toBeCloseTo(0.700_84, 4);
+    expect(dotweenEaseCurve("OutElastic")(0.4)).toBeCloseTo(1.105_77, 4);
+    expect(dotweenEaseCurve("InElastic")(0.5)).toBeCloseTo(-0.052_88, 4);
+    // The easings.net form has the wrong sign here (-0.25).
+    expect(dotweenEaseCurve("InElastic")(0.9)).toBeCloseTo(0.346_14, 4);
+    expect(dotweenEaseCurve("InOutElastic")(0.4)).toBeCloseTo(-0.058_6, 4);
+    expect(dotweenEaseCurve("InOutElastic")(0.6)).toBeCloseTo(1.176_32, 4);
+  });
+
+  it("anchors the elastic endpoints native short-circuits", () => {
+    for (const name of ["InElastic", "OutElastic", "InOutElastic"]) {
+      expect(dotweenEaseCurve(name)(0)).toBe(0);
+      expect(dotweenEaseCurve(name)(1)).toBe(1);
+    }
+    expect(dotweenEaseCurve("InOutElastic")(0.5)).toBeCloseTo(0.5, 5);
   });
 });
 

--- a/tests/tweenRunner.spec.ts
+++ b/tests/tweenRunner.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { dotweenEaseCurve } from "../src/widgets/StoryPlayer/engine/rendering/core/DotweenEase";
+import { TweenRunner } from "../src/widgets/StoryPlayer/engine/rendering/core/TweenRunner";
+
+import type { AnimationClock } from "../src/widgets/StoryPlayer/engine/execution";
+
+/** Synchronous AnimationClock whose frames flush only when time advances. */
+function createManualClock() {
+  let now = 0;
+  const frames: Array<() => void> = [];
+  const clock: AnimationClock = {
+    cancelFrame: () => {},
+    now: () => now,
+    requestFrame: (callback) => {
+      frames.push(callback);
+      return frames.length;
+    },
+  };
+  return {
+    advance(ms: number) {
+      now += ms;
+      const pending = frames.slice();
+      frames.length = 0;
+      for (const callback of pending) callback();
+    },
+    clock,
+  };
+}
+
+describe("TweenRunner ease and loops (DOTween SetEase/SetLoops port)", () => {
+  it("keeps linear progress without options", async () => {
+    const manual = createManualClock();
+    const runner = new TweenRunner(() => true, manual.clock);
+    const progress: number[] = [];
+    const done = vi.fn();
+    const run = runner.run(1000, (p) => progress.push(p), done);
+    manual.advance(500);
+    manual.advance(1000);
+    expect(await run).toBeUndefined();
+    expect(progress).toEqual([0.5, 1]);
+    expect(done).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the ease curve to each step", async () => {
+    const manual = createManualClock();
+    const runner = new TweenRunner(() => true, manual.clock);
+    const progress: number[] = [];
+    const run = runner.run(1000, (p) => progress.push(p), undefined, {
+      ease: dotweenEaseCurve("OutQuad"),
+    });
+    // Raw 0.5 becomes 0.75 under OutQuad.
+    manual.advance(500);
+    manual.advance(500);
+    await run;
+    expect(progress).toEqual([0.75, 1]);
+  });
+
+  it("replays from the start on every Restart loop cycle", async () => {
+    const manual = createManualClock();
+    const runner = new TweenRunner(() => true, manual.clock);
+    const progress: number[] = [];
+    const done = vi.fn();
+    const run = runner.run(1000, (p) => progress.push(p), done, { loops: 2 });
+    manual.advance(1500);
+    expect(progress).toEqual([0.5]);
+    manual.advance(500);
+    await run;
+    // Second cycle boundary lands on the total end: eased final step, then
+    // done fires exactly once after both loops.
+    expect(progress).toEqual([0.5, 1]);
+    expect(done).toHaveBeenCalledTimes(1);
+  });
+
+  it("never completes an infinite loop while alive", async () => {
+    const manual = createManualClock();
+    let alive = true;
+    const runner = new TweenRunner(() => alive, manual.clock);
+    const progress: number[] = [];
+    const done = vi.fn();
+    let settled = false;
+    const run = runner.run(1000, (p) => progress.push(p), done, { loops: -1 });
+    void run.then(() => {
+      settled = true;
+    });
+    manual.advance(2500);
+    expect(progress).toEqual([0.5]);
+    expect(done).not.toHaveBeenCalled();
+    expect(settled).toBe(false);
+    alive = false;
+    manual.advance(500);
+    await run;
+    expect(settled).toBe(true);
+    expect(done).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/tweenRunner.spec.ts
+++ b/tests/tweenRunner.spec.ts
@@ -72,6 +72,20 @@ describe("TweenRunner ease and loops (DOTween SetEase/SetLoops port)", () => {
     expect(done).toHaveBeenCalledTimes(1);
   });
 
+  it("clamps the loop count like SetLoops", async () => {
+    const manual = createManualClock();
+    const runner = new TweenRunner(() => true, manual.clock);
+    const progress: number[] = [];
+    // `SetLoops` @ 0x184885f00 rewrites 0 into a single pass.
+    const run = runner.run(1000, (p) => progress.push(p), undefined, {
+      loops: 0,
+    });
+    manual.advance(500);
+    manual.advance(500);
+    await run;
+    expect(progress).toEqual([0.5, 1]);
+  });
+
   it("never completes an infinite loop while alive", async () => {
     const manual = createManualClock();
     let alive = true;
@@ -79,7 +93,8 @@ describe("TweenRunner ease and loops (DOTween SetEase/SetLoops port)", () => {
     const progress: number[] = [];
     const done = vi.fn();
     let settled = false;
-    const run = runner.run(1000, (p) => progress.push(p), done, { loops: -1 });
+    // `SetLoops` also rewrites anything below -1 into the -1 infinite loop.
+    const run = runner.run(1000, (p) => progress.push(p), done, { loops: -4 });
     void run.then(() => {
       settled = true;
     });


### PR DESCRIPTION
## 背景

`backgroundtween` / `imagetween` / `largebgtween` / `largeimgtween` 的 ease/loop 修复(#358/#348/#361/#362)此前各自携带一份 DOTween 曲线实现(#361/#362 的 TweenRunner 内联表逐字节相同,#348 又在 PixiStoryRenderer 内联一份)。本 PR 把这份共享基础设施抽成独立模块,四个命令 PR 改为基于本 PR。

## native 依据(2.7.61 / build 2761 GameAssembly.dll IDA 复核)

- 曲线本体是内嵌 DOTween:`DG.Tweening.Core.Easing.EaseManager.Evaluate` @ **0x184140b40**(Robert Penner 方程;超枚举域数值走 default 分支 = OutQuad 抛物线,`INTERNAL_Zero` 恒 1),`Bounce`/`Flash` 辅助类 @ 0x18413fb50-0x1841438a0。
- AVG executor 统一经 `DotNetExtensionMethods.GetEnum<Ease>(param, "ease", 默认立即数 1 = Ease.Linear, ignoreCase: false)` 选曲线:枚举名大小写敏感,整数字符串按 ordinal(`ease="6"` = OutQuad,负数与超表 ordinal 走 EaseManager default 分支 = OutQuad),解析失败回落 Linear。
- `loop` 喂 `SetLoops(2*!loop - 1)`:`true → -1` 即无限 Restart 循环(每轮回 From 重放,OnComplete 永不触发),`false → 1` 单次。

## 修复内容

### 1. 新增 `core/DotweenEase.ts`(曲线库,取自 #358 的完整移植)

- 全套 `Ease` 枚举曲线(0-37),**含 Flash 族直译**(`Flash.Ease` @ 0x184143780 等:Flash 实现对 `overshootOrAmplitude`/`period` 不做哨兵替换,库级 SetEase 默认 (-1/0) 原样进公式,每段波退化为平面二次曲线——按公式带默认值直译)。注意:这取代了 #361/#362/#348 里"Flash 不移植、回落 Linear"的简化,超集且更贴 native。
- `dotweenEaseCurve(ease)` 按 GetEnum 语义解析(名字大小写敏感 / 整数串含负数按 ordinal / 超表 ordinal → OutQuad default 分支 / 其余回落 Linear)。

### 2. `core/TweenRunner.run` 增加 `options?: TweenRunOptions`

- `options.ease`:逐周期曲线(默认 Linear);
- `options.loops`:`SetLoops` Restart 语义,负数无限循环——每周期从 From 重放,仅在 `isAlive` 失效时 settle(调用方不得对其 await 阻塞)。

### 3. `PixiStoryRenderer` 私有 `tween` helper 透传 `options`

命令侧调用点统一 `{ ease: dotweenEaseCurve(input.ease), loops: input.loop ? -1 : 1 }` 形状,由各命令 PR 提供。

## 测试

- `tests/tweenEase.spec.ts`:名字/ordinal(含负数与超表)/Flash/端点锚定;
- `tests/tweenRunner.spec.ts`:ease 步进、Restart 周期重放、无限循环仅在 isAlive 失效时 settle。

## 后续

- #358(backgroundtween)、#361(largebgtween+largeimgtween,吸收 #362)、#348(imagetween)已 rebase 到本分支,base 已切换;本 PR 合并后它们自动回到 main 基线。
