### PR TITLE
fix(story-player): interlude type=1 资源改走 cutin 路径族

### DIFF
--- a/src/widgets/StoryPlayer/engine/asset.ts
+++ b/src/widgets/StoryPlayer/engine/asset.ts
@@ -2,12 +2,22 @@ const TORAPPU_ORIGIN = "https://torappu.prts.wiki";
 
 /**
  * Native provenance: `Torappu.ResourceRouter.GetBackgroundPath`, `GetImagePath`,
- * `GetCharacterPath`, `GetItemPath`, `GetMusicPath`, and `GetAudioPath`.
+ * `GetCharacterPath`, `GetItemPath`, `GetMusicPath`, and `GetAudioPath`. The
+ * cutin family comes from `CutinController`'s `Cutin/Characters/{name}` route
+ * (interlude type=1), not `GetImagePath`.
  *
  * Ports the AVG asset-family routing. HTTP URLs, extension conversion, and URL
  * escaping are web delivery adaptations rather than native behavior.
  *
  */
+
+export type StoryAssetFamily = "background" | "image" | "cutin";
+
+const FAMILY_FOLDER: Record<StoryAssetFamily, string> = {
+  background: "background",
+  image: "images",
+  cutin: "cutin",
+};
 
 function normalizeImageKey(rawKey: string): string {
   return rawKey.trim().toLowerCase();
@@ -35,13 +45,12 @@ export function resolveAssetUrl(raw: string): string {
 
 export function resolveStoryAssetByKey(
   rawKey: string,
-  isBackground: boolean,
+  family: StoryAssetFamily,
 ): string | null {
   const key = normalizeImageKey(rawKey);
   if (!key) return null;
 
-  const folder = isBackground ? "background" : "images";
-  return `${TORAPPU_ORIGIN}/assets/avg/${folder}/${key}.png`;
+  return `${TORAPPU_ORIGIN}/assets/avg/${FAMILY_FOLDER[family]}/${key}.png`;
 }
 
 export function resolveStoryCharacterAssetByKey(rawKey: string): string | null {

--- a/src/widgets/StoryPlayer/engine/preload.ts
+++ b/src/widgets/StoryPlayer/engine/preload.ts
@@ -5,6 +5,7 @@ import {
   resolveStoryAssetByKey,
   resolveStoryAudioByKey,
   resolveStoryCharacterAssetByKey,
+  type StoryAssetFamily,
 } from "./asset";
 import { resolveCharacterSelection } from "./characterRef";
 import { parseScript } from "./parser";
@@ -44,12 +45,12 @@ function resolveGroupedImageSelection(
 function addImageUrl(
   urls: Set<string>,
   rawKey: string,
-  asBackground: boolean,
+  family: StoryAssetFamily,
 ): void {
   const key = rawKey.trim();
   if (!key) return;
 
-  const rawUrl = resolveStoryAssetByKey(key, asBackground);
+  const rawUrl = resolveStoryAssetByKey(key, family);
   if (!rawUrl) return;
   urls.add(resolveAssetUrl(rawUrl));
 }
@@ -99,7 +100,7 @@ function addScriptImageUrls(urls: Set<string>, context: Context): void {
 
     const image = argAsString(line.args.image);
     if (line.command === "background") {
-      addImageUrl(urls, image, true);
+      addImageUrl(urls, image, "background");
       continue;
     }
     if (line.command === "avgdisplay") {
@@ -107,7 +108,7 @@ function addScriptImageUrls(urls: Set<string>, context: Context): void {
       const styleMap: Record<string, string> = { 5: "bg", 7: "character" };
       const style = styleMap[rawStyle] ?? rawStyle;
       const name = argAsString(line.args.name);
-      if (style === "bg") addImageUrl(urls, name, true);
+      if (style === "bg") addImageUrl(urls, name, "background");
       else if (style === "character") addCharacterUrl(urls, name);
       continue;
     }
@@ -117,7 +118,7 @@ function addScriptImageUrls(urls: Set<string>, context: Context): void {
       line.command === "cgitem" ||
       line.command === "blocker"
     ) {
-      addImageUrl(urls, image, false);
+      addImageUrl(urls, image, "image");
       continue;
     }
     if (line.command === "interlude") {
@@ -125,9 +126,10 @@ function addScriptImageUrls(urls: Set<string>, context: Context): void {
       const numericType =
         typeof line.args.type === "number" ? line.args.type : Number(type);
       const name = argAsString(line.args.name);
-      if (type === "bg" || numericType === 2) addImageUrl(urls, name, true);
+      if (type === "bg" || numericType === 2)
+        addImageUrl(urls, name, "background");
       else if (type === "uichar" || numericType === 1)
-        addImageUrl(urls, name, false);
+        addImageUrl(urls, name, "cutin");
       continue;
     }
 
@@ -146,7 +148,11 @@ function addScriptImageUrls(urls: Set<string>, context: Context): void {
       );
       if (!groupSelection) continue;
       for (const key of groupSelection.group.split("/"))
-        addImageUrl(urls, key, groupSelection.asBackground);
+        addImageUrl(
+          urls,
+          key,
+          groupSelection.asBackground ? "background" : "image",
+        );
     }
   }
 }

--- a/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
+++ b/src/widgets/StoryPlayer/engine/rendering/PixiStoryRenderer.ts
@@ -19,6 +19,7 @@ import {
   resolveAssetUrl,
   resolveStoryAssetByKey,
   resolveStoryCharacterAssetByKey,
+  type StoryAssetFamily,
 } from "../asset";
 import {
   buildTagStyles,
@@ -2445,7 +2446,7 @@ export class PixiStoryRenderer implements StoryRenderer {
   async setBlocker(input: BlockerInput): Promise<void> {
     const blocker = this.ensureBlocker();
     if (input.style === "default" && input.image) {
-      const url = resolveStoryAssetByKey(input.image, false);
+      const url = resolveStoryAssetByKey(input.image, "image");
       if (url) {
         try {
           blocker.texture = await Assets.load<Texture>(url);
@@ -4821,9 +4822,9 @@ export class PixiStoryRenderer implements StoryRenderer {
 
   private async textureForImageKey(
     key: string,
-    kind: "background" | "image",
+    kind: StoryAssetFamily,
   ): Promise<Texture | null> {
-    const rawUrl = resolveStoryAssetByKey(key, kind === "background");
+    const rawUrl = resolveStoryAssetByKey(key, kind);
     if (!rawUrl) {
       this.onWarning?.(`missing ${kind}: ${key}`);
       return null;
@@ -4845,11 +4846,14 @@ export class PixiStoryRenderer implements StoryRenderer {
   private async textureForInterlude(
     input: InterludeInput,
   ): Promise<Texture | null> {
-    if (input.type !== 3)
-      return this.textureForImageKey(
-        input.name,
-        input.type === 2 ? "background" : "image",
-      );
+    if (input.type !== 3) {
+      // CutinController routes type 1 (uichar) through Cutin/Characters and
+      // type 2 (bg) through AVG/Backgrounds; only type 3 reuses AVG characters.
+      let kind: StoryAssetFamily = "image";
+      if (input.type === 2) kind = "background";
+      else if (input.type === 1) kind = "cutin";
+      return this.textureForImageKey(input.name, kind);
+    }
 
     const base = input.avatarCharacterKey;
     const expression = input.avatarExpression;

--- a/tests/asset.spec.ts
+++ b/tests/asset.spec.ts
@@ -22,20 +22,26 @@ describe("resolveAssetUrl", () => {
 
 describe("story image resolvers", () => {
   it("resolves plain image key to avg images path", () => {
-    expect(resolveStoryAssetByKey("XyZ_01", false)).toBe(
+    expect(resolveStoryAssetByKey("XyZ_01", "image")).toBe(
       "https://torappu.prts.wiki/assets/avg/images/xyz_01.png",
     );
   });
 
   it("resolves background key with bg_ prefix to avg background path", () => {
-    expect(resolveStoryAssetByKey("bg_lungmen_n", true)).toBe(
+    expect(resolveStoryAssetByKey("bg_lungmen_n", "background")).toBe(
       "https://torappu.prts.wiki/assets/avg/background/bg_lungmen_n.png",
     );
   });
 
   it("resolves background key without bg_ prefix to avg background path", () => {
-    expect(resolveStoryAssetByKey("lungmen_n", true)).toBe(
+    expect(resolveStoryAssetByKey("lungmen_n", "background")).toBe(
       "https://torappu.prts.wiki/assets/avg/background/lungmen_n.png",
+    );
+  });
+
+  it("resolves cutin key to avg cutin path", () => {
+    expect(resolveStoryAssetByKey("cutin_char_9", "cutin")).toBe(
+      "https://torappu.prts.wiki/assets/avg/cutin/cutin_char_9.png",
     );
   });
 });


### PR DESCRIPTION
原生 CutinController 对 interlude type=1(uichar) 的图片走 Cutin/Characters/{name},而非 GetImagePath 的 avg/images。 resolveStoryAssetByKey 改为按 StoryAssetFamily(background/image/cutin) 分流,渲染与预加载同步切到 assets/avg/cutin/,与 torappu 新增的avg cutin 提取输出对应。
https://github.com/MooncellWiki/torappu/pull/101