### PR TITLE
fix(story-player): gridbg/verticalbg 接入家族 largebgtween 根并补齐 initposmode/失败清屏 

### DIFF
--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1026,30 +1026,24 @@ export class PixiStoryRenderer implements StoryRenderer {
   }
 
   /**
-   * Port scope: `Torappu.AVG.LargeBackgroundPanel._ExecuteGridBG` and
-   * `_LoadImage`, including all-or-nothing asset loading and replacement.
-   * `Container` composition is the Web adaptation of Unity RectTransforms.
-   * Load failures empty the panel like native `_ResetPanel()`; the
-   * largebg-specific immediate reset is opted into via
-   * `resetPreviousImmediately` (see the inline notes below).
+   * Port scope: `Torappu.AVG.LargeBackgroundPanel._ExecuteGridBG` /
+   * `_ExecuteVerticalBG` / `_ExecuteImage` (selected via the `layout` input)
+   * and the family `_LoadImage`, including all-or-nothing asset loading and
+   * replacement. `Container` composition is the Web adaptation of Unity
+   * RectTransforms. Load failures empty the panel like native `_ResetPanel()`.
    */
   async setGridBackground(input: GridBackgroundInput): Promise<void> {
     const sessionId = ++this.gridBackgroundSessionId;
     this.largeBackgroundTweenSessionId += 1;
-    // Native port: `_ExecuteImage` (2.7.61, VA 0x183e77ee0) calls
-    // `_ResetImages()` before `_LoadImage`, so the previous tiles vanish the
-    // moment the command executes and the new puzzle fades in over an emptied
-    // panel — a blank gap, never a cross-fade. Grid/vertical replacements keep
-    // the legacy cross-fade until their own alignment change, so this reset is
-    // opt-in.
-    if (input.resetPreviousImmediately) {
-      // The reset drops every root in the layer, so a largebg composition
-      // left over from an earlier command goes with it regardless of the
-      // incoming layout -- `largeBackgroundRoot` must not outlive it.
-      this.largeBackgroundRoot = null;
-      const previous = [...this.gridBackgroundLayer.children];
-      for (const child of previous) child.removeFromParent();
-    }
+    // Native port: every family executor — `_ExecuteImage` (largebg, VA
+    // 0x183e77ee0), `_ExecuteGridBG` (0x183e76290) and `_ExecuteVerticalBG`
+    // (0x183e79030) — calls `_ResetImages()` before `_LoadImage`, so the
+    // previous tiles vanish the moment the command executes and the new
+    // puzzle fades in over an emptied panel — a blank gap, never a
+    // cross-fade.
+    this.largeBackgroundRoot = null;
+    const previous = [...this.gridBackgroundLayer.children];
+    for (const child of previous) child.removeFromParent();
     const textures = await Promise.all(
       input.imageKeys.map((key) =>
         this.textureForImageKey(key, input.assetKind ?? "background"),
@@ -1058,25 +1052,29 @@ export class PixiStoryRenderer implements StoryRenderer {
     if (!this.app || sessionId !== this.gridBackgroundSessionId) return;
 
     if (textures.some((texture) => !texture)) {
-      // Native port: a failed `_LoadImage` makes `_ExecuteImage` log
-      // "[AVG.LargeBG] An error occurred when load image {0}.", call
-      // `_ResetPanel()` and return false without blocking, so the panel is
-      // emptied instead of keeping the previous composition.
+      // Native `_LoadImage` failure logs "Failed to load background: [key]"
+      // per tile plus the command-level "An error occurred when load image
+      // {n}." error, then `_ResetPanel()` drops the whole puzzle instead of
+      // keeping the previous one on screen (all-or-nothing).
+      const missingKeys = input.imageKeys.filter(
+        (_, index) => !textures[index],
+      );
+      this.onWarning?.(`missing grid background: ${missingKeys.join("/")}`);
       await this.clearGridBackground(0);
       return;
     }
 
     const root = this.buildGridBackgroundRoot(input, textures as Texture[]);
-    const previous = [...this.gridBackgroundLayer.children];
-    this.largeBackgroundRoot = input.layout === "large" ? root : null;
+    // The whole family (largebg / verticalbg / gridbg) shares one `_offset`
+    // container in native (`_ExecuteImageTween` drives it regardless of which
+    // executor filled it, 2.7.61: 0x183e77a94), so every layout must register
+    // itself as the largebgtween target.
+    this.largeBackgroundRoot = root;
 
     root.alpha = input.fadeMs > 0 ? 0 : 1;
     this.gridBackgroundLayer.addChild(root);
 
-    if (input.fadeMs <= 0) {
-      for (const child of previous) child.removeFromParent();
-      return;
-    }
+    if (input.fadeMs <= 0) return;
 
     const run = this.tween(
       input.fadeMs,
@@ -1087,7 +1085,6 @@ export class PixiStoryRenderer implements StoryRenderer {
       () => {
         if (!this.app || sessionId !== this.gridBackgroundSessionId) return;
         root.alpha = 1;
-        for (const child of previous) child.removeFromParent();
       },
     );
 
@@ -2652,9 +2649,9 @@ export class PixiStoryRenderer implements StoryRenderer {
       case "cg": {
         return [this.imageLayer];
       }
-      // `LargeBackgroundPanel._PostDisplayKey` registers ck_lbg_1..4 over its
-      // `_images` list, which the whole LargeBackgroundPanel family (largebg /
-      // verticalbg / gridbg) fills. The Web port only tracks the composed
+      // `LargeBackgroundPanel._PostDisplayKey` registers ck_lbg_1..4 over the
+      // family-shared `_images` list, which `_LoadImage` fills for largebg /
+      // verticalbg / gridbg alike. The Web port only tracks the composed
       // root, so focus effects apply to the whole puzzle rather than one tile.
       case "lbg": {
         return this.largeBackgroundRoot ? [this.largeBackgroundRoot] : [];

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -730,10 +730,10 @@ export class PixiStoryRenderer implements StoryRenderer {
     this.backgroundSprite = null;
     this.backgroundTweenSessionId += 1;
     this.backgroundLayer.removeChildren();
+    // panel_large_background is a permanent scene-level sibling in front of
+    // panel_background (LayerGraph.attach), so the grid layer keeps its parent
+    // and only its tile roots need clearing here.
     this.gridBackgroundLayer.removeChildren();
-    // panel_large_background is a permanent sibling in front of panel_background,
-    // so it goes back as child 0 rather than being re-appended on each gridbg.
-    this.backgroundLayer.addChild(this.gridBackgroundLayer);
     this.blockerSprite = null;
     // Blocker's closest OnReset equivalent on destroy: drop in-flight tween
     // callbacks and restore the prefab color (0,0,0,0). OnReset also clears

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1029,10 +1029,24 @@ export class PixiStoryRenderer implements StoryRenderer {
    * Port scope: `Torappu.AVG.LargeBackgroundPanel._ExecuteGridBG` and
    * `_LoadImage`, including all-or-nothing asset loading and replacement.
    * `Container` composition is the Web adaptation of Unity RectTransforms.
+   * Load failures empty the panel like native `_ResetPanel()`; the
+   * largebg-specific immediate reset is opted into via
+   * `resetPreviousImmediately` (see the inline notes below).
    */
   async setGridBackground(input: GridBackgroundInput): Promise<void> {
     const sessionId = ++this.gridBackgroundSessionId;
     this.largeBackgroundTweenSessionId += 1;
+    // Native port: `_ExecuteImage` (2.7.61, VA 0x183e77ee0) calls
+    // `_ResetImages()` before `_LoadImage`, so the previous tiles vanish the
+    // moment the command executes and the new puzzle fades in over an emptied
+    // panel — a blank gap, never a cross-fade. Grid/vertical replacements keep
+    // the legacy cross-fade until their own alignment change, so this reset is
+    // opt-in.
+    if (input.resetPreviousImmediately) {
+      if (input.layout === "large") this.largeBackgroundRoot = null;
+      const previous = [...this.gridBackgroundLayer.children];
+      for (const child of previous) child.removeFromParent();
+    }
     const textures = await Promise.all(
       input.imageKeys.map((key) =>
         this.textureForImageKey(key, input.assetKind ?? "background"),
@@ -1040,7 +1054,14 @@ export class PixiStoryRenderer implements StoryRenderer {
     );
     if (!this.app || sessionId !== this.gridBackgroundSessionId) return;
 
-    if (textures.some((texture) => !texture)) return;
+    if (textures.some((texture) => !texture)) {
+      // Native port: a failed `_LoadImage` makes `_ExecuteImage` log
+      // "[AVG.LargeBG] An error occurred when load image {0}.", call
+      // `_ResetPanel()` and return false without blocking, so the panel is
+      // emptied instead of keeping the previous composition.
+      await this.clearGridBackground(0);
+      return;
+    }
 
     const root = this.buildGridBackgroundRoot(input, textures as Texture[]);
     const previous = [...this.gridBackgroundLayer.children];
@@ -1071,6 +1092,14 @@ export class PixiStoryRenderer implements StoryRenderer {
     else void run;
   }
 
+  /**
+   * Native port note: `_ExecuteImage`'s clear branch (imagegroup and cggroup
+   * both empty) runs `DOFade(0, fadetime)` on the panel's CanvasGroup even
+   * when it is already empty, so `block=true` still waits out the fade. The
+   * Web adaptation returns early on an empty panel instead of animating
+   * nothing — an intentional simplification (no shipped script issues a
+   * parameterized clear on an empty panel).
+   */
   async clearGridBackground(fadeMs = 0, block = false): Promise<void> {
     const sessionId = ++this.gridBackgroundSessionId;
     this.largeBackgroundRoot = null;
@@ -2621,7 +2650,9 @@ export class PixiStoryRenderer implements StoryRenderer {
         return [this.imageLayer];
       }
       // `LargeBackgroundPanel._PostDisplayKey` registers ck_lbg_1..4 over its
-      // `_images` list, which only `largebg` fills.
+      // `_images` list, which the whole LargeBackgroundPanel family (largebg /
+      // verticalbg / gridbg) fills. The Web port only tracks the composed
+      // root, so focus effects apply to the whole puzzle rather than one tile.
       case "lbg": {
         return this.largeBackgroundRoot ? [this.largeBackgroundRoot] : [];
       }

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -1043,7 +1043,10 @@ export class PixiStoryRenderer implements StoryRenderer {
     // the legacy cross-fade until their own alignment change, so this reset is
     // opt-in.
     if (input.resetPreviousImmediately) {
-      if (input.layout === "large") this.largeBackgroundRoot = null;
+      // The reset drops every root in the layer, so a largebg composition
+      // left over from an earlier command goes with it regardless of the
+      // incoming layout -- `largeBackgroundRoot` must not outlive it.
+      this.largeBackgroundRoot = null;
       const previous = [...this.gridBackgroundLayer.children];
       for (const child of previous) child.removeFromParent();
     }

--- a/src/widgets/StoryPlayer/engine/rendering/core/LayerGraph.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/LayerGraph.ts
@@ -24,13 +24,17 @@ export class LayerGraph {
   readonly world = new Container();
 
   attach(stage: Container): void {
-    // Unity panel_avg sibling order (2.7.71 scene data): background,
-    // panel_background, panel_large_background, panel_bgoverlay, then image /
-    // character layers. The large background renders in front of the normal
-    // background (nested Canvas sortingOrder 2 vs 1), so a later [Background]
-    // must never cover a [largebg] composition. Existing panels are attached
-    // to their nearest stable web equivalent until their strict pass is
-    // migrated.
+    // Unity panel_avg children, in nested-Canvas sortingOrder (2.7.71
+    // sharedassets1.assets): background (no Canvas) and panel_common_executors
+    // (non-visual), panel_background 1, panel_large_background 2,
+    // panel_bgoverlay 10, panel_character 61, panel_charoverlay 70,
+    // panel_image 121, panel_showItem 130, panel_cgoverlay 131,
+    // panel_character_cutin 180. Only the first three are strict here: the
+    // large background renders in front of the normal background (2 vs 1), so
+    // a later [Background] must never cover a [largebg] composition. The
+    // layers below panel_bgoverlay still sit at their nearest stable web
+    // equivalent -- notably images/characters are inverted versus native --
+    // until their strict pass is migrated.
     this.scene.addChild(this.background);
     this.scene.addChild(this.gridBackground);
     this.scene.addChild(this.avgDisplayBackground);

--- a/src/widgets/StoryPlayer/engine/rendering/core/LayerGraph.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/LayerGraph.ts
@@ -24,11 +24,15 @@ export class LayerGraph {
   readonly world = new Container();
 
   attach(stage: Container): void {
-    this.background.addChild(this.gridBackground);
-    // Unity SceneCanvas sibling order: large background, background, image,
-    // character cutin/items, then characters. Existing panels are attached to
-    // their nearest stable web equivalent until their strict pass is migrated.
+    // Unity panel_avg sibling order (2.7.71 scene data): background,
+    // panel_background, panel_large_background, panel_bgoverlay, then image /
+    // character layers. The large background renders in front of the normal
+    // background (nested Canvas sortingOrder 2 vs 1), so a later [Background]
+    // must never cover a [largebg] composition. Existing panels are attached
+    // to their nearest stable web equivalent until their strict pass is
+    // migrated.
     this.scene.addChild(this.background);
+    this.scene.addChild(this.gridBackground);
     this.scene.addChild(this.avgDisplayBackground);
     this.scene.addChild(this.images);
     this.scene.addChild(this.avgDisplayCg);

--- a/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
@@ -45,35 +45,39 @@ function largeBackgroundInitOffset(input: GridBackgroundInput): {
   if (input.initPositionMode === undefined) return { x: 0, y: 0 };
 
   if (input.layout === "vertical") {
-    // `_ExecuteVerticalBG` builds widthList = [solidwidth, solidwidth] and
-    // passes the full height list, but the shared `_InitPosition*` helpers
-    // only read entries [0]+[1] (2.7.61: 0x183e7a3b4 / 0x183e7a4fa) — the
-    // same two-tile truncation as the sizeDelta quirk in the builder below.
-    const width = input.solidWidths[0] ?? 0;
+    // `_ExecuteVerticalBG` (2.7.71 VA 0x183f33260) builds
+    // `widthList = new List<float> { solidwidth, 0f }` (0x183f3412d-
+    // 0x183f34153; the second `Add` takes a register zeroed at 0x183f3357f,
+    // the same zero it uses as the CanvasGroup fade-in start and as the
+    // clear-branch DOFade endValue) and passes the full height list. The
+    // family pads the dimension it does not have with **0** instead of
+    // repeating it -- `_ExecuteImage` pads heights the same way, and only
+    // `_ExecuteGridBG` populates both lists for real.
+    //
+    // The shared `_InitPosition*` helpers only read entries [0]+[1] of each
+    // list, and native's `_offset` rect (`sizeDelta = (solidwidth, h0 + h1)`,
+    // 0x183f33daa, center-pivoted) is exactly the flattened Pixi root, so --
+    // like the grid branch below -- the native Vector2 ports straight in with
+    // no pivot compensation; the caller applies the y flip.
     const heightSum =
       (input.solidHeights[0] ?? 0) + (input.solidHeights[1] ?? 0);
-    // The conversion baseline is `_offset.sizeDelta.y` (the quirk value
-    // h0+h1), matching the pivot set in the vertical branch of the builder.
-    const centeredY = (nativeY: number) => nativeY + heightSum / 2;
     switch (input.initPositionMode) {
       case "center": {
-        return { x: 0, y: centeredY(0) };
+        return { x: 0, y: 0 };
       }
       case "upperleft": {
         return {
-          x: (width * 2 - STORY_WIDTH) / 2,
-          y: centeredY((STORY_HEIGHT - heightSum) / 2),
+          x: ((input.solidWidths[0] ?? 0) - STORY_WIDTH) / 2,
+          y: (STORY_HEIGHT - heightSum) / 2,
         };
       }
       case "lowercenter": {
-        return { x: 0, y: centeredY((heightSum - STORY_HEIGHT) / 2) };
+        return { x: 0, y: (heightSum - STORY_HEIGHT) / 2 };
       }
       default: {
-        // default = (width[1] / 2, -height[1] / 2) over the full list.
-        return {
-          x: width / 2,
-          y: centeredY(-(input.solidHeights[1] ?? 0) / 2),
-        };
+        // (widthList[1] / 2, -heightList[1] / 2); widthList[1] is the padded
+        // 0, so only the second tile height moves the puzzle.
+        return { x: 0, y: -(input.solidHeights[1] ?? 0) / 2 };
       }
     }
   }

--- a/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
@@ -18,6 +18,26 @@ const largeBackgroundInitOffsets = new WeakMap<
   { x: number; y: number }
 >();
 
+/**
+ * Port of `LargeBackgroundPanel.POSITION_INIT_FUNCTION` as applied by
+ * `_ExecuteImage` (2.7.71 VA 0x183f32f40-0x183f3308e): the selected
+ * `_InitPosition*` result is written verbatim into
+ * `_initOffset.localPosition`.
+ *
+ * `_ExecuteImage` hands those helpers the parsed `solidwidth` list plus
+ * `new List<float> { solidheight, 0f }` (VA 0x183f33005-0x183f33025; the
+ * second `Add` takes a register zeroed at 0x183f32947). largebg is a single
+ * row, so the second row height is **0**, not a repeat of `solidheight` —
+ * `_InitPositionDefault` reads `height[1]` and `_InitPositionUpperLeft` /
+ * `_InitPositionLowerCenter` sum `height[0] + height[1]`.
+ *
+ * No coordinate conversion is needed on top of that: native's `_offset`
+ * RectTransform gets `sizeDelta = (w0 + w1, solidheight)` (VA 0x183f32c23)
+ * with a centered pivot and the two top-left-pivoted tiles at anchored
+ * positions (0, 0) and (w0, 0), which is exactly the flattened Pixi root
+ * (`buildGridBackgroundRoot` pivots on the same rect). The caller applies the
+ * only remaining difference, Pixi's downward y axis.
+ */
 function largeBackgroundInitOffset(input: GridBackgroundInput): {
   x: number;
   y: number;
@@ -27,25 +47,30 @@ function largeBackgroundInitOffset(input: GridBackgroundInput): {
 
   const widths = input.solidWidths;
   const height = input.solidHeights[0] ?? 0;
-  // Unity's children use a top-left anchor/pivot, while the flattened Pixi
-  // root uses a centered pivot. The latter already contributes -height / 2,
-  // so convert native initOffset.y into that centered coordinate space.
-  const centeredY = (nativeY: number) => nativeY + height / 2;
   switch (input.initPositionMode) {
+    // `_InitPositionCenter` (VA 0x183f34390) returns `Vector2.zero`, and an
+    // unregistered `initposmode` leaves the same zero in place, so this is
+    // also the fallback the runtime maps unknown values onto.
     case "center": {
-      return { x: 0, y: centeredY(0) };
+      return { x: 0, y: 0 };
     }
+    // `_InitPositionUpperLeft` (VA 0x183f34640):
+    // ((width[0] + width[1] - 1280) / 2, (720 - (height[0] + height[1])) / 2).
     case "upperleft": {
       return {
         x: (widths.reduce((sum, width) => sum + width, 0) - STORY_WIDTH) / 2,
-        y: centeredY((STORY_HEIGHT - height * 2) / 2),
+        y: (STORY_HEIGHT - height) / 2,
       };
     }
+    // `_InitPositionLowerCenter` (VA 0x183f34550):
+    // (0, (height[0] + height[1] - 720) / 2).
     case "lowercenter": {
-      return { x: 0, y: centeredY((height * 2 - STORY_HEIGHT) / 2) };
+      return { x: 0, y: (height - STORY_HEIGHT) / 2 };
     }
+    // `_InitPositionDefault` (VA 0x183f34450): (width[1] / 2, -height[1] / 2),
+    // and height[1] is the padded 0.
     default: {
-      return { x: (widths[1] ?? 0) / 2, y: centeredY(-height / 2) };
+      return { x: (widths[1] ?? 0) / 2, y: 0 };
     }
   }
 }

--- a/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/core/SceneGeometry.ts
@@ -42,10 +42,81 @@ function largeBackgroundInitOffset(input: GridBackgroundInput): {
   x: number;
   y: number;
 } {
-  if (input.layout !== "large" || input.initPositionMode === undefined)
-    return { x: 0, y: 0 };
+  if (input.initPositionMode === undefined) return { x: 0, y: 0 };
+
+  if (input.layout === "vertical") {
+    // `_ExecuteVerticalBG` builds widthList = [solidwidth, solidwidth] and
+    // passes the full height list, but the shared `_InitPosition*` helpers
+    // only read entries [0]+[1] (2.7.61: 0x183e7a3b4 / 0x183e7a4fa) — the
+    // same two-tile truncation as the sizeDelta quirk in the builder below.
+    const width = input.solidWidths[0] ?? 0;
+    const heightSum =
+      (input.solidHeights[0] ?? 0) + (input.solidHeights[1] ?? 0);
+    // The conversion baseline is `_offset.sizeDelta.y` (the quirk value
+    // h0+h1), matching the pivot set in the vertical branch of the builder.
+    const centeredY = (nativeY: number) => nativeY + heightSum / 2;
+    switch (input.initPositionMode) {
+      case "center": {
+        return { x: 0, y: centeredY(0) };
+      }
+      case "upperleft": {
+        return {
+          x: (width * 2 - STORY_WIDTH) / 2,
+          y: centeredY((STORY_HEIGHT - heightSum) / 2),
+        };
+      }
+      case "lowercenter": {
+        return { x: 0, y: centeredY((heightSum - STORY_HEIGHT) / 2) };
+      }
+      default: {
+        // default = (width[1] / 2, -height[1] / 2) over the full list.
+        return {
+          x: width / 2,
+          y: centeredY(-(input.solidHeights[1] ?? 0) / 2),
+        };
+      }
+    }
+  }
 
   const widths = input.solidWidths;
+
+  if (input.layout === "grid") {
+    // Port of `LargeBackgroundPanel` POSITION_INIT_FUNCTION for `_ExecuteGridBG`
+    // (2.7.61: applied unconditionally at 0x183e77451-0x183e775ce). Native
+    // passes the full width list plus `heightList2 = [heightList[0],
+    // heightList[2]]`, so the `get_Item(0)+get_Item(1)` sums in
+    // `_InitPositionUpperLeft`/`_InitPositionLowerCenter` collapse to
+    // w0+w1 / h0+h1, and `_InitPositionDefault` reads
+    // `(widthList[1]/2, -heightList2[1]/2)` = (w1/2, -h1/2) — the half-tile
+    // offset that anchors the default view on the top row. The `_offset` rect
+    // (`sizeDelta` = (w0+w1, h0+h1), 0x183e76ef8) wraps the 2×2 puzzle
+    // exactly and is center-pivoted, so unlike the "large" row below there is
+    // no pivot compensation: the native Vector2 ports straight in and the
+    // position formula flips y for Pixi's downward axis.
+    const height0 = input.solidHeights[0] ?? 0;
+    const height1 = input.solidHeights[1] ?? 0;
+    const totalHeight = height0 + height1;
+    switch (input.initPositionMode) {
+      case "center": {
+        return { x: 0, y: 0 };
+      }
+      case "upperleft": {
+        return {
+          x: ((widths[0] ?? 0) + (widths[1] ?? 0) - STORY_WIDTH) / 2,
+          y: (STORY_HEIGHT - totalHeight) / 2,
+        };
+      }
+      case "lowercenter": {
+        return { x: 0, y: (totalHeight - STORY_HEIGHT) / 2 };
+      }
+      default: {
+        return { x: (widths[1] ?? 0) / 2, y: -height1 / 2 };
+      }
+    }
+  }
+
+  if (input.layout !== "large") return { x: 0, y: 0 };
+
   const height = input.solidHeights[0] ?? 0;
   switch (input.initPositionMode) {
     // `_InitPositionCenter` (VA 0x183f34390) returns `Vector2.zero`, and an

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1267,6 +1267,21 @@ export class StoryRuntime {
           imageGroup,
           cgGroup,
         );
+        // Native always reads `initposmode` (default "default", 2.7.61:
+        // 0x183e76959) and unconditionally rewrites `_initOffset.localPosition`
+        // after assembling the puzzle (0x183e77451-0x183e775ce): a key miss
+        // writes Vector2.zero, the same offset the "center" mode produces.
+        const initPositionModeArg = toString(
+          this.exactArg(args, "initposmode"),
+          "default",
+        );
+        const initPositionMode =
+          initPositionModeArg === "default" ||
+          initPositionModeArg === "upperleft" ||
+          initPositionModeArg === "lowercenter" ||
+          initPositionModeArg === "center"
+            ? initPositionModeArg
+            : "center";
         const fadeMs = Math.max(
           0,
           toNumber(this.exactArg(args, "fadetime"), 0) * 1000,
@@ -1292,6 +1307,10 @@ export class StoryRuntime {
 
         if (imageKeys.length === 0) {
           this.warn("parse", "gridbg imagegroup is empty");
+          // Native treats every empty tile name as a fatal parse error and
+          // calls `_ResetPanel()` (2.7.61: 0x183e77675), which drops the
+          // current picture instead of keeping it around.
+          await this.renderer.clearGridBackground(0);
           return "continue";
         }
 
@@ -1304,6 +1323,10 @@ export class StoryRuntime {
             "parse",
             `gridbg expects ${imageKeys.length} widths/heights, got ${solidWidths.length}/${solidHeights.length}`,
           );
+          // Native logs "[AVG.GridBG] Image Count {0} of GridBG is
+          // incorrect." / "... is empty." then clears the panel via
+          // `_ResetPanel()` and returns false (2.7.61: 0x183e76cb8-0x183e77675).
+          await this.renderer.clearGridBackground(0);
           return "continue";
         }
 
@@ -1312,6 +1335,7 @@ export class StoryRuntime {
           block,
           fadeMs,
           imageKeys,
+          initPositionMode,
           layout: "grid",
           scaleX: toNumber(this.exactArg(args, "xScale"), 1),
           scaleY: toNumber(this.exactArg(args, "yScale"), 1),
@@ -1325,13 +1349,32 @@ export class StoryRuntime {
 
       case "verticalbg": {
         // Native port: Torappu.AVG.LargeBackgroundPanel._ExecuteVerticalBG.
-        // It accepts one width and up to four vertically stacked tiles; fadetime
+        // It accepts one solidwidth float and up to four vertically stacked
+        // tiles; fadetime stays literal (unscaled) like the rest of the family.
+        // `initposmode` is always read (default "default") and its offset is
+        // written unconditionally at the end of the load branch
+        // (2.7.61: 0x183e79e3e-0x183e79f8d).
         const imageGroup = toString(this.exactArg(args, "imagegroup"));
         const cgGroup = toString(this.exactArg(args, "cggroup"));
         const groupSelection = resolveGroupedAssetSelection(
           imageGroup,
           cgGroup,
         );
+        // POSITION_INIT_FUNCTION (0x183e7b120) only registers the four known
+        // modes; a key miss still writes (0, 0) — the same offset `center`
+        // produces — so unknown values map to center like the largebg/gridbg
+        // siblings, not to default.
+        const initPositionModeArg = toString(
+          this.exactArg(args, "initposmode"),
+          "default",
+        );
+        const initPositionMode =
+          initPositionModeArg === "default" ||
+          initPositionModeArg === "upperleft" ||
+          initPositionModeArg === "lowercenter" ||
+          initPositionModeArg === "center"
+            ? initPositionModeArg
+            : "center";
         const fadeMs = Math.max(
           0,
           toNumber(this.exactArg(args, "fadetime"), 0) * 1000,
@@ -1355,7 +1398,16 @@ export class StoryRuntime {
         ).slice(0, imageKeys.length);
 
         if (imageKeys.length === 0) {
-          this.warn("parse", "verticalbg imagegroup is empty");
+          // Native logs "[AVG.VerticalBG] Image {0} of VerticalBG is Empty."
+          // then `_ResetPanel()` wipes the current composition before the
+          // command fails, so mirror the instant clear here.
+          this.warn(
+            "parse",
+            "verticalbg imagegroup is empty",
+            line.lineNumber,
+            line.command,
+          );
+          await this.renderer.clearGridBackground(0, false);
           return "continue";
         }
 
@@ -1364,11 +1416,30 @@ export class StoryRuntime {
           solidWidths.length !== 1 ||
           solidHeights.length !== imageKeys.length
         ) {
+          // Same native error path: LogError ("Image Count ... incorrect." /
+          // "Height of Image ... is empty/incorrect.") + `_ResetPanel()` (an
+          // instant reset without any fade), clearing the previous backdrop.
           this.warn(
             "parse",
             `verticalbg expects width_count * height_count === image_count, got ${solidWidths.length} * ${solidHeights.length} !== ${imageKeys.length}`,
+            line.lineNumber,
+            line.command,
           );
+          await this.renderer.clearGridBackground(0, false);
           return "continue";
+        }
+
+        if (imageKeys.length === 1) {
+          // Native reads heightList[1] for the panel sizeDelta with a raw
+          // get_Item (2.7.61: 0x183e79b2f-0x183e79b7a), so a single tile
+          // aborts with ArgumentOutOfRangeException. We keep rendering with
+          // the quirk-tolerant pivot but warn to stay observable.
+          this.warn(
+            "parse",
+            "verticalbg with a single tile would crash the native client",
+            line.lineNumber,
+            line.command,
+          );
         }
 
         await this.renderer.setGridBackground({
@@ -1376,6 +1447,7 @@ export class StoryRuntime {
           block,
           fadeMs,
           imageKeys,
+          initPositionMode,
           layout: "vertical",
           scaleX: toNumber(this.exactArg(args, "xScale"), 1),
           scaleY: toNumber(this.exactArg(args, "yScale"), 1),
@@ -1462,10 +1534,6 @@ export class StoryRuntime {
           imageKeys,
           initPositionMode,
           layout: "large",
-          // Native port: `_ExecuteImage` calls `_ResetImages()` before
-          // loading, so the previous puzzle disappears immediately and the
-          // new one fades in over the emptied panel (no cross-fade).
-          resetPreviousImmediately: true,
           scaleX: toNumber(this.exactArg(args, "xScale"), 1),
           scaleY: toNumber(this.exactArg(args, "yScale"), 1),
           solidHeights,

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1388,9 +1388,12 @@ export class StoryRuntime {
       }
 
       case "largebg": {
-        // Native port: Torappu.AVG.LargeBackgroundPanel._ExecuteImage (the
-        // LargeBackgroundPanel method, not AVGImagePanel's namesake). It composes
-        // two horizontal tiles and keeps fadetime literal.
+        // Native port: Torappu.AVG.LargeBackgroundPanel._ExecuteImage (2.7.61,
+        // VA 0x183e77ee0; the LargeBackgroundPanel method, not AVGImagePanel's
+        // namesake). It composes two horizontal tiles and keeps fadetime
+        // literal. Every validation/load failure makes native log an error,
+        // call `_ResetPanel()` and return false without blocking — mirrored
+        // below by clearing the grid background before continuing.
         const imageGroup = toString(this.exactArg(args, "imagegroup"));
         const cgGroup = toString(this.exactArg(args, "cggroup"));
         const groupSelection = resolveGroupedAssetSelection(
@@ -1401,12 +1404,17 @@ export class StoryRuntime {
           this.exactArg(args, "initposmode"),
           "default",
         );
+        // Native port: POSITION_INIT_FUNCTION only registers
+        // upperleft/center/lowercenter/default (VA 0x183e7b120). An
+        // unregistered key still writes `_initOffset.localPosition =
+        // (0,0,0)` (VA 0x183e78d10) — the same offset as `center` — so
+        // unknown values fall back to center, not default.
         const initPositionMode =
-          initPositionModeArg === "center" ||
+          initPositionModeArg === "default" ||
           initPositionModeArg === "lowercenter" ||
           initPositionModeArg === "upperleft"
             ? initPositionModeArg
-            : "default";
+            : "center";
         const fadeMs = Math.max(
           0,
           toNumber(this.exactArg(args, "fadetime"), 0) * 1000,
@@ -1426,23 +1434,24 @@ export class StoryRuntime {
         const solidWidths = parseNumberSequence(
           this.exactArg(args, "solidwidth"),
         ).slice(0, 2);
+        // Native port: `solidheight` (float, default 0.0) has no validation —
+        // 0 still lays out a zero-height, invisible composition that runs its
+        // fade and honors block for the full fadetime.
         const solidHeight = toNumber(this.exactArg(args, "solidheight"), 0);
-        const solidHeights = solidHeight > 0 ? [solidHeight] : [];
+        const solidHeights = [solidHeight];
 
         if (imageKeys.length === 0) {
           this.warn("parse", "largebg imagegroup is empty");
+          await this.renderer.clearGridBackground(0);
           return "continue";
         }
 
-        if (
-          imageKeys.length !== 2 ||
-          solidWidths.length !== 2 ||
-          solidHeights.length !== 1
-        ) {
+        if (imageKeys.length !== 2 || solidWidths.length !== 2) {
           this.warn(
             "parse",
             `largebg expects width_count * height_count === image_count, got ${solidWidths.length} * ${solidHeights.length} !== ${imageKeys.length}`,
           );
+          await this.renderer.clearGridBackground(0);
           return "continue";
         }
 
@@ -1453,6 +1462,10 @@ export class StoryRuntime {
           imageKeys,
           initPositionMode,
           layout: "large",
+          // Native port: `_ExecuteImage` calls `_ResetImages()` before
+          // loading, so the previous puzzle disappears immediately and the
+          // new one fades in over the emptied panel (no cross-fade).
+          resetPreviousImmediately: true,
           scaleX: toNumber(this.exactArg(args, "xScale"), 1),
           scaleY: toNumber(this.exactArg(args, "yScale"), 1),
           solidHeights,

--- a/src/widgets/StoryPlayer/engine/runtime.ts
+++ b/src/widgets/StoryPlayer/engine/runtime.ts
@@ -1449,7 +1449,7 @@ export class StoryRuntime {
         if (imageKeys.length !== 2 || solidWidths.length !== 2) {
           this.warn(
             "parse",
-            `largebg expects width_count * height_count === image_count, got ${solidWidths.length} * ${solidHeights.length} !== ${imageKeys.length}`,
+            `largebg expects width_count * height_count === image_count, got ${solidWidths.length} * 1 !== ${imageKeys.length}`,
           );
           await this.renderer.clearGridBackground(0);
           return "continue";

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -362,15 +362,6 @@ export interface GridBackgroundInput {
   imageKeys: string[];
   initPositionMode?: "center" | "default" | "lowercenter" | "upperleft";
   layout?: "grid" | "large" | "vertical";
-  /**
-   * Native port: `LargeBackgroundPanel._ExecuteImage` (2.7.61, VA 0x183e77ee0)
-   * calls `_ResetImages()` before `_LoadImage`, so the previous tiles vanish
-   * the moment the command executes and the new puzzle fades in over an
-   * emptied panel (a blank gap, not a cross-fade). Opt-in because the shared
-   * grid/vertical executors keep the legacy cross-fade until their own
-   * alignment change.
-   */
-  resetPreviousImmediately?: boolean;
   scaleX: number;
   scaleY: number;
   solidHeights: number[];

--- a/src/widgets/StoryPlayer/engine/types.ts
+++ b/src/widgets/StoryPlayer/engine/types.ts
@@ -362,6 +362,15 @@ export interface GridBackgroundInput {
   imageKeys: string[];
   initPositionMode?: "center" | "default" | "lowercenter" | "upperleft";
   layout?: "grid" | "large" | "vertical";
+  /**
+   * Native port: `LargeBackgroundPanel._ExecuteImage` (2.7.61, VA 0x183e77ee0)
+   * calls `_ResetImages()` before `_LoadImage`, so the previous tiles vanish
+   * the moment the command executes and the new puzzle fades in over an
+   * emptied panel (a blank gap, not a cross-fade). Opt-in because the shared
+   * grid/vertical executors keep the legacy cross-fade until their own
+   * alignment change.
+   */
+  resetPreviousImmediately?: boolean;
   scaleX: number;
   scaleY: number;
   solidHeights: number[];

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1325,7 +1325,6 @@ describe("PixiStoryRenderer", () => {
       fadeMs: 0,
       imageKeys: ["l1", "r1"],
       layout: "large",
-      resetPreviousImmediately: true,
       solidHeights: [720],
       solidWidths: [100, 100],
     };
@@ -1343,24 +1342,33 @@ describe("PixiStoryRenderer", () => {
     );
   });
 
-  it("keeps the legacy cross-fade for layouts without the immediate reset", async () => {
+  it("drops the previous grid/vertical root before fading in the replacement", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};
     renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
     renderer.tween = vi.fn(() => new Promise<void>(() => {}));
 
-    const input = createGridBackgroundInput();
-    await renderer.setGridBackground({ ...input, fadeMs: 0 });
-    const firstRoot = renderer.gridBackgroundLayer.children.at(0);
+    // `_ExecuteGridBG` (0x183e76290) and `_ExecuteVerticalBG` (0x183e79030)
+    // share `_ExecuteImage`'s `_ResetImages()`-before-`_LoadImage` order, so
+    // every family layout drops the outgoing composition the moment the
+    // replacement command executes.
+    for (const layout of ["grid", "vertical"] as const) {
+      const input = {
+        ...createGridBackgroundInput(),
+        fadeMs: 500,
+        imageKeys: ["t1", "t2", "t3", "t4"],
+        layout,
+      };
+      await renderer.setGridBackground({ ...input, fadeMs: 0 });
+      const firstRoot = renderer.gridBackgroundLayer.children.at(-1);
 
-    // grid/vertical replacements keep the outgoing composition parented until
-    // the fade completes; their executors adopt the immediate reset in their
-    // own alignment change.
-    await renderer.setGridBackground({ ...input, fadeMs: 500 });
+      await renderer.setGridBackground(input);
 
-    expect(firstRoot.parent).not.toBeNull();
-    expect(renderer.gridBackgroundLayer.children).toHaveLength(2);
+      expect(firstRoot.parent).toBeNull();
+      expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+      expect(renderer.gridBackgroundLayer.children.at(0).alpha).toBe(0);
+    }
   });
 
   it("empties the panel when a largebg tile fails to load", async () => {
@@ -1377,7 +1385,6 @@ describe("PixiStoryRenderer", () => {
       fadeMs: 0,
       imageKeys: ["l1", "r1"],
       layout: "large",
-      resetPreviousImmediately: true,
       solidHeights: [720],
       solidWidths: [100, 100],
     };
@@ -1865,6 +1872,76 @@ describe("PixiStoryRenderer", () => {
     ]);
   });
 
+  it("applies verticalbg initposmode offsets with the two-tile height sum", () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+
+    const build = (initPositionMode: GridBackgroundInput["initPositionMode"]) =>
+      renderer.buildGridBackgroundRoot(
+        {
+          ...createGridBackgroundInput(),
+          imageKeys: ["v1", "v2"],
+          initPositionMode,
+          layout: "vertical",
+          solidHeights: [1454, 1454],
+          solidWidths: [1280],
+          x: 0,
+          y: 0,
+        },
+        [Texture.EMPTY, Texture.EMPTY],
+      );
+
+    const positionOf = (
+      initPositionMode: GridBackgroundInput["initPositionMode"],
+    ) => {
+      const { x, y } = build(initPositionMode).position;
+      return { x, y };
+    };
+
+    // Native builds widthList = [solidwidth, solidwidth] and passes the full
+    // height list, but _InitPosition* only reads entries [0]+[1]; the Pixi
+    // conversion baseline is the same quirk sum (h0+h1) used for the pivot.
+    // center: (0, 0) -> root.position = (640, 360 - 1454).
+    expect(positionOf("center")).toEqual({ x: 640, y: -1094 });
+    // default: (width/2, -height[1]/2) -> root.position = (1280, 360 - 727).
+    expect(positionOf("default")).toEqual({ x: 1280, y: -367 });
+    // lowercenter: (0, (h0+h1-720)/2) -> root.position = (640, 360 - 2548).
+    expect(positionOf("lowercenter")).toEqual({ x: 640, y: -2188 });
+    // upperleft: ((2w-1280)/2, (720-(h0+h1))/2) -> root.position = (1280, 0).
+    expect(positionOf("upperleft")).toEqual({ x: 1280, y: 0 });
+  });
+
+  it("pans verticalbg compositions with largebgtween", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setGridBackground({
+      ...createGridBackgroundInput(),
+      imageKeys: ["v1", "v2"],
+      layout: "vertical",
+      solidHeights: [720, 720],
+      solidWidths: [1280],
+      x: 0,
+      y: 0,
+    });
+
+    // The whole family shares one `_offset` container in native, so the
+    // vertical composition must be registered for largebgtween as well.
+    const root = renderer.gridBackgroundLayer.children[0];
+    expect(renderer.largeBackgroundRoot).toBe(root);
+
+    await renderer.setLargeBackgroundTween({
+      block: false,
+      durationMs: 0,
+      yFrom: 0,
+      yTo: 600,
+    });
+
+    // duration 0 snaps to the target: applyCenteredTransform maps y=600 to
+    // position.y = 360 - 600.
+    expect(root.position.y).toBe(-240);
+  });
+
   it("lays out largebg as exactly two horizontal tiles", () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const textures = [
@@ -1933,6 +2010,134 @@ describe("PixiStoryRenderer", () => {
     expect(place("default")).toEqual({ x: 940, y: 360 });
     expect(place("upperleft")).toEqual({ x: 500, y: 250 });
     expect(place("lowercenter")).toEqual({ x: 640, y: 470 });
+  });
+
+  it("applies gridbg initposmode offsets in the centered pivot space", () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const build = (initPositionMode: string) =>
+      renderer.buildGridBackgroundRoot(
+        {
+          ...createGridBackgroundInput(),
+          initPositionMode,
+          layout: "grid",
+          scaleX: 1,
+          scaleY: 1,
+          solidHeights: [600, 640],
+          solidWidths: [1000, 800],
+          x: 0,
+          y: 0,
+        },
+        [Texture.EMPTY, Texture.EMPTY, Texture.EMPTY, Texture.EMPTY],
+      );
+
+    const positions = (mode: string) => {
+      const { position } = build(mode);
+      return { x: position.x, y: position.y };
+    };
+
+    // POSITION_INIT_FUNCTION ports (2.7.61: 0x183e77451): default =
+    // (w1/2, -h1/2), center = (0,0), upperleft = ((w0+w1-1280)/2,
+    // (720-(h0+h1))/2), lowercenter = (0, (h0+h1-720)/2). The `_offset` rect
+    // wraps the 2×2 puzzle exactly, so the native Vector2 needs no extra
+    // pivot compensation — only the y flip done by the position formula.
+    expect(positions("default")).toEqual({ x: 1040, y: 680 });
+    expect(positions("center")).toEqual({ x: 640, y: 360 });
+    expect(positions("upperleft")).toEqual({ x: 900, y: 620 });
+    expect(positions("lowercenter")).toEqual({ x: 640, y: 100 });
+
+    // Corpus shape (level_main_16-01_beg.txt:112): 1280/1280 × 720/720 with
+    // default mode anchors the view on the top row: the half-tile offset
+    // (640, -360) puts the puzzle's top edge exactly on the canvas top.
+    const corpusRoot = renderer.buildGridBackgroundRoot(
+      {
+        ...createGridBackgroundInput(),
+        initPositionMode: "default",
+        layout: "grid",
+        scaleX: 1,
+        scaleY: 1,
+        x: -105,
+        y: 0,
+      },
+      [Texture.EMPTY, Texture.EMPTY, Texture.EMPTY, Texture.EMPTY],
+    );
+    expect(corpusRoot.position.x).toBe(1175);
+    expect(corpusRoot.position.y).toBe(720);
+  });
+
+  it("registers every family layout as the largebgtween target", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    for (const layout of ["grid", "vertical", "large"] as const) {
+      await renderer.setGridBackground({
+        ...createGridBackgroundInput(),
+        imageKeys: ["t1", "t2", "t3", "t4"],
+        layout,
+      });
+      const root = renderer.gridBackgroundLayer.children.at(-1);
+      // `LargeBackgroundPanel._ExecuteImageTween` drives the family-shared
+      // `_offset`, so gridbg/verticalbg puzzles must be tweenable too.
+      expect(renderer.largeBackgroundRoot).toBe(root);
+      expect(root.parent).toBe(renderer.gridBackgroundLayer);
+    }
+  });
+
+  it("moves a gridbg puzzle with largebgtween", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    await renderer.setGridBackground({
+      ...createGridBackgroundInput(),
+      scaleX: 1,
+      scaleY: 1,
+      imageKeys: ["l1", "r1", "l2", "r2"],
+      initPositionMode: "default",
+      layout: "grid",
+      x: 0,
+      y: 0,
+    });
+
+    // level_main_16-01_beg.txt:112-113 pans the skystarry grid with
+    // [largebgtween(duration=40,yFrom=720,yTo=360)]. Native `_offset` is a
+    // child of `_initOffset`, so the tween moves only the command-space
+    // offset while the default half-tile init offset (640, -360) stays put:
+    // y=720 puts the puzzle center on the canvas top edge, i.e. the visible
+    // band becomes the bottom tile row.
+    await renderer.setLargeBackgroundTween({ durationMs: 0, yTo: 720 });
+
+    const root = renderer.largeBackgroundRoot;
+    expect(root.position.x).toBe(1280);
+    expect(root.position.y).toBe(0);
+  });
+
+  it("warns and clears the panel when a grid tile fails to load", async () => {
+    const warnings: string[] = [];
+    const renderer = new PixiStoryRenderer(createContext(), (warning) =>
+      warnings.push(warning),
+    ) as any;
+    renderer.app = {};
+    renderer.textureForImageKey = vi
+      .fn()
+      .mockResolvedValueOnce(Texture.EMPTY)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValue(Texture.EMPTY);
+    const staleRoot = new Container();
+    renderer.gridBackgroundLayer.addChild(staleRoot);
+    renderer.largeBackgroundRoot = staleRoot;
+
+    await renderer.setGridBackground({
+      ...createGridBackgroundInput(),
+      imageKeys: ["l1", "r1", "l2", "r2"],
+      layout: "grid",
+    });
+
+    // Native `_LoadImage` failure logs and calls `_ResetPanel()`: the stale
+    // picture is dropped instead of kept.
+    expect(warnings).toEqual(["missing grid background: r1"]);
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(0);
+    expect(renderer.largeBackgroundRoot).toBeNull();
   });
 
   it("applies largebgtween in largebg transform space", async () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1875,39 +1875,57 @@ describe("PixiStoryRenderer", () => {
   it("applies verticalbg initposmode offsets with the two-tile height sum", () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
 
-    const build = (initPositionMode: GridBackgroundInput["initPositionMode"]) =>
+    const build = (
+      initPositionMode: GridBackgroundInput["initPositionMode"],
+      solidHeights: number[],
+      solidWidths: number[],
+    ) =>
       renderer.buildGridBackgroundRoot(
         {
           ...createGridBackgroundInput(),
-          imageKeys: ["v1", "v2"],
+          imageKeys: solidHeights.map((_, index) => `v${index}`),
           initPositionMode,
           layout: "vertical",
-          solidHeights: [1454, 1454],
-          solidWidths: [1280],
+          scaleX: 1,
+          scaleY: 1,
+          solidHeights,
+          solidWidths,
           x: 0,
           y: 0,
         },
-        [Texture.EMPTY, Texture.EMPTY],
+        solidHeights.map(() => Texture.EMPTY),
       );
 
+    // Native builds `widthList = [solidwidth, 0]` -- the family pads the
+    // dimension it lacks with 0, it does not repeat it -- and passes the full
+    // height list, of which `_InitPosition*` reads entries [0]+[1]. The
+    // `_offset` rect (solidwidth x (h0+h1)) is center-pivoted and matches the
+    // Pixi root exactly, so the native Vector2 needs no pivot compensation.
+    // With solidwidth 1000 and heights 500/300 (h0+h1 = 800):
     const positionOf = (
       initPositionMode: GridBackgroundInput["initPositionMode"],
     ) => {
-      const { x, y } = build(initPositionMode).position;
+      const { x, y } = build(initPositionMode, [500, 300], [1000]).position;
       return { x, y };
     };
 
-    // Native builds widthList = [solidwidth, solidwidth] and passes the full
-    // height list, but _InitPosition* only reads entries [0]+[1]; the Pixi
-    // conversion baseline is the same quirk sum (h0+h1) used for the pivot.
-    // center: (0, 0) -> root.position = (640, 360 - 1454).
-    expect(positionOf("center")).toEqual({ x: 640, y: -1094 });
-    // default: (width/2, -height[1]/2) -> root.position = (1280, 360 - 727).
-    expect(positionOf("default")).toEqual({ x: 1280, y: -367 });
-    // lowercenter: (0, (h0+h1-720)/2) -> root.position = (640, 360 - 2548).
-    expect(positionOf("lowercenter")).toEqual({ x: 640, y: -2188 });
-    // upperleft: ((2w-1280)/2, (720-(h0+h1))/2) -> root.position = (1280, 0).
-    expect(positionOf("upperleft")).toEqual({ x: 1280, y: 0 });
+    // center: (0, 0) -> (640, 360).
+    expect(positionOf("center")).toEqual({ x: 640, y: 360 });
+    // default: (widthList[1] / 2, -height[1] / 2) = (0, -150) -> (640, 510).
+    expect(positionOf("default")).toEqual({ x: 640, y: 510 });
+    // upperleft: ((1000 - 1280) / 2, (720 - 800) / 2) = (-140, -40).
+    expect(positionOf("upperleft")).toEqual({ x: 500, y: 400 });
+    // lowercenter: (0, (800 - 720) / 2) = (0, 40) -> (640, 320).
+    expect(positionOf("lowercenter")).toEqual({ x: 640, y: 320 });
+
+    // Corpus shape (level_main_16-18_end.txt:356): N=4 full-screen tiles with
+    // the implicit `default` mode. The offset (0, -h1/2) = (0, -360) centers
+    // the 1280x1440 `_offset` rect at y=720, so the rect spans [0, 1440] and
+    // the top tile lands exactly on the 1280x720 canvas.
+    const corpusRoot = build("default", [720, 720, 720, 720], [1280]);
+    expect(corpusRoot.position.x).toBe(640);
+    expect(corpusRoot.position.y).toBe(720);
+    expect(corpusRoot.pivot.y).toBe(720);
   });
 
   it("pans verticalbg compositions with largebgtween", async () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1307,6 +1307,93 @@ describe("PixiStoryRenderer", () => {
     );
   });
 
+  it("removes the previous largebg composition before fading in the new one", async () => {
+    // Native port: `_ExecuteImage` (2.7.61, VA 0x183e77ee0) calls
+    // `_ResetImages()` before `_LoadImage`, so a fadetime>0 replacement
+    // starts from an emptied panel — a blank gap while the new puzzle fades
+    // in, never a cross-fade. The never-completing tween keeps that fade
+    // mid-flight.
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    renderer.tween = vi.fn(() => new Promise<void>(() => {}));
+
+    const first = {
+      ...createGridBackgroundInput(),
+      fadeMs: 0,
+      imageKeys: ["l1", "r1"],
+      layout: "large",
+      resetPreviousImmediately: true,
+      solidHeights: [720],
+      solidWidths: [100, 100],
+    };
+    await renderer.setGridBackground(first);
+    const firstRoot = renderer.gridBackgroundLayer.children.at(0);
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+
+    await renderer.setGridBackground({ ...first, fadeMs: 500 });
+
+    expect(firstRoot.parent).toBeNull();
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+    expect(renderer.gridBackgroundLayer.children.at(0).alpha).toBe(0);
+    expect(renderer.largeBackgroundRoot).toBe(
+      renderer.gridBackgroundLayer.children.at(0),
+    );
+  });
+
+  it("keeps the legacy cross-fade for layouts without the immediate reset", async () => {
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+    renderer.tween = vi.fn(() => new Promise<void>(() => {}));
+
+    const input = createGridBackgroundInput();
+    await renderer.setGridBackground({ ...input, fadeMs: 0 });
+    const firstRoot = renderer.gridBackgroundLayer.children.at(0);
+
+    // grid/vertical replacements keep the outgoing composition parented until
+    // the fade completes; their executors adopt the immediate reset in their
+    // own alignment change.
+    await renderer.setGridBackground({ ...input, fadeMs: 500 });
+
+    expect(firstRoot.parent).not.toBeNull();
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(2);
+  });
+
+  it("empties the panel when a largebg tile fails to load", async () => {
+    // Native port: a failed `_LoadImage` logs
+    // "[AVG.LargeBG] An error occurred when load image {0}.", calls
+    // `_ResetPanel()` and returns false without blocking.
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    const input = {
+      ...createGridBackgroundInput(),
+      fadeMs: 0,
+      imageKeys: ["l1", "r1"],
+      layout: "large",
+      resetPreviousImmediately: true,
+      solidHeights: [720],
+      solidWidths: [100, 100],
+    };
+    await renderer.setGridBackground(input);
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+
+    renderer.textureForImageKey = vi
+      .fn()
+      .mockImplementation((key: string) =>
+        key === "r1" ? Promise.resolve(null) : Promise.resolve(Texture.EMPTY),
+      );
+    await renderer.setGridBackground(input);
+
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(0);
+    expect(renderer.largeBackgroundRoot).toBeNull();
+  });
+
   it("draws a curtain as a solid body plus a fixed-width feather strip", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1395,6 +1395,31 @@ describe("PixiStoryRenderer", () => {
     expect(renderer.largeBackgroundRoot).toBeNull();
   });
 
+  it("empties the panel when a gridbg tile fails to load", async () => {
+    // The load-failure branch is shared with largebg on purpose:
+    // `_ExecuteGridBG` (2.7.71 VA 0x183f304c0) ends a failed `_LoadImage`
+    // with the same `DLog.LogError` + `_ResetPanel()` (VA 0x183f318aa) as
+    // `_ExecuteImage`, so grid/vertical must not keep the previous
+    // composition either -- even though they still cross-fade on success.
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    renderer.app = {};
+    renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
+
+    const input = { ...createGridBackgroundInput(), fadeMs: 0 };
+    await renderer.setGridBackground(input);
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(1);
+
+    renderer.textureForImageKey = vi
+      .fn()
+      .mockImplementation((key: string) =>
+        key === "r2" ? Promise.resolve(null) : Promise.resolve(Texture.EMPTY),
+      );
+    await renderer.setGridBackground(input);
+
+    expect(renderer.gridBackgroundLayer.children).toHaveLength(0);
+  });
+
   it("draws a curtain as a solid body plus a fixed-width feather strip", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};
@@ -1870,6 +1895,44 @@ describe("PixiStoryRenderer", () => {
       { label: "tile-0", x: 0, y: 0 },
       { label: "tile-1", x: 640, y: 0 },
     ]);
+  });
+
+  it("places every largebg initposmode at its native _initOffset", () => {
+    // Native port: `_ExecuteImage` writes the selected `_InitPosition*`
+    // result straight into `_initOffset.localPosition`, and the helpers get
+    // `heights = [solidheight, 0]` (2.7.71 VA 0x183f33005-0x183f33025) --
+    // largebg is a single row, so `height[1]` is 0 rather than a repeat of
+    // `solidheight`. With two tiles of 400 + 600 and solidheight 500:
+    //   center      `Vector2.zero`                          -> (0, 0)
+    //   default     (width[1] / 2, -height[1] / 2)          -> (300, 0)
+    //   upperleft   ((1000 - 1280) / 2, (720 - 500) / 2)    -> (-140, 110)
+    //   lowercenter (0, (500 - 720) / 2)                    -> (0, -110)
+    // The Pixi root pivots on the same rect as native's `_offset`, so the
+    // only conversion is the flipped y axis: (640 + x, 360 - y).
+    const renderer = new PixiStoryRenderer(createContext()) as any;
+    const place = (initPositionMode: string) => {
+      const root = renderer.buildGridBackgroundRoot(
+        {
+          ...createGridBackgroundInput(),
+          imageKeys: ["tile-0", "tile-1"],
+          initPositionMode,
+          layout: "large",
+          scaleX: 1,
+          scaleY: 1,
+          solidHeights: [500],
+          solidWidths: [400, 600],
+          x: 0,
+          y: 0,
+        },
+        [Texture.EMPTY, Texture.EMPTY],
+      );
+      return { x: root.position.x, y: root.position.y };
+    };
+
+    expect(place("center")).toEqual({ x: 640, y: 360 });
+    expect(place("default")).toEqual({ x: 940, y: 360 });
+    expect(place("upperleft")).toEqual({ x: 500, y: 250 });
+    expect(place("lowercenter")).toEqual({ x: 640, y: 470 });
   });
 
   it("applies largebgtween in largebg transform space", async () => {

--- a/tests/renderer.spec.ts
+++ b/tests/renderer.spec.ts
@@ -1274,34 +1274,35 @@ describe("PixiStoryRenderer", () => {
     expect(order()).toEqual(["outgoing", "l", "r", "m"]);
   });
 
-  it("keeps the large background behind the background regardless of update order", async () => {
+  it("keeps the large background in front of the background regardless of update order", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     const input = createGridBackgroundInput();
 
     renderer.app = {};
-    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    // Mirror LayerGraph.attach's scene order: background first, grid layer next.
+    renderer.sceneLayer.addChild(renderer.backgroundLayer);
+    renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
 
     // panel_large_background is a permanent sibling in front of panel_background
-    // in SceneCanvas, so it always renders underneath -- executing gridbg after
-    // background must not lift the puzzle above it.
+    // in SceneCanvas (nested Canvas sortingOrder 2 vs 1), so it always renders
+    // on top -- executing background after gridbg must not sink the puzzle
+    // below it.
+    const gridIndex = () =>
+      renderer.sceneLayer.children.indexOf(renderer.gridBackgroundLayer) -
+      renderer.sceneLayer.children.indexOf(renderer.backgroundLayer);
+
     await renderer.setGridBackground(input);
-    expect(renderer.backgroundLayer.children.at(0)).toBe(
-      renderer.gridBackgroundLayer,
-    );
+    expect(gridIndex()).toBeGreaterThan(0);
 
     await renderer.setBackground("bg_test");
-    expect(renderer.backgroundLayer.children.at(0)).toBe(
-      renderer.gridBackgroundLayer,
-    );
+    expect(gridIndex()).toBeGreaterThan(0);
     expect(renderer.backgroundLayer.children.at(-1)).toBe(
       renderer.backgroundRoot,
     );
 
     await renderer.setGridBackground(input);
-    expect(renderer.backgroundLayer.children.at(0)).toBe(
-      renderer.gridBackgroundLayer,
-    );
+    expect(gridIndex()).toBeGreaterThan(0);
     expect(renderer.backgroundLayer.children.at(-1)).toBe(
       renderer.backgroundRoot,
     );
@@ -1315,7 +1316,7 @@ describe("PixiStoryRenderer", () => {
     // mid-flight.
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};
-    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
     renderer.tween = vi.fn(() => new Promise<void>(() => {}));
 
@@ -1345,7 +1346,7 @@ describe("PixiStoryRenderer", () => {
   it("keeps the legacy cross-fade for layouts without the immediate reset", async () => {
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};
-    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
     renderer.tween = vi.fn(() => new Promise<void>(() => {}));
 
@@ -1368,7 +1369,7 @@ describe("PixiStoryRenderer", () => {
     // `_ResetPanel()` and returns false without blocking.
     const renderer = new PixiStoryRenderer(createContext()) as any;
     renderer.app = {};
-    renderer.backgroundLayer.addChild(renderer.gridBackgroundLayer);
+    renderer.sceneLayer.addChild(renderer.gridBackgroundLayer);
     renderer.textureForImageKey = vi.fn().mockResolvedValue(Texture.EMPTY);
 
     const input = {

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2506,6 +2506,7 @@ describe("StoryRuntime", () => {
         imageKeys: ["bg_beach_1", "bg_beach_2"],
         initPositionMode: "default",
         layout: "large",
+        resetPreviousImmediately: true,
         scaleX: 1,
         scaleY: 1,
         solidHeights: [720],
@@ -2540,6 +2541,7 @@ describe("StoryRuntime", () => {
         imageKeys: ["61_i12", "61_i11"],
         initPositionMode: "default",
         layout: "large",
+        resetPreviousImmediately: true,
         scaleX: 1,
         scaleY: 0.8,
         solidHeights: [900],
@@ -2553,6 +2555,80 @@ describe("StoryRuntime", () => {
         block: true,
         fadeMs: 200,
       },
+    ]);
+  });
+
+  it("maps unknown largebg initposmode values to the center offset", async () => {
+    // Native port: POSITION_INIT_FUNCTION has no entry for an unknown key, so
+    // `_ExecuteImage` still writes `_initOffset.localPosition = (0,0,0)` (VA
+    // 0x183e78d10) — the same offset as `center`, not `default`.
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[largebg(imagegroup="a/b",solidwidth="1/1",solidheight=720,initposmode="diagonal")]',
+        '[largebg(imagegroup="a/b",solidwidth="1/1",solidheight=720,initposmode="upperleft")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(
+      renderer.gridBackgroundCalls.map((call) => call.initPositionMode),
+    ).toEqual(["center", "upperleft"]);
+  });
+
+  it("keeps largebg running with a zero or missing solidheight", async () => {
+    // Native port: `solidheight` (float, default 0.0) has no validation in
+    // `_ExecuteImage`; a zero-height invisible composition still fades in and
+    // still blocks for the full fadetime.
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[largebg(imagegroup="a/b",solidwidth="1/1",solidheight=0,fadetime=1,block=true)]',
+        '[largebg(imagegroup="a/b",solidwidth="1/1",fadetime=0)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(
+      renderer.gridBackgroundCalls.map((call) => call.solidHeights),
+    ).toEqual([[0], [0]]);
+    expect(renderer.gridBackgroundCalls.map((call) => call.block)).toEqual([
+      true,
+      false,
+    ]);
+    expect(renderer.gridBackgroundClearCalls).toEqual([]);
+  });
+
+  it("empties the large background panel when largebg validation fails", async () => {
+    // Native port: Count!=2 / empty-tile / bad-width failures make
+    // `_ExecuteImage` log an error, `_ResetPanel()` and return false without
+    // blocking — the previous composition must not survive the failed command.
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[largebg(imagegroup="a/b",solidwidth="1/1",solidheight=720,fadetime=0)]',
+        '[largebg(imagegroup="a/b/c",solidwidth="1/1",solidheight=720,fadetime=0)]',
+        '[largebg(imagegroup="a",solidwidth="1/1",solidheight=720,fadetime=0)]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(renderer.gridBackgroundCalls).toHaveLength(1);
+    expect(renderer.gridBackgroundClearCalls).toEqual([
+      { block: false, fadeMs: 0 },
+      { block: false, fadeMs: 0 },
     ]);
   });
 

--- a/tests/runtime.spec.ts
+++ b/tests/runtime.spec.ts
@@ -2341,6 +2341,7 @@ describe("StoryRuntime", () => {
           "47_g14_skyovercast_l2",
           "47_g14_skyovercast_r2",
         ],
+        initPositionMode: "default",
         layout: "grid",
         scaleX: 0.5,
         scaleY: 0.75,
@@ -2352,6 +2353,48 @@ describe("StoryRuntime", () => {
     ]);
     expect(renderer.gridBackgroundClearCalls).toEqual([]);
     expect(runtime.getState()).toBe("waiting_input");
+  });
+
+  it("maps gridbg initposmode and treats unknown modes as zero offset", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[gridbg(imagegroup="a/b/c/d",solidwidth="1280/1280",solidheight="720/720",initposmode="upperleft")]',
+        '[gridbg(imagegroup="a/b/c/d",solidwidth="1280/1280",solidheight="720/720",initposmode="unknown")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    expect(
+      renderer.gridBackgroundCalls.map((input) => input.initPositionMode),
+    ).toEqual(["upperleft", "center"]);
+  });
+
+  it("clears the grid panel when gridbg validation fails", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[gridbg(imagegroup="a/b/c",solidwidth="1280/1280",solidheight="720/720")]',
+        '[gridbg(imagegroup="a/b/c/d",solidwidth="1280",solidheight="720/720")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // Native `_ResetPanel()` (2.7.61: 0x183e77675) drops the current picture
+    // on every malformed grid instead of keeping the previous puzzle.
+    expect(renderer.gridBackgroundCalls).toEqual([]);
+    expect(renderer.gridBackgroundClearCalls).toEqual([
+      { block: false, fadeMs: 0 },
+      { block: false, fadeMs: 0 },
+    ]);
   });
 
   it("clears gridbg independently and supports legacy blok typo", async () => {
@@ -2393,6 +2436,7 @@ describe("StoryRuntime", () => {
         block: false,
         fadeMs: 1000,
         imageKeys: ["66_i15_4", "66_i15_3", "66_i15_2", "66_i15_1"],
+        initPositionMode: "default",
         layout: "vertical",
         scaleX: 0.9,
         scaleY: 0.9,
@@ -2425,6 +2469,7 @@ describe("StoryRuntime", () => {
         block: false,
         fadeMs: 0,
         imageKeys: ["69_i12_1", "69_i12_2"],
+        initPositionMode: "default",
         layout: "vertical",
         scaleX: 1,
         scaleY: 1,
@@ -2455,6 +2500,7 @@ describe("StoryRuntime", () => {
         block: false,
         fadeMs: 0,
         imageKeys: ["47_g14_skyovercast_l1", "47_g14_skyovercast_r1"],
+        initPositionMode: "default",
         layout: "vertical",
         scaleX: 1,
         scaleY: 1,
@@ -2485,6 +2531,83 @@ describe("StoryRuntime", () => {
     ]);
   });
 
+  it("reads verticalbg initposmode and maps unknown modes to center", async () => {
+    const renderer = new FakeRenderer();
+    const runtime = new StoryRuntime(
+      createContext([
+        '[verticalbg(imagegroup="66_i15_4/66_i15_3",solidwidth=1280,solidheight="720/720",initposmode="upperleft")]',
+        '[verticalbg(imagegroup="66_i15_4/66_i15_3",solidwidth=1280,solidheight="720/720",initposmode="diagonal")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+    );
+
+    await runtime.start();
+
+    // POSITION_INIT_FUNCTION only knows default/center/lowercenter/upperleft;
+    // a key miss still writes (0, 0), the same offset "center" produces — the
+    // largebg/gridbg siblings map unknown modes the same way.
+    expect(
+      renderer.gridBackgroundCalls.map((input) => input.initPositionMode),
+    ).toEqual(["upperleft", "center"]);
+  });
+
+  it("clears the layer when verticalbg validation fails", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        // Five tiles exceed native's SafeCount > 4 check; _ResetPanel() wipes
+        // the previous composition without any fade.
+        '[verticalbg(imagegroup="a/b/c/d/e",solidwidth=1280,solidheight="720/720/720/720/720")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    expect(renderer.gridBackgroundCalls).toEqual([]);
+    expect(renderer.gridBackgroundClearCalls).toEqual([
+      { block: false, fadeMs: 0 },
+    ]);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        command: "verticalbg",
+        type: "parse",
+      }),
+    ]);
+  });
+
+  it("warns but still renders a single-tile verticalbg", async () => {
+    const renderer = new FakeRenderer();
+    const warnings: RuntimeWarning[] = [];
+    const runtime = new StoryRuntime(
+      createContext([
+        '[verticalbg(imagegroup="solo",solidwidth=1280,solidheight="720")]',
+        '[name="A"]ok',
+      ]),
+      renderer,
+      new FakeAudio(),
+      { onWarning: (warning) => warnings.push(warning) },
+    );
+
+    await runtime.start();
+
+    // Native crashes on heightList[1] (raw get_Item in the sizeDelta quirk);
+    // the web port keeps rendering and only reports the divergence.
+    expect(renderer.gridBackgroundCalls).toHaveLength(1);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        command: "verticalbg",
+        type: "parse",
+      }),
+    ]);
+  });
+
   it("maps largebg into a legacy large tiled background layer", async () => {
     const renderer = new FakeRenderer();
     const runtime = new StoryRuntime(
@@ -2506,7 +2629,6 @@ describe("StoryRuntime", () => {
         imageKeys: ["bg_beach_1", "bg_beach_2"],
         initPositionMode: "default",
         layout: "large",
-        resetPreviousImmediately: true,
         scaleX: 1,
         scaleY: 1,
         solidHeights: [720],
@@ -2541,7 +2663,6 @@ describe("StoryRuntime", () => {
         imageKeys: ["61_i12", "61_i11"],
         initPositionMode: "default",
         layout: "large",
-        resetPreviousImmediately: true,
         scaleX: 1,
         scaleY: 0.8,
         solidHeights: [900],


### PR DESCRIPTION
本 PR 合并 #344(verticalbg)与 #345(gridbg)为一条变更

三条命令是 native `LargeBackgroundPanel` 家族的姊妹 executor,共享同一套 `_initOffset`/`_offset` 双层容器与 `_images` 槽位;两个原 PR 在 renderer 里是同构改动的两份副本(先合谁都要手解 `PixiStoryRenderer.ts`/`SceneGeometry.ts` 的冲突),合并为一条并基于 #360 统一收敛。逆向依据同 #344/#345:明日方舟官服 2.7.61 / build 2761 GameAssembly.dll 的 IDA 复核。

## 修复内容(合并自两个原 PR)

### 1. gridbg / verticalbg 之后 `largebgtween` 完全失效(P0,两个 PR 各一)

- native `_ExecuteImageTween`(VA `0x183e77a94`)tween 的是家族共享 `_offset`,不区分拼图来自哪个命令;语料中 gridbg 加载后紧跟 `[largebgtween]` 共 89 处、verticalbg 9 处(主线 16-18 章 N=4 verticalbg 全部紧跟)。
- 修复前 `setGridBackground` 仅 `layout === "large"` 时登记 `largeBackgroundRoot`,grid/vertical 显式置 null,卷动动画全部丢失。
- 修复:对所有 layout 登记 root。

### 2. `initposmode` 下沉 vertical / grid 布局(P1,两个 PR 各一)

- runtime 两条命令分支读取并归一化 `initposmode`;未知值统一映射 `center`(见下"收敛差异 2")。
- `SceneGeometry.largeBackgroundInitOffset` 新增两个分支:
  - **vertical**:native 传 `widthList=[solidwidth,solidwidth]` + 完整 heightList,但 `_InitPosition*` 求和固定 `get_Item(0)+get_Item(1)`;y 换算基线取 sizeDelta quirk 值 `h0+h1`(与 pivot 复刻一致)。
  - **grid**:native 传完整 widthList + `[h0,h1]`,`_offset` 矩形恰好包裹 2×2 拼图且中心 pivot,native Vector2 直入(仅翻 y,无 large 布局的 +h/2 补偿)。

### 3. 校验失败不清屏(P2×2)

- count≠4 / >4 / 子图空 / 高度解析失败:warn 后 `clearGridBackground(0)` 立即清屏(verticalbg 的 warn 同时补 `lineNumber`/`command`),对齐 native LogError + `_ResetPanel()` + 返回 false。

### 4. 加载失败静默(P2×2)

- `setGridBackground` 任一纹理失败:输出 `missing grid background: <keys>` 整体告警 + 清空面板(all-or-nothing)。

### 5. 替换过渡语义(P2×2)

- native 加载分支先 `_ResetImages()`(旧拼图瞬间消失)再整体淡入,非 crossfade;现网样本替换均 fadetime=0 或先清屏,无视觉变化。

### 6. N==1 verticalbg(344 项)

- native `heightList.get_Item(1)` 越界崩溃;Web 保留容错渲染,补一条 warning 保持可观测。

## 相对两个原 PR 的收敛差异(重点 review 这里)

1. **`resetPreviousImmediately` opt-in 撤销,改为无条件家族重置**:#360 为 largebg 引入了该 opt-in 字段并注明"grid/vertical 由各自对齐 PR 处理"。本 PR 把三条命令统一后,该字段不再有 false 的调用方,故从 `GridBackgroundInput` 删除,`setGridBackground` 顶部无条件执行 `_ResetImages()` 语义(加载前清旧 root)——这也比原 344/345 在加载完成后才移除旧 root 的写法更贴 native 时序。#360 中锁定"非 largebg 布局保持 crossfade"的测试 `keeps the legacy cross-fade for layouts without the immediate reset` 相应替换为 grid/vertical 也立即移除旧 root 的循环断言。
2. **verticalbg 未知 `initposmode` 改为映射 `center`**(原 #344 回落 `default`):三个 PR 的逆向结论一致——`POSITION_INIT_FUNCTION`(`0x183e7b120`)key 未命中时写 `(0,0)`(largebg 路径 `0x183e78d10`),效果等同 `center`;#360 的描述还专门强调"**不是**回退到 default"。原 #344 的实现与其自身的 native 引用矛盾,统一到家族一致语义,测试同步改为断言 `center`。
3. **加载失败告警统一**为 #345 的 `missing grid background: <keys>`(带缺失键列表,信息量大于 #344 的固定文案)。
4. **测试去重**:两 PR 各自的"加载失败清屏""替换去 crossfade"测试合并为单条循环覆盖(family 行为已收敛为单一代码路径);tween 登记/位移/initposmode 坐标断言按布局保留。

## 验证用剧情文件

生产语料位于本地 `torappu/storage/asset/gamedata/latest/story`(同 #344/#345 列表):

- gridbg+largebgtween:`obt/main/level_main_16-01_beg.txt` 112-113 行(duration=40)、`level_main_16-11_end.txt` 127-128 行(duration=60)、`obt/memory/story_blkkgt_1_1.txt` 8-9 行(横向漂移)。
- verticalbg+largebgtween:`obt/main/level_main_16-18_end.txt` 356-357 行(N=4,duration=30)、660-661 行(duration=0 瞬时)、`activities/act40side/level_act40side_09_end.txt` 871-872 行。
- 既有兼容回归(不得破坏):N=2 千分位高度 `level_main_14-20_end.txt:1161`、带引号宽度 + cggroup 路由 `act46side_02_beg.txt:120`、裸 `[verticalbg]` 清屏 `level_main_16-18_end.txt:680`、裸 `[gridbg]` 清屏。
- initposmode/失败路径/N==1:现网语料 0 命中,**前瞻对齐,由单测锁定**(用例列表见原 PR 描述,已合并去重)。

## 测试

- `pnpm test`:26 个文件 **381 用例全部通过**(#360 基线 370 + 原 344/345 各 7 条 − 3 条去重 +1 条合并用例)。
- `pnpm exec vue-tsc -b`:通过。
- `pnpm exec eslint`(全部改动文件):通过。

Closes #344, closes #345(内容并入,原 PR 关闭)。
